### PR TITLE
Fix dead link on PyPI

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ aisuite is released under the MIT License. You are free to use, modify, and dist
 
 ## Contributing
 
-If you would like to contribute, please read our [Contributing Guide](CONTRIBUTING.md) and join our [Discord](https://discord.gg/T6Nvn8ExSb) server!
+If you would like to contribute, please read our [Contributing Guide](https://github.com/andrewyng/aisuite/blob/main/CONTRIBUTING.md) and join our [Discord](https://discord.gg/T6Nvn8ExSb) server!
 
 ## Adding support for a provider
 We have made easy for a provider or volunteer to add support for a new platform.


### PR DESCRIPTION
The [README.md](https://github.com/andrewyng/aisuite/blob/main/README.md) file for `aisuite` uses a relative URL for the [Contributing Guide](https://github.com/andrewyng/aisuite/blob/main/CONTRIBUTING.md). While this works well on GitHub, it returns a 404 error when visited on [PyPI](https://pypi.org/project/aisuite).

This change updates the README.md to include an absolute URL for the Contributing Guide that works well on both GitHub and PyPI.