### PR TITLE
fixed-typo-poetry install --with dev,test

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -160,7 +160,7 @@ git checkout -B <username>/<description>
 
 Please install the development and test dependencies:
 ```bash
-poetry install --with dev,test
+poetry install --with dev
 ```
 
 `aisuite` uses pre-commit to ensure the formatting is consistent:


### PR DESCRIPTION
- fixed typo for poetry install command 

removed `,test` from this command 

```bash
 poetry install --with dev,test
```
and new version is this
```bash
 poetry install --with dev
```
