### PR TITLE
Fix streaming support in client

### DIFF
--- a/tests/client/test_client.py
+++ b/tests/client/test_client.py
@@ -139,6 +139,16 @@ class TestClient(unittest.TestCase):
         next_compl_instance = client.chat.completions
         assert compl_instance is next_compl_instance
 
+        # Test streaming response for Anthropic model
+        stream_anthropic_model = "anthropic" + ":" + "anthropic-model"
+        stream_anthropic_response = client.chat.completions.create(
+            stream_anthropic_model, messages=messages, stream=True
+        )
+        self.assertEqual(stream_anthropic_response, "Anthropic Response")
+        mock_anthropic.assert_called_with(
+            "anthropic-model", messages, stream=True
+        )
+
     def test_invalid_provider_in_client_config(self):
         # Testing an invalid provider name in the configuration
         invalid_provider_configs = {


### PR DESCRIPTION
Fixes #103

Add support for streaming responses in the Anthropic provider.

* Handle the `stream` parameter in the `chat_completions_create` method in `aisuite/providers/anthropic_provider.py`.
* Use `handle_streaming_response` method to process streaming responses.
* Add a test case for the `stream` parameter in `tests/client/test_client.py`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/andrewyng/aisuite/pull/105?shareId=961ef4b2-e0a1-471e-8c6f-284992984664).