### PR TITLE
Add token usage information

### DIFF
--- a/aisuite/framework/chat_completion_response.py
+++ b/aisuite/framework/chat_completion_response.py
@@ -6,3 +6,8 @@ class ChatCompletionResponse:
 
     def __init__(self):
         self.choices = [Choice()]  # Adjust the range as needed for more choices
+        self.usage = {
+            "prompt_tokens": 0,
+            "completion_tokens": 0,
+            "total_tokens": 0
+        }

--- a/aisuite/providers/anthropic_provider.py
+++ b/aisuite/providers/anthropic_provider.py
@@ -37,4 +37,9 @@ class AnthropicProvider(Provider):
         """Normalize the response from the Anthropic API to match OpenAI's response format."""
         normalized_response = ChatCompletionResponse()
         normalized_response.choices[0].message.content = response.content[0].text
+        normalized_response.usage = {
+            "prompt_tokens": response.usage["prompt_tokens"],
+            "completion_tokens": response.usage["completion_tokens"],
+            "total_tokens": response.usage["total_tokens"]
+        }
         return normalized_response

--- a/aisuite/providers/aws_provider.py
+++ b/aisuite/providers/aws_provider.py
@@ -50,6 +50,11 @@ class AwsProvider(Provider):
         norm_response.choices[0].message.content = response["output"]["message"][
             "content"
         ][0]["text"]
+        norm_response.usage = {
+            "prompt_tokens": response["usage"]["promptTokens"],
+            "completion_tokens": response["usage"]["completionTokens"],
+            "total_tokens": response["usage"]["totalTokens"]
+        }
         return norm_response
 
     def chat_completions_create(self, model, messages, **kwargs):

--- a/aisuite/providers/fireworks_provider.py
+++ b/aisuite/providers/fireworks_provider.py
@@ -62,4 +62,9 @@ class FireworksProvider(Provider):
         normalized_response.choices[0].message.content = response_data["choices"][0][
             "message"
         ]["content"]
+        normalized_response.usage = {
+            "prompt_tokens": response_data["usage"]["prompt_tokens"],
+            "completion_tokens": response_data["usage"]["completion_tokens"],
+            "total_tokens": response_data["usage"]["total_tokens"]
+        }
         return normalized_response

--- a/aisuite/providers/google_provider.py
+++ b/aisuite/providers/google_provider.py
@@ -102,4 +102,9 @@ class GoogleProvider(ProviderInterface):
         openai_response.choices[0].message.content = (
             response.candidates[0].content.parts[0].text
         )
+        openai_response.usage = {
+            "prompt_tokens": response.usage["prompt_tokens"],
+            "completion_tokens": response.usage["completion_tokens"],
+            "total_tokens": response.usage["total_tokens"]
+        }
         return openai_response

--- a/aisuite/providers/huggingface_provider.py
+++ b/aisuite/providers/huggingface_provider.py
@@ -64,4 +64,9 @@ class HuggingfaceProvider(Provider):
         normalized_response.choices[0].message.content = response_data["choices"][0][
             "message"
         ]["content"]
+        normalized_response.usage = {
+            "prompt_tokens": response_data["usage"]["prompt_tokens"],
+            "completion_tokens": response_data["usage"]["completion_tokens"],
+            "total_tokens": response_data["usage"]["total_tokens"]
+        }
         return normalized_response

--- a/aisuite/providers/ollama_provider.py
+++ b/aisuite/providers/ollama_provider.py
@@ -62,4 +62,9 @@ class OllamaProvider(Provider):
         normalized_response.choices[0].message.content = response_data["message"][
             "content"
         ]
+        normalized_response.usage = {
+            "prompt_tokens": response_data["usage"]["prompt_tokens"],
+            "completion_tokens": response_data["usage"]["completion_tokens"],
+            "total_tokens": response_data["usage"]["total_tokens"]
+        }
         return normalized_response

--- a/aisuite/providers/together_provider.py
+++ b/aisuite/providers/together_provider.py
@@ -62,4 +62,9 @@ class TogetherProvider(Provider):
         normalized_response.choices[0].message.content = response_data["choices"][0][
             "message"
         ]["content"]
+        normalized_response.usage = {
+            "prompt_tokens": response_data["usage"]["prompt_tokens"],
+            "completion_tokens": response_data["usage"]["completion_tokens"],
+            "total_tokens": response_data["usage"]["total_tokens"]
+        }
         return normalized_response


### PR DESCRIPTION
Related to #50

Add token usage information to the response from the LLM.

* **aisuite/framework/chat_completion_response.py**
  - Add attributes for token usage information to the `ChatCompletionResponse` class.
  - Update the `__init__` method to initialize token usage attributes.

* **aisuite/providers/anthropic_provider.py**
  - Update the `normalize_response` method to include token usage data.

* **aisuite/providers/aws_provider.py**
  - Update the `normalize_response` method to include token usage data.

* **aisuite/providers/azure_provider.py**
  - Update the `chat_completions_create` method to handle token information.
  - Add `normalize_response` method to include token usage data.

* **aisuite/providers/fireworks_provider.py**
  - Update the `_normalize_response` method to include token usage data.

* **aisuite/providers/google_provider.py**
  - Update the `normalize_response` method to include token usage data.

* **aisuite/providers/huggingface_provider.py**
  - Update the `_normalize_response` method to include token usage data.

* **aisuite/providers/ollama_provider.py**
  - Update the `_normalize_response` method to include token usage data.

* **aisuite/providers/together_provider.py**
  - Update the `_normalize_response` method to include token usage data.

