### PR TITLE
Add the Azure api-version query parameters

### DIFF
--- a/aisuite/providers/azure_provider.py
+++ b/aisuite/providers/azure_provider.py
@@ -82,6 +82,7 @@ class AzureProvider(Provider):
     def __init__(self, **config):
         self.base_url = config.get("base_url") or os.getenv("AZURE_BASE_URL")
         self.api_key = config.get("api_key") or os.getenv("AZURE_API_KEY")
+        self.api_version = config.get("api_version") or os.getenv("AZURE_API_VERSION")
         if not self.api_key:
             raise ValueError("For Azure, api_key is required.")
         if not self.base_url:
@@ -92,6 +93,9 @@ class AzureProvider(Provider):
 
     def chat_completions_create(self, model, messages, **kwargs):
         url = f"{self.base_url}/chat/completions"
+
+        if self.api_version:
+            url = f"{url}?api-version={self.api_version}"
 
         # Remove 'stream' from kwargs if present
         kwargs.pop("stream", None)

--- a/guides/azure.md
+++ b/guides/azure.md
@@ -18,6 +18,7 @@ After creating your deployment, you'll need to gather the following information:
 
 1. API Key: Found in the "Keys and Endpoint" section of your Azure OpenAI resource.
 2. Base URL: This can be obtained from your deployment details. It will look something like this - `https://aisuite-Mistral-large-2407.westus3.models.ai.azure.com/v1/`
+3. API Version: Optional configuration and mainly introduced for Azure OpenAI services. Once specified, the `api-version` query parameters will be added in the end of the API request.
 
 
 Set the following environment variables:
@@ -25,6 +26,7 @@ Set the following environment variables:
 ```shell
 export AZURE_API_KEY="your-api-key"
 export AZURE_BASE_URL="https://deployment-name.region-name.models.ai.azure.com/v1"
+export AZURE_API_VERSION="=2024-08-01-preview"
 ```
 
 ## Create a Chat Completion
@@ -38,7 +40,8 @@ import aisuite as ai
 # Setting the params in ai.Client() will override the values from environment vars.
 client = ai.Client(
     base_url=os.environ["AZURE_OPENAI_BASE_URL"],
-    api_key=os.environ["AZURE_OPENAI_API_KEY"]
+    api_key=os.environ["AZURE_OPENAI_API_KEY"],
+    api_version=os.environ["AZURE_API_VERSION"]
 )
 
 model = "azure:aisuite-Mistral-large-2407"  # Replace with your deployment name.


### PR DESCRIPTION
To use Azure OpenAI models, the API endpoint requires a `api-version` query parameters to be specified. Otherwise a 404 Resouce Not Found error will be throw upon the API call.

To solve this issue, we introduced this `AZURE_API_VERSION` in the configuration.