### PR TITLE
added LM Studio provider support

### DIFF
--- a/aisuite/providers/lmstudio_provider.py
+++ b/aisuite/providers/lmstudio_provider.py
@@ -1,0 +1,66 @@
+import os
+import httpx
+from aisuite.provider import Provider, LLMError
+from aisuite.framework import ChatCompletionResponse
+
+
+class LmstudioProvider(Provider):
+    """
+    LM Studio Provider that makes HTTP calls. Inspired by OllamaProvider in aisuite.
+    It uses the /v1/chat/completions endpoint.
+    Read more here - https://lmstudio.ai/docs/api and on your local instance in the "Developer" tab.
+    If LMSTUDIO_API_URL is not set and not passed in config, then it will default to "http://localhost:1234"
+    """
+
+    _CHAT_COMPLETION_ENDPOINT = "/v1/chat/completions"
+    _CONNECT_ERROR_MESSAGE = "LM Studio is likely not running. Start LM Studio by running `ollama serve` on your host."
+
+    def __init__(self, **config):
+        """
+        Initialize the LM Studio provider with the given configuration.
+        """
+        self.url = config.get("api_url") or os.getenv(
+            "LMSTUDIO_API_URL", "http://localhost:1234"
+        )
+
+        # Optionally set a custom timeout (default to 300s)
+        self.timeout = config.get("timeout", 300)
+
+    def chat_completions_create(self, model, messages, **kwargs):
+        """
+        Makes a request to the chat completions endpoint using httpx.
+        """
+        kwargs["stream"] = False
+        data = {
+            "model": model,
+            "messages": messages,
+            **kwargs,  # Pass any additional arguments to the API
+        }
+
+        try:
+            response = httpx.post(
+                self.url.rstrip("/") + self._CHAT_COMPLETION_ENDPOINT,
+                json=data,
+                timeout=self.timeout,
+            )
+            response.raise_for_status()
+        except httpx.ConnectError:  # Handle connection errors
+            raise LLMError(f"Connection failed: {self._CONNECT_ERROR_MESSAGE}")
+        except httpx.HTTPStatusError as http_err:
+            raise LLMError(f"LM Studio request failed: {http_err}")
+        except Exception as e:
+            raise LLMError(f"An error occurred: {e}")
+
+        # Return the normalized response
+        return self._normalize_response(response.json())
+
+    def _normalize_response(self, response_data):
+        """
+        Normalize the API response to a common format (ChatCompletionResponse).
+        """
+        normalized_response = ChatCompletionResponse()
+        normalized_response.choices[0].message.content = response_data["choices"][0][
+            "message"
+        ]["content"]
+
+        return normalized_response

--- a/guides/README.md
+++ b/guides/README.md
@@ -14,6 +14,10 @@ Here are the instructions for:
 - [xAI](xai.md)
 - [DeepSeek](deepseek.md)
 
+For locally hosted models using `Ollama` or `LM Studio`, follow these instructions:
+- [Ollama](ollama.md)
+- [LM Studio](lmstudio.md)
+
 Unless otherwise stated, these guides have not been endorsed by the providers. 
 
 We also welcome additional [contributions](../CONTRIBUTING.md). 

--- a/guides/lmstudio.md
+++ b/guides/lmstudio.md
@@ -1,0 +1,77 @@
+# LM Studio
+
+LM Studio allows users to locally host open-source models available in [their model catalog](https://lmstudio.ai/models). 
+It also provides a web portal with a ChatGPT-like interface.
+Once an LM Studio instance is locally running in your setup (default `http://localhost:1234`), you can use the `aisuite` API for chat completions as shown below.
+No API Key is needed for these locally hosted models.
+
+## Create a Chat Completion
+
+Sample code:
+```python
+import aisuite as ai
+
+def main():
+    # Set the API URL to remote NGA2 server
+    client = ai.Client(
+        provider_configs={
+            "lmstudio": {
+                "api_url": "http://localhost:1234",
+                "timeout": 300,
+            }
+        }
+    )
+    messages = [
+        {
+            "role": "system", 
+            "content": "Be verbose"
+        },
+        {
+            "role": "user", 
+            "content": "Tell me something about University of Michigan's CSE department."
+        },
+    ]
+
+    lmstudio_llama = "lmstudio:llama-3.2-3b-instruct"
+
+    response = client.chat.completions.create(
+        model=lmstudio_llama, 
+        messages=messages, 
+        temperature=0.75,
+    )
+    print(response.choices[0].message.content)
+
+
+if __name__ == "__main__":
+    main()
+```
+
+You can expect a response like the following:
+
+```markdown
+The Computer Science and Engineering (CSE) Department at the University of Michigan is one of the most prestigious and highly-regarded computer science programs in the world. Located in the heart of Ann Arbor, Michigan, the Department of CSE is a leading institution for undergraduate and graduate education in the field of computer science.
+
+With a rich history dating back to 1940, the CSE Department at the University of Michigan has a long tradition of academic excellence, cutting-edge research, and innovative teaching. The department is composed of over 70 faculty members, many of whom are prominent researchers in their fields, and has a student body of around 500 undergraduate majors and 1,000 graduate students.
+
+The CSE Department offers a wide range of undergraduate and graduate degree programs, including Bachelor of Science in Computer Science, Bachelor of Arts in Computer Science, Master of Science in Computer Science, Master of Engineering in Computer Science, and Ph.D. in Computer Science. These programs are designed to provide students with a comprehensive education in computer science, including a strong foundation in mathematics, computer systems, algorithms, computer networks, and software engineering.
+
+The department is particularly renowned for its research programs in areas such as artificial intelligence, computer vision, natural language processing, robotics, and data science. The CSE Department has a strong research focus, and its faculty members are actively engaged in research projects, partnerships, and collaborations with industry, government, and academia.
+
+One of the unique aspects of the CSE Department at the University of Michigan is its strong commitment to interdisciplinary research and education. The department has established partnerships with various academic departments across the university, including physics, mathematics, and engineering, to provide students with a well-rounded education that incorporates multiple disciplines.
+
+The CSE Department also has a strong focus on industry collaboration and engagement. The department has established the University of Michigan's College of Engineering, which provides students with opportunities to engage in research, internships, and co-op programs with top industry partners.
+
+Overall, the Computer Science and Engineering Department at the University of Michigan is a world-class institution that provides students with a world-class education, innovative research opportunities, and strong industry connections. Its highly-regarded faculty, cutting-edge research programs, and strong industry partnerships make it an attractive destination for students interested in pursuing a career in computer science.
+
+Some of the key statistics and achievements of the CSE Department at the University of Michigan include:
+
+* Ranked #5 in the US News & World Report's Best Undergraduate Computer Science Programs (2022)
+* Ranked #10 in the QS World University Rankings by Subject: Computer Science (2022)
+* 97% of undergraduate graduates find employment or continue their education within six months of graduation
+* 98% of graduate students are employed or continue their education within six months of graduation
+* 10:1 student-to-faculty ratio, providing students with personalized attention and mentorship
+
+These statistics demonstrate the exceptional quality of education and research provided by the CSE Department at the University of Michigan, and highlight its reputation as one of the world's leading institutions for computer science education and research.
+```
+
+Happy coding! If you’d like to contribute, please read our [Contributing Guide](CONTRIBUTING.md).

--- a/guides/ollama.md
+++ b/guides/ollama.md
@@ -1,0 +1,50 @@
+# Ollama
+
+Ollama allows users to locally host open-source models available in [their library](https://ollama.com/library). 
+Once an Ollama instance is locally running in your setup (default `http://localhost:11434`), you can use the `aisuite` API for chat completions as shown below.
+No API Key is needed for these locally hosted models.
+
+## Create a Chat Completion
+
+Sample code:
+```python
+import aisuite as ai
+
+def main():
+    client = ai.Client(
+        provider_configs={
+            "ollama": {
+                "api_url": "http://10.168.0.177:11434",
+                "timeout": 300,
+            }
+        }
+    )
+    messages = [
+        {
+            "role": "system", 
+            "content": "Be verbose"
+        },
+        {
+            "role": "user", 
+            "content": "Tell me something about University of Michigan's CSE department."
+        },
+    ]
+
+    ollama_llama3 = "ollama:llama3:latest"
+    ollama_gemma = "ollama:gemma:latest"
+    ollama_deepseek_32B = "ollama:deepseek-r1:32b"
+    ollama_deepseek_70B = "ollama:deepseek-r1:70b"
+
+    response = client.chat.completions.create(
+        model=ollama_gemma, 
+        messages=messages, 
+        temperature=0.75,
+    )
+    print(response.choices[0].message.content)
+
+
+if __name__ == "__main__":
+    main()
+```
+
+Happy coding! If you’d like to contribute, please read our [Contributing Guide](CONTRIBUTING.md).

--- a/tests/providers/test_lmstudio_provider.py
+++ b/tests/providers/test_lmstudio_provider.py
@@ -1,0 +1,45 @@
+import pytest
+from unittest.mock import patch, MagicMock
+from aisuite.providers.lmstudio_provider import LmstudioProvider
+
+
+@pytest.fixture(autouse=True)
+def set_api_url_var(monkeypatch):
+    """Fixture to set environment variables for tests."""
+    monkeypatch.setenv("LMSTUDIO_API_URL", "http://localhost:1234")
+
+
+def test_completion():
+    """Test that completions request successfully."""
+
+    user_greeting = "Howdy!"
+    message_history = [{"role": "user", "content": user_greeting}]
+    selected_model = "best-model-ever"
+    chosen_temperature = 0.77
+    response_text_content = "mocked-text-response-from-ollama-model"
+
+    lmstudio = LmstudioProvider()
+    mock_response = {"choices": [{"message": {"content": response_text_content}}]}
+
+    with patch(
+        "httpx.post",
+        return_value=MagicMock(status_code=200, json=lambda: mock_response),
+    ) as mock_post:
+        response = lmstudio.chat_completions_create(
+            messages=message_history,
+            model=selected_model,
+            temperature=chosen_temperature,
+        )
+
+        mock_post.assert_called_once_with(
+            "http://localhost:1234/v1/chat/completions",
+            json={
+                "model": selected_model,
+                "messages": message_history,
+                "stream": False,
+                "temperature": chosen_temperature,
+            },
+            timeout=300,
+        )
+
+        assert response.choices[0].message.content == response_text_content


### PR DESCRIPTION
Based on #106. Added support for LM Studio provider along with a test and markdown guides for both LM Studio and Ollama. The implementation is mostly based on Ollama provider since both provide support for locally hosted models through similar APIs.