### PR TITLE
fix: update Azure Provider with openai models

### DIFF
--- a/aisuite/providers/azure_provider.py
+++ b/aisuite/providers/azure_provider.py
@@ -92,7 +92,13 @@ class AzureProvider(Provider):
         self.transformer = AzureMessageConverter()
 
     def chat_completions_create(self, model, messages, **kwargs):
-        url = f"{self.base_url}/chat/completions"
+
+        if ".openai.azure.com" in self.base_url:
+            url = f"{self.base_url}/openai/deployments/{model}/chat/completions"
+            headers = {"Content-Type": "application/json", "api-key": self.api_key}
+        else:
+            url = f"{self.base_url}/chat/completions"
+            headers = {"Content-Type": "application/json", "Authorization": self.api_key}
 
         if self.api_version:
             url = f"{url}?api-version={self.api_version}"
@@ -120,7 +126,6 @@ class AzureProvider(Provider):
         data.update(kwargs)
 
         body = json.dumps(data).encode("utf-8")
-        headers = {"Content-Type": "application/json", "Authorization": self.api_key}
 
         try:
             req = urllib.request.Request(url, body, headers)


### PR DESCRIPTION
The current implementation of the Azure provider works with some models but not with some others.

Some will use :

> https://**YOUR_DEPLOYMENT_NAME.YOUR_REGION_NAME.models.ai.azure.com/v1**/chat/completions?api-version=YOUR_API_VERSION
> headers = {"Content-Type": "application/json", "**Authorization**": self.api_key}

And some other will call:

> https://**YOUR_RESSOURCE_NAME.openai.azure.com/openai/deployments/YOUR_DEPLOYMENT_NAME**
> headers = {"Content-Type": "application/json", "**api-key**": self.api_key}

So, I updated the provider to make it detect which one is used and prepare the parameters correctly.

```
        if ".openai.azure.com" in self.base_url:
            url = f"{self.base_url}/openai/deployments/{model}/chat/completions"
            headers = {"Content-Type": "application/json", "api-key": self.api_key}
        else:
            url = f"{self.base_url}/chat/completions"
            headers = {"Content-Type": "application/json", "Authorization": self.api_key}
```