### PR TITLE
Fix  typo in Cerebras guide

### DIFF
--- a/guides/cerebras.md
+++ b/guides/cerebras.md
@@ -41,7 +41,7 @@ messages = [
 ]
 
 response = client.chat.completions.create(
-    model="cerebras:cerebras:llama3.1-8b",
+    model="cerebras:llama3.1-8b",
     messages=messages,
     temperature=0.75
 )


### PR DESCRIPTION
`cerebras:cerebras:llama3.1-8b` -> `cerebras:llama3.1-8b`