### PR TITLE
Improved JSON Encoding

### DIFF
--- a/aisuite/utils/tools.py
+++ b/aisuite/utils/tools.py
@@ -294,20 +294,21 @@ class DefaultJSONEncoder(json.JSONEncoder):
 
     dataclasses: by calling `asdict`
     datetime.dateime: by calling `datetime.datetime.isoformat()`
-    Markup and other objects: by checking for a __html__ method to return a str. 
+    Markup and other objects: by checking for a __html__ method to return a str.
     """
+
     def default(self, obj: Any) -> Any:
         # Handle dataclasses by converting them to dictionaries
         if dataclasses.is_dataclass(obj):
             return dataclasses.asdict(obj)
-        
+
         # Handle datetime objects by using isoformat
         if isinstance(obj, datetime.datetime):
             return obj.isoformat()
-        
+
         # Check for __html__ method which is used by Markupsafe a ton of other libraries and call it
         if hasattr(obj, "__html__") and callable(getattr(obj, "__html__")):
             return obj.__html__()
-        
+
         # Let the base class handle anything else
         return super().default(obj)


### PR DESCRIPTION
**Why:** There are a lot of advantages to returning a slightly richer python object as opposed to simply a dictionary or string. Say perhaps, you are returning objects that will be tracked by an ORM or you are returning simple data classes. 

**What:** Leverages a simple enhanced JSON encoder class that handles dataclasses, datetimes, and and __html__ method. This is copy of the implementation for flask https://github.com/pallets/flask/blob/f61172b8dd3f962d33f25c50b2f5405e90ceffa5/src/flask/json/provider.py#L108


**How:** Adds a DefaultJSONEncoder to the tools orchestration that is passed into `json.dumps`. This also enables users to override the default if needed. 

I have run `pre-commit` and I have run most of the test suite but a small subset of the provider tests I am not able to run. 

Thanks really great library that I use a lot. 