### PR TITLE
Updated aws provider to use credentials from the provider config when #221

### DIFF
--- a/aisuite/client.py
+++ b/aisuite/client.py
@@ -17,9 +17,9 @@ class Client:
                 {
                     "openai": {"api_key": "your_openai_api_key"},
                     "aws-bedrock": {
-                        "aws_access_key": "your_aws_access_key",
-                        "aws_secret_key": "your_aws_secret_key",
-                        "aws_region": "us-west-2"
+                        "aws_access_key_id": "your_aws_access_key",
+                        "aws_secret_access_key": "your_aws_secret_key",
+                        "region_name": "us-west-2"
                     }
                 }
         """

--- a/aisuite/providers/aws_provider.py
+++ b/aisuite/providers/aws_provider.py
@@ -16,9 +16,21 @@ class BedrockConfig:
         self.region_name = config.get(
             "region_name", os.getenv("AWS_REGION", "us-west-2")
         )
+        self.aws_access_key_id = config.get(
+            "aws_access_key_id", os.getenv("AWS_ACCESS_KEY_ID", "")
+        )
+        self.aws_secret_access_key = config.get(
+            "aws_secret_access_key", os.getenv("AWS_SECRET_ACCESS_KEY", "")
+        )
 
     def create_client(self):
-        return boto3.client("bedrock-runtime", region_name=self.region_name)
+        # https://boto3.amazonaws.com/v1/documentation/api/latest/guide/credentials.html
+        return boto3.client(
+            "bedrock-runtime",
+            region_name=self.region_name,
+            aws_access_key_id=self.aws_access_key_id,
+            aws_secret_access_key=self.aws_secret_access_key,
+        )
 
 
 # AWS Bedrock API Example -


### PR DESCRIPTION
Updated aws provider to use credentials from provider config when available. Updated the client documentation as well to reflect the names of the config inline with aws documentation.

I have run pre-commit on the changes. Tests are running except a small subset that need api key set.

Issue #221 