### PR TITLE
AWS provider use credentials from config

### DIFF
--- a/aisuite/providers/aws_provider.py
+++ b/aisuite/providers/aws_provider.py
@@ -16,9 +16,26 @@ class BedrockConfig:
         self.region_name = config.get(
             "region_name", os.getenv("AWS_REGION", "us-west-2")
         )
+        self.access_key_id = config.get(
+            "access_key_id", os.getenv("AWS_ACCESS_KEY_ID")
+        )
+        if not self.access_key_id:
+            raise ValueError("For AWS, access_key_id is required.")
+        self.secret_access_key = config.get(
+            "secret_access_key", os.getenv("AWS_SECRET_ACCESS_KEY")
+        )
+        if not self.secret_access_key:
+            raise ValueError("For AWS, secret_access_key is required.")
 
     def create_client(self):
-        return boto3.client("bedrock-runtime", region_name=self.region_name)
+        session = boto3.Session(
+            aws_access_key_id=self.access_key_id,
+            aws_secret_access_key=self.secret_access_key,
+        )
+        return session.client(
+            "bedrock-runtime", 
+            region_name=self.region_name,
+        )
 
 
 # AWS Bedrock API Example -


### PR DESCRIPTION
In the current state the AwsProvider take the "AWS_ACCESS_KEY_ID" and "AWS_SECRET_ACCESS_KEY" only from os.env.
The boto3.client instance is created with the default client that take the above parameters from os.env (and internally create a static shared instance of Session)
This is very limiting when using multiple credentials on parallel processes (like web applications and each user has is own keys) or simply you don't won't to export your private keys in your env.

My proposed solution, allows to create indipendent instances of the AwsProvider (no static shared boto3.Session) and also allows to specify the "access_key_id" and "secret_access_key" parameters via the provider configuration dictionary (directly in python).