### PR TITLE
feat(ollama): migrate OllamaProvider to OpenAI‑compatible API

### DIFF
--- a/guides/ollama.md
+++ b/guides/ollama.md
@@ -14,7 +14,7 @@ def main():
     client = ai.Client(
         provider_configs={
             "ollama": {
-                "api_url": "http://10.168.0.177:11434",
+                "base_url": "http://10.168.0.177:11434",
                 "timeout": 300,
             }
         }

--- a/tests/providers/test_ollama_provider.py
+++ b/tests/providers/test_ollama_provider.py
@@ -1,45 +1,107 @@
-import pytest
 from unittest.mock import patch, MagicMock
+
+import pytest
+
 from aisuite.providers.ollama_provider import OllamaProvider
 
 
 @pytest.fixture(autouse=True)
-def set_api_url_var(monkeypatch):
-    """Fixture to set environment variables for tests."""
-    monkeypatch.setenv("OLLAMA_API_URL", "http://localhost:11434")
+def set_api_url(monkeypatch):
+    monkeypatch.setenv("OLLAMA_API_URL", "http://localhost:11434/v1")
 
 
-def test_completion():
-    """Test that completions request successfully."""
+def test_parsing_with_tool_call():
+    provider_under_test = OllamaProvider()
 
-    user_greeting = "Howdy!"
-    message_history = [{"role": "user", "content": user_greeting}]
-    selected_model = "best-model-ever"
-    chosen_temperature = 0.77
-    response_text_content = "mocked-text-response-from-ollama-model"
+    mock_tool_call_response = MagicMock()
+    mock_tool_call_response.model_dump.return_value = {
+        "choices": [
+            {
+                "message": {
+                    "role": "assistant",
+                    "content": None,
+                    "tool_calls": [
+                        {
+                            "id": "call_123",
+                            "function": {
+                                "name": "will_it_rain",
+                                "arguments": '{"location": "San Francisco", "time_of_day": "2pm"}',
+                            },
+                        }
+                    ],
+                }
+            }
+        ]
+    }
+
+    with patch.object(
+        provider_under_test.client.chat.completions,
+        "create",
+        return_value=mock_tool_call_response,
+    ) as mock_create:
+
+        response = provider_under_test.chat_completions_create(
+            model="ollama:qwen3:4b",
+            messages=[
+                {"role": "user", "content": "Will it rain in San Francisco at 2pm?"}
+            ],
+        )
+
+        assert mock_create.call_count == 1
+        assert response.choices[0].message.content is None
+        assert len(response.choices[0].message.tool_calls) == 1
+        assert response.choices[0].message.tool_calls[0].type == "function"
+        assert response.choices[0].message.tool_calls[0].function.name == "will_it_rain"
+
+
+def test_parsing_without_tool_call():
+    provider_under_test = OllamaProvider()
+
+    mock_without_tool_call_response = MagicMock()
+    mock_without_tool_call_response.model_dump.return_value = {
+        "choices": [
+            {
+                "message": {
+                    "role": "assistant",
+                    "content": "I can not help you to determine real time weather!",
+                }
+            }
+        ]
+    }
+
+    with patch.object(
+        provider_under_test.client.chat.completions,
+        "create",
+        return_value=mock_without_tool_call_response,
+    ) as mock_create:
+
+        response = provider_under_test.chat_completions_create(
+            model="ollama:qwen3:4b",
+            messages=[
+                {"role": "user", "content": "Will it rain in San Francisco at 2pm?"}
+            ],
+        )
+
+        assert mock_create.call_count == 1
+        assert (
+            response.choices[0].message.content
+            == "I can not help you to determine real time weather!"
+        )
+        assert response.choices[0].message.tool_calls is None
+
+
+def test_base_url_normalisation():
+    ollama = OllamaProvider(base_url="http://localhost:8080")
+    assert ollama.client.base_url == "http://localhost:8080/v1/"
+
+    ollama = OllamaProvider(base_url="http://localhost:8080/")
+    assert ollama.client.base_url == "http://localhost:8080/v1/"
+
+    ollama = OllamaProvider(base_url="http://localhost:8080/v1")
+    assert ollama.client.base_url == "http://localhost:8080/v1/"
+
+    ollama = OllamaProvider(api_url="http://localhost:8080/v1")
+    assert ollama.client.base_url == "http://localhost:8080/v1/"
 
     ollama = OllamaProvider()
-    mock_response = {"message": {"content": response_text_content}}
-
-    with patch(
-        "httpx.post",
-        return_value=MagicMock(status_code=200, json=lambda: mock_response),
-    ) as mock_post:
-        response = ollama.chat_completions_create(
-            messages=message_history,
-            model=selected_model,
-            temperature=chosen_temperature,
-        )
-
-        mock_post.assert_called_once_with(
-            "http://localhost:11434/api/chat",
-            json={
-                "model": selected_model,
-                "messages": message_history,
-                "stream": False,
-                "temperature": chosen_temperature,
-            },
-            timeout=30,
-        )
-
-        assert response.choices[0].message.content == response_text_content
+    assert ollama.client.base_url == "http://localhost:11434/v1/"


### PR DESCRIPTION
In current **OllamaProvider** the tool invocation flow is not working. I suspect because tool_calls node is not parsed in below parsing,

```
    def _normalize_response(self, response_data):
        """
        Normalize the API response to a common format (ChatCompletionResponse).
        """
        normalized_response = ChatCompletionResponse()
        normalized_response.choices[0].message.content = response_data["message"][
            "content"
        ]
        return normalized_response

```
One option was to fix the tool_calls node parsing in existing **OllamaProvider** but as officially ollama is openai compatible we can reuse the OpenAICompliantMessageConverter. Hence, in this PR migrating to OpenAICompliantMessageConverter

The client side code is still same and backward compatible. The only issue client can face is if they are using a old ollama server on local, it might not have the openai compatible apis.

* Migrate **OllamaProvider** to use openai compatible apis
* Similar structure is already followed in **DeepseekProvider**
* in OllamaProvider test response with and without tool_calls

Related Issues: 
https://github.com/andrewyng/aisuite/issues/248
https://github.com/andrewyng/aisuite/issues/253
