### PR TITLE
fix: prevent shared state between client instances

### DIFF
--- a/aisuite/client.py
+++ b/aisuite/client.py
@@ -1,5 +1,4 @@
 from .provider import ProviderFactory
-import os
 from .utils.tools import Tools
 from typing import Union, BinaryIO, Optional, Any, Literal
 from contextlib import ExitStack
@@ -21,7 +20,7 @@ except ImportError:
 class Client:
     def __init__(
         self,
-        provider_configs: dict = {},
+        provider_configs: dict | None = None,
         extra_param_mode: Literal["strict", "warn", "permissive"] = "warn",
     ):
         """
@@ -47,7 +46,10 @@ class Client:
                 - "permissive": Allow all params without validation (testing)
         """
         self.providers = {}
-        self.provider_configs = provider_configs
+        if provider_configs:
+            self.provider_configs = provider_configs
+        else:
+            self.provider_configs = {}
         self.extra_param_mode = extra_param_mode
         self.param_validator = ParamValidator(extra_param_mode)
         self._chat = None
@@ -171,8 +173,7 @@ class Completions:
                     processed_tools.extend(mcp_tools)
                 except Exception as e:
                     raise ValueError(
-                        f"Failed to create MCP client from config: {e}\n"
-                        f"Config: {tool}"
+                        f"Failed to create MCP client from config: {e}\nConfig: {tool}"
                     )
             else:
                 # Regular callable tool - pass through


### PR DESCRIPTION
## **Summary**

The `provider_configs` field in the `Client` class was using a mutable default argument (`dict = {}`). This caused shared state issues where modifying the configuration of one `Client` instance would inadvertently affect all other instances initialized with the default value.

**Changes:**

* Changed `provider_configs` default value from `{}` to `None` in `Client.__init__`.
* Added logic to initialize `self.provider_configs` as a new dictionary if `None` is provided.

## **Root Cause**

Default arguments are evaluated only once at function definition time. Using a mutable object like a dictionary as a default argument leads to a persistent object shared across all calls that do not provide an explicit value.

```python
# Problematic behavior in current implementation:
client_a = ai.Client()
client_b = ai.Client()

client_a.configure({"openai": {"api_key": "sk-example"}})

# client_b now unexpectedly contains client_a's config 
# because they both point to the same internal dictionary object.
print(client_b.provider_configs) 
# Output: {'openai': {'api_key': 'sk-example'}}

```

## **Solution**

```python
def __init__(
    self,
    provider_configs: dict | None = None,
    extra_param_mode: Literal["strict", "warn", "permissive"] = "warn",
):
    self.providers = {}
    # Ensures a fresh dictionary for every instance
    if provider_configs:
        self.provider_configs = provider_configs
    else:
        self.provider_configs = {}
    # ...

```