### PR TITLE
docs: updates the examples in README to use currently supported models

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-#  aisuite
+# aisuite
 
 [![PyPI](https://img.shields.io/pypi/v/aisuite)](https://pypi.org/project/aisuite/)
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
@@ -55,7 +55,7 @@ install the provider-specific library either separately or when installing aisui
 The API Keys can be set as environment variables, or can be passed as config to the aisuite Client constructor.
 You can use tools like [`python-dotenv`](https://pypi.org/project/python-dotenv/) or [`direnv`](https://direnv.net/) to set the environment variables manually. Please take a look at the `examples` folder to see usage.
 
-Here is a short example of using `aisuite` to generate chat completion responses from gpt-4o and claude-3-5-sonnet.
+Here is a short example of using `aisuite` to generate chat completion responses from gpt-4o and claude-4-5-sonnet.
 
 Set the API keys.
 
@@ -70,7 +70,7 @@ Use the python client.
 import aisuite as ai
 client = ai.Client()
 
-models = ["openai:gpt-4o", "anthropic:claude-3-5-sonnet-20240620"]
+models = ["openai:gpt-4o", "anthropic:claude-sonnet-4-5-20250929"]
 
 messages = [
     {"role": "system", "content": "Respond in Pirate English."},


### PR DESCRIPTION
## **Summary**

Fixes #260 
The example code provided in the README uses a specific model version (`anthropic:claude-3-5-sonnet-20240620`) that has been deprecated by Anthropic as of August 2025. This causes a `404 Not Found` error when users attempt to run the quickstart example.

**Changes:**

* Updated the `models` list in the example code to use the latest stable version: `anthropic:claude-sonnet-4-5-20250929`.

## **Root Cause**

The specific timestamped version `20240620` has been retired from their active API endpoints, leading the Anthropic Python SDK to return a `NotFoundError`.

```python
# The current error in the log:
anthropic.NotFoundError: Error code: 404 - {
    'type': 'error', 
    'error': {
        'type': 'not_found_error', 
        'message': 'model: claude-3-5-sonnet-20240620'
    }
}

```

## **Solution**

Update the model strings to use sonnet 4.5 model to ensure the README remains functional for new users.

```python
import aisuite as ai
client = ai.Client()

models = ["openai:gpt-4o", "anthropic:claude-sonnet-4-5-20250929"]

messages = [
    {"role": "system", "content": "Respond in Pirate English."},
    {"role": "user", "content": "Tell me a joke."},
]

for model in models:
    response = client.chat.completions.create(
        model=model,
        messages=messages,
        temperature=0.75
    )
    print(response.choices[0].message.content)


```