### PR TITLE
Fix Google tool response history for Vertex function calling

### DIFF
--- a/aisuite/providers/google_provider.py
+++ b/aisuite/providers/google_provider.py
@@ -81,8 +81,8 @@ class GoogleMessageConverter:
             part = Part.from_function_response(
                 name=message["name"], response=content_json
             )
-            # TODO: Return Content instead of Part. But returning Content is not working.
-            return part
+            # Wrap tool response in Content so history is a list of Content objects.
+            return Content(role="function", parts=[part])
         except json.JSONDecodeError:
             raise ValueError("Tool result message must be valid JSON")
 
@@ -303,8 +303,8 @@ class GoogleProvider(Provider):
         # If the last message is a function response, send the Part object directly
         # Otherwise, send just the text content
         message_to_send = (
-            Content(role="function", parts=[last_message])
-            if isinstance(last_message, Part)
+            last_message
+            if isinstance(last_message, Content) and last_message.role == "function"
             else last_message.parts[0].text
         )
         # response = chat.send_message(message_to_send)


### PR DESCRIPTION
This PR fixes a type mismatch in the Google provider’s tool-calling flow.
 Tool results were previously returned as Part objects and mixed into the chat history, but Vertex expects a history of
Content objects. This caused “part” errors during Google multi-turn tool calls.