### PR TITLE
Add MLX-LM provider

### DIFF
--- a/aisuite/providers/mlx_provider.py
+++ b/aisuite/providers/mlx_provider.py
@@ -1,0 +1,69 @@
+import os
+import httpx
+from aisuite.provider import Provider, LLMError
+from aisuite.framework import ChatCompletionResponse
+
+
+class MlxProvider(Provider):
+    """
+    MLX-LM Provider that makes HTTP calls to an mlx_lm.server instance.
+    It uses the /v1/chat/completions endpoint.
+    Read more here - https://github.com/ml-explore/mlx-lm/blob/main/mlx_lm/SERVER.md
+    If MLX_API_URL is not set and not passed in config, then it will default to "http://localhost:8080"
+    """
+
+    _CHAT_COMPLETION_ENDPOINT = "/v1/chat/completions"
+    _CONNECT_ERROR_MESSAGE = (
+        "MLX-LM server is likely not running. Start it with "
+        "`mlx_lm.server --model <path_or_hf_repo>` on your host."
+    )
+
+    def __init__(self, **config):
+        """
+        Initialize the MLX-LM provider with the given configuration.
+        """
+        self.url = config.get("api_url") or os.getenv(
+            "MLX_API_URL", "http://localhost:8080"
+        )
+
+        # Optionally set a custom timeout (default to 30s)
+        self.timeout = config.get("timeout", 30)
+
+    def chat_completions_create(self, model, messages, **kwargs):
+        """
+        Makes a request to the chat completions endpoint using httpx.
+        """
+        kwargs["stream"] = False
+        data = {
+            "model": model,
+            "messages": messages,
+            **kwargs,  # Pass any additional arguments to the API
+        }
+
+        try:
+            response = httpx.post(
+                self.url.rstrip("/") + self._CHAT_COMPLETION_ENDPOINT,
+                json=data,
+                timeout=self.timeout,
+            )
+            response.raise_for_status()
+        except httpx.ConnectError:  # Handle connection errors
+            raise LLMError(f"Connection failed: {self._CONNECT_ERROR_MESSAGE}")
+        except httpx.HTTPStatusError as http_err:
+            raise LLMError(f"MLX-LM request failed: {http_err}")
+        except Exception as e:
+            raise LLMError(f"An error occurred: {e}")
+
+        # Return the normalized response
+        return self._normalize_response(response.json())
+
+    def _normalize_response(self, response_data):
+        """
+        Normalize the API response to a common format (ChatCompletionResponse).
+        MLX-LM is OpenAI-like, so we read choices[0].message.content.
+        """
+        normalized_response = ChatCompletionResponse()
+        normalized_response.choices[0].message.content = response_data["choices"][0][
+            "message"
+        ]["content"]
+        return normalized_response

--- a/guides/README.md
+++ b/guides/README.md
@@ -15,9 +15,10 @@ Here are the instructions for:
 - [xAI](xai.md)
 - [DeepSeek](deepseek.md)
 
-For locally hosted models using `Ollama` or `LM Studio`, follow these instructions:
+For locally hosted models using `Ollama`, `LM Studio`, or `MLX-LM`, follow these instructions:
 - [Ollama](ollama.md)
 - [LM Studio](lmstudio.md)
+- [MLX-LM](mlx.md)
 
 Unless otherwise stated, these guides have not been endorsed by the providers. 
 

--- a/guides/mlx.md
+++ b/guides/mlx.md
@@ -1,0 +1,61 @@
+# MLX-LM (local)
+
+MLX-LM lets you run local models on Apple Silicon and exposes an OpenAI-compatible HTTP API via `mlx_lm.server`.
+
+## Prerequisites
+
+Install MLX-LM:
+
+```bash
+pip install mlx-lm
+```
+
+## Start the MLX-LM server
+
+```bash
+mlx_lm.server --model mlx-community/Mistral-7B-Instruct-v0.3-4bit
+```
+
+By default, the server listens on `http://localhost:8080`. You can change the host/port:
+
+```bash
+mlx_lm.server --model mlx-community/Mistral-7B-Instruct-v0.3-4bit --host 127.0.0.1 --port 8080
+```
+
+## Use with aisuite
+
+```python
+import aisuite as ai
+
+client = ai.Client(
+    provider_configs={
+        "mlx": {
+            "api_url": "http://localhost:8080",  # optional, this is the default
+            "timeout": 30,                       # optional, this is the default
+        }
+    }
+)
+
+messages = [{"role": "user", "content": "Say this is a test!"}]
+
+response = client.chat.completions.create(
+    model="mlx:mlx-community/Mistral-7B-Instruct-v0.3-4bit",
+    messages=messages,
+    temperature=0.7,
+)
+
+print(response.choices[0].message.content)
+```
+
+Notes:
+- `aisuite` requires model strings formatted as `provider:model`.
+- The `model` value after the `:` is forwarded directly to the MLX-LM server as the `model` field. If the server was started with a fixed model, the value is effectively ignored by the server.
+- If `MLX_API_URL` is set in your environment, the provider will use that as the base URL instead of the default.
+
+## Environment variable
+
+You can configure the server URL via environment variable instead of passing it in `provider_configs`:
+
+```bash
+export MLX_API_URL=http://localhost:8080
+```

--- a/tests/providers/test_mlx_provider.py
+++ b/tests/providers/test_mlx_provider.py
@@ -1,0 +1,45 @@
+import pytest
+from unittest.mock import patch, MagicMock
+from aisuite.providers.mlx_provider import MlxProvider
+
+
+@pytest.fixture(autouse=True)
+def set_api_url_var(monkeypatch):
+    """Fixture to set environment variables for tests."""
+    monkeypatch.setenv("MLX_API_URL", "http://localhost:8080")
+
+
+def test_completion():
+    """Test that completions request successfully."""
+
+    user_greeting = "Say this is a test!"
+    message_history = [{"role": "user", "content": user_greeting}]
+    selected_model = "mlx-community/Mistral-7B-Instruct-v0.3-4bit"
+    chosen_temperature = 0.7
+    response_text_content = "mocked-text-response-from-mlx-model"
+
+    mlx = MlxProvider()
+    mock_response = {"choices": [{"message": {"content": response_text_content}}]}
+
+    with patch(
+        "httpx.post",
+        return_value=MagicMock(status_code=200, json=lambda: mock_response),
+    ) as mock_post:
+        response = mlx.chat_completions_create(
+            messages=message_history,
+            model=selected_model,
+            temperature=chosen_temperature,
+        )
+
+        mock_post.assert_called_once_with(
+            "http://localhost:8080/v1/chat/completions",
+            json={
+                "model": selected_model,
+                "messages": message_history,
+                "stream": False,
+                "temperature": chosen_temperature,
+            },
+            timeout=30,
+        )
+
+        assert response.choices[0].message.content == response_text_content


### PR DESCRIPTION
## Summary
Adds an `MlxProvider` that connects aisuite to a locally running `mlx_lm.server` instance on Apple Silicon Macs.

MLX-LM exposes an OpenAI-compatible `/v1/chat/completions` HTTP endpoint, following the same pattern as `OllamaProvider`.

## Changes
- `aisuite/providers/mlx_provider.py` — new provider, mirrors `OllamaProvider` structure
- `tests/providers/test_mlx_provider.py` — unit test matching `test_ollama_provider.py` style
- `guides/mlx.md` — setup and usage guide
- `guides/README.md` — linked MLX-LM guide under locally hosted models

## Usage
Start the server:

    mlx_lm.server --model mlx-community/Llama-3.2-3B-Instruct-4bit

Use with aisuite:

    import aisuite as ai
    client = ai.Client(provider_configs={"mlx": {"api_url": "http://localhost:8080"}})
    response = client.chat.completions.create(
        model="mlx:mlx-community/Llama-3.2-3B-Instruct-4bit",
        messages=[{"role": "user", "content": "Say this is a test!"}],
        temperature=0.7,
    )
    print(response.choices[0].message.content)

## Testing
- Unit test passes (mocked HTTP): `pytest tests/providers/test_mlx_provider.py`
- Live end-to-end tested against `mlx_lm.server` on macOS with `mlx-community/Llama-3.2-3B-Instruct-4bit`