### PR TITLE
feat: add OpenRouter provider integration

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -45,3 +45,6 @@ SAMBANOVA_API_KEY=
 
 # Inception Labs
 INCEPTION_API_KEY=
+
+# OpenRouter Labs
+OPENROUTER_API_KEY=

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
 
 `aisuite` is a lightweight Python library that provides a **unified API for working with multiple Generative AI providers**.  
-It offers a consistent interface for models from *OpenAI, Anthropic, Google, Hugging Face, AWS, Cohere, Mistral, Ollama*, and others—abstracting away SDK differences, authentication details, and parameter variations.  
+It offers a consistent interface for models from *OpenAI, Anthropic, Google, Hugging Face, AWS, Cohere, Mistral, Ollama, OpenRouter*, and others—abstracting away SDK differences, authentication details, and parameter variations.  
 Its design is modeled after OpenAI’s API style, making it instantly familiar and easy to adopt.
 
 `aisuite` lets developers build and **run LLM-based or agentic applications across providers** with minimal setup.  
@@ -62,6 +62,7 @@ Set the API keys.
 ```shell
 export OPENAI_API_KEY="your-openai-api-key"
 export ANTHROPIC_API_KEY="your-anthropic-api-key"
+export OPENROUTER_API_KEY="your-openrouter-api-key"
 ```
 
 Use the python client.
@@ -70,7 +71,7 @@ Use the python client.
 import aisuite as ai
 client = ai.Client()
 
-models = ["openai:gpt-4o", "anthropic:claude-3-5-sonnet-20240620"]
+models = ["openai:gpt-4o", "anthropic:claude-3-5-sonnet-20240620","openrouter:google/gemma-4-26b-a4b-it:free"]
 
 messages = [
     {"role": "system", "content": "Respond in Pirate English."},

--- a/aisuite/providers/openrouter_provider.py
+++ b/aisuite/providers/openrouter_provider.py
@@ -1,0 +1,49 @@
+import openai
+import os
+from aisuite.provider import Provider, LLMError
+from aisuite.providers.message_converter import OpenAICompliantMessageConverter
+
+
+class OpenrouterProvider(Provider):
+    def __init__(self, **config):
+        """
+        Initialize the OpenRouter provider with the given configuration.
+        Pass the entire configuration dictionary to the OpenAI client constructor.
+        """
+        # Ensure API key is provided either in config or via environment variable
+        config.setdefault("api_key", os.getenv("OPENROUTER_API_KEY"))
+        config.setdefault("base_url", "https://openrouter.ai/api/v1")
+
+        # Support optional OpenRouter attribution headers
+        default_headers = config.get("default_headers", {})
+        if os.getenv("OR_SITE_URL") and "HTTP-Referer" not in default_headers:
+            default_headers["HTTP-Referer"] = os.getenv("OR_SITE_URL")
+        if os.getenv("OR_APP_NAME") and "X-OpenRouter-Title" not in default_headers:
+            default_headers["X-OpenRouter-Title"] = os.getenv("OR_APP_NAME")
+
+        if default_headers:
+            config["default_headers"] = default_headers
+
+        if not config["api_key"]:
+            raise ValueError(
+                "OpenRouter API key is missing. Please provide it in the config or set the OPENROUTER_API_KEY environment variable."
+            )
+
+        self.client = openai.OpenAI(**config)
+        self.transformer = OpenAICompliantMessageConverter()
+
+        super().__init__()
+
+    def chat_completions_create(self, model, messages, **kwargs):
+        # Any exception raised by OpenRouter will be returned to the caller.
+        # Maybe we should catch them and raise a custom LLMError.
+        try:
+            transformed_messages = self.transformer.convert_request(messages)
+            response = self.client.chat.completions.create(
+                model=model,
+                messages=transformed_messages,
+                **kwargs,  # Pass any additional arguments to the OpenRouter API
+            )
+            return response
+        except Exception as e:
+            raise LLMError(f"An error occurred: {e}")

--- a/tests/providers/test_openrouter_provider.py
+++ b/tests/providers/test_openrouter_provider.py
@@ -1,0 +1,104 @@
+"""Tests for OpenRouter provider functionality."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from aisuite.providers.openrouter_provider import OpenrouterProvider
+from aisuite.provider import LLMError
+from aisuite.providers.message_converter import OpenAICompliantMessageConverter
+
+
+@pytest.fixture(autouse=True)
+def set_env_vars(monkeypatch):
+    """Fixture to set environment variables for tests."""
+    monkeypatch.setenv("OPENROUTER_API_KEY", "test-or-api-key")
+    monkeypatch.setenv("OR_SITE_URL", "https://my-test-site.com")
+    monkeypatch.setenv("OR_APP_NAME", "TestApp")
+
+
+@pytest.fixture
+def openrouter_provider():
+    """Create an OpenRouter provider instance for testing."""
+    return OpenrouterProvider()
+
+
+class TestOpenrouterProvider:
+    """Test suite for OpenRouter provider initialization."""
+
+    def test_provider_initialization(self, openrouter_provider):
+        """Test that OpenRouter provider initializes correctly."""
+        assert openrouter_provider is not None
+        assert hasattr(openrouter_provider, "client")
+        assert hasattr(openrouter_provider, "transformer")
+        # Ensure the base URL is properly overridden for OpenRouter
+        assert (
+            str(openrouter_provider.client.base_url) == "https://openrouter.ai/api/v1/"
+        )
+
+    def test_provider_missing_api_key(self, monkeypatch):
+        """Test initialization fails when API key is missing."""
+        monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+        with pytest.raises(ValueError, match="OpenRouter API key is missing"):
+            OpenrouterProvider()
+
+
+class TestOpenrouterChatCompletions:
+    """Test suite for OpenRouter chat completions functionality."""
+
+    @patch("openai.OpenAI")
+    @patch.object(OpenAICompliantMessageConverter, "convert_request")
+    def test_chat_completions_create_success(
+        self, mock_convert, mock_openai_class, openrouter_provider
+    ):
+        """Test successful chat completion request."""
+        # Setup mock client and response
+        mock_client_instance = mock_openai_class.return_value
+        mock_response = MagicMock()
+        mock_client_instance.chat.completions.create.return_value = mock_response
+
+        # Inject the mock client into our provider
+        openrouter_provider.client = mock_client_instance
+
+        # Mock the message converter
+        mock_converted_messages = [{"role": "user", "content": "Transformed"}]
+        mock_convert.return_value = mock_converted_messages
+
+        original_messages = [{"role": "user", "content": "Hello"}]
+
+        # Execute the method
+        result = openrouter_provider.chat_completions_create(
+            model="openrouter:openai/gpt-4o",
+            messages=original_messages,
+            temperature=0.7,
+        )
+
+        # Assertions
+        mock_convert.assert_called_once_with(original_messages)
+        mock_client_instance.chat.completions.create.assert_called_once_with(
+            model="openrouter:openai/gpt-4o",
+            messages=mock_converted_messages,
+            temperature=0.7,
+        )
+        assert result == mock_response
+
+    @patch("openai.OpenAI")
+    def test_chat_completions_create_error_handling(
+        self, mock_openai_class, openrouter_provider
+    ):
+        """Test error handling for API failures."""
+        # Setup mock client to throw an exception
+        mock_client_instance = mock_openai_class.return_value
+        mock_client_instance.chat.completions.create.side_effect = Exception(
+            "API Error"
+        )
+
+        # Inject the mock client
+        openrouter_provider.client = mock_client_instance
+
+        # Execute and assert the custom LLMError is raised
+        with pytest.raises(LLMError, match="An error occurred: API Error"):
+            openrouter_provider.chat_completions_create(
+                model="openrouter:openai/gpt-4o",
+                messages=[{"role": "user", "content": "Hello"}],
+            )


### PR DESCRIPTION
## Description
This PR introduces support for **OpenRouter**, allowing users to route requests to hundreds of models (including free tiers) using a unified, OpenAI-compatible API.

Because OpenRouter is fully compliant with the OpenAI SDK, this implementation leverages the existing `OpenAICompliantMessageConverter` and the `openai` Python client, seamlessly overriding the `base_url` to handle the routing.

## Changes Made
* **Added `OpenrouterProvider`:** Created `aisuite/providers/openrouter_provider.py` to handle initialization and request forwarding.
* **Header Support:** Added native support for OpenRouter's app attribution headers (`HTTP-Referer` and `X-OpenRouter-Title`) via `OR_SITE_URL` and `OR_APP_NAME` environment variables.
* **Advanced Routing:** Ensured `**kwargs` are passed through to the `chat.completions.create` method. This means OpenRouter's advanced functionalities—like **Streaming (`stream=True`)**, **Model Fallbacks**, and **Provider Preferences** via `extra_body`—are fully supported out-of-the-box.
* **Documentation:** Added OpenRouter to the supported providers list in `README.md` and included the API key in `.env.example`.

## Testing
* **Unit Tests:** Added `tests/test_openrouter_provider.py` using `unittest.mock` to verify initialization, key handling, and successful/failed chat completion routing. 
* **Integration:** Manually tested end-to-end using an actual OpenRouter API key.
* **CI/CD:** Ran the full `pytest tests/` suite and executed `pre-commit run --all-files` to ensure no regressions and strict adherence to formatting guidelines.

## Checklist
- [x] Code follows the project's style guidelines (`pre-commit` passed)
- [x] Unit tests have been added and pass locally
- [x] Documentation (`README.md`, `.env.example`) has been updated