### PR TITLE
fix(providers): enable tool calling and resolve JSON serialization crash in Ollama provider

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -45,3 +45,6 @@ SAMBANOVA_API_KEY=
 
 # Inception Labs
 INCEPTION_API_KEY=
+
+# OpenRouter Labs
+OPENROUTER_API_KEY=

--- a/.env.sample
+++ b/.env.sample
@@ -48,3 +48,6 @@ INCEPTION_API_KEY=
 
 # OpenRouter Labs
 OPENROUTER_API_KEY=
+
+# Ollama Labs
+OLLAMA_API_KEY=

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
 
 `aisuite` is a lightweight Python library that provides a **unified API for working with multiple Generative AI providers**.  
-It offers a consistent interface for models from *OpenAI, Anthropic, Google, Hugging Face, AWS, Cohere, Mistral, Ollama*, and others—abstracting away SDK differences, authentication details, and parameter variations.  
+It offers a consistent interface for models from *OpenAI, Anthropic, Google, Hugging Face, AWS, Cohere, Mistral, Ollama, OpenRouter*, and others—abstracting away SDK differences, authentication details, and parameter variations.  
 Its design is modeled after OpenAI’s API style, making it instantly familiar and easy to adopt.
 
 `aisuite` lets developers build and **run LLM-based or agentic applications across providers** with minimal setup.  
@@ -62,6 +62,7 @@ Set the API keys.
 ```shell
 export OPENAI_API_KEY="your-openai-api-key"
 export ANTHROPIC_API_KEY="your-anthropic-api-key"
+export OPENROUTER_API_KEY="your-openrouter-api-key"
 ```
 
 Use the python client.
@@ -70,7 +71,7 @@ Use the python client.
 import aisuite as ai
 client = ai.Client()
 
-models = ["openai:gpt-4o", "anthropic:claude-3-5-sonnet-20240620"]
+models = ["openai:gpt-4o", "anthropic:claude-3-5-sonnet-20240620","openrouter:google/gemma-4-26b-a4b-it:free"]
 
 messages = [
     {"role": "system", "content": "Respond in Pirate English."},

--- a/aisuite/providers/ollama_provider.py
+++ b/aisuite/providers/ollama_provider.py
@@ -2,6 +2,7 @@ import os
 import httpx
 from aisuite.provider import Provider, LLMError
 from aisuite.framework import ChatCompletionResponse
+from aisuite.providers.message_converter import OpenAICompliantMessageConverter
 
 
 class OllamaProvider(Provider):
@@ -26,15 +27,23 @@ class OllamaProvider(Provider):
         # Optionally set a custom timeout (default to 30s)
         self.timeout = config.get("timeout", 30)
 
+        # Initialize the message converter to sanitize aisuite Message objects into JSON
+        self.transformer = OpenAICompliantMessageConverter()
+
     def chat_completions_create(self, model, messages, **kwargs):
         """
         Makes a request to the chat completions endpoint using httpx.
         """
         kwargs["stream"] = False
+
+        # Convert internal aisuite Message objects to standard dictionaries
+        transformed_messages = self.transformer.convert_request(messages)
+
         data = {
             "model": model,
-            "messages": messages,
-            **kwargs,  # Pass any additional arguments to the API
+            "messages": transformed_messages,
+            # Pass any additional arguments to the API (like tools, temperature)
+            **kwargs,
         }
 
         try:
@@ -59,7 +68,15 @@ class OllamaProvider(Provider):
         Normalize the API response to a common format (ChatCompletionResponse).
         """
         normalized_response = ChatCompletionResponse()
-        normalized_response.choices[0].message.content = response_data["message"][
-            "content"
-        ]
+        message_data = response_data.get("message", {})
+
+        # Map the standard text content (defaults to empty string if missing)
+        normalized_response.choices[0].message.content = message_data.get("content", "")
+
+        # Map the tool calls if the LLM generated them
+        if "tool_calls" in message_data and message_data["tool_calls"]:
+            normalized_response.choices[0].message.tool_calls = message_data[
+                "tool_calls"
+            ]
+
         return normalized_response

--- a/aisuite/providers/openrouter_provider.py
+++ b/aisuite/providers/openrouter_provider.py
@@ -1,0 +1,49 @@
+import openai
+import os
+from aisuite.provider import Provider, LLMError
+from aisuite.providers.message_converter import OpenAICompliantMessageConverter
+
+
+class OpenrouterProvider(Provider):
+    def __init__(self, **config):
+        """
+        Initialize the OpenRouter provider with the given configuration.
+        Pass the entire configuration dictionary to the OpenAI client constructor.
+        """
+        # Ensure API key is provided either in config or via environment variable
+        config.setdefault("api_key", os.getenv("OPENROUTER_API_KEY"))
+        config.setdefault("base_url", "https://openrouter.ai/api/v1")
+
+        # Support optional OpenRouter attribution headers
+        default_headers = config.get("default_headers", {})
+        if os.getenv("OR_SITE_URL") and "HTTP-Referer" not in default_headers:
+            default_headers["HTTP-Referer"] = os.getenv("OR_SITE_URL")
+        if os.getenv("OR_APP_NAME") and "X-OpenRouter-Title" not in default_headers:
+            default_headers["X-OpenRouter-Title"] = os.getenv("OR_APP_NAME")
+
+        if default_headers:
+            config["default_headers"] = default_headers
+
+        if not config["api_key"]:
+            raise ValueError(
+                "OpenRouter API key is missing. Please provide it in the config or set the OPENROUTER_API_KEY environment variable."
+            )
+
+        self.client = openai.OpenAI(**config)
+        self.transformer = OpenAICompliantMessageConverter()
+
+        super().__init__()
+
+    def chat_completions_create(self, model, messages, **kwargs):
+        # Any exception raised by OpenRouter will be returned to the caller.
+        # Maybe we should catch them and raise a custom LLMError.
+        try:
+            transformed_messages = self.transformer.convert_request(messages)
+            response = self.client.chat.completions.create(
+                model=model,
+                messages=transformed_messages,
+                **kwargs,  # Pass any additional arguments to the OpenRouter API
+            )
+            return response
+        except Exception as e:
+            raise LLMError(f"An error occurred: {e}")

--- a/tests/providers/test_openrouter_provider.py
+++ b/tests/providers/test_openrouter_provider.py
@@ -1,0 +1,104 @@
+"""Tests for OpenRouter provider functionality."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from aisuite.providers.openrouter_provider import OpenrouterProvider
+from aisuite.provider import LLMError
+from aisuite.providers.message_converter import OpenAICompliantMessageConverter
+
+
+@pytest.fixture(autouse=True)
+def set_env_vars(monkeypatch):
+    """Fixture to set environment variables for tests."""
+    monkeypatch.setenv("OPENROUTER_API_KEY", "test-or-api-key")
+    monkeypatch.setenv("OR_SITE_URL", "https://my-test-site.com")
+    monkeypatch.setenv("OR_APP_NAME", "TestApp")
+
+
+@pytest.fixture
+def openrouter_provider():
+    """Create an OpenRouter provider instance for testing."""
+    return OpenrouterProvider()
+
+
+class TestOpenrouterProvider:
+    """Test suite for OpenRouter provider initialization."""
+
+    def test_provider_initialization(self, openrouter_provider):
+        """Test that OpenRouter provider initializes correctly."""
+        assert openrouter_provider is not None
+        assert hasattr(openrouter_provider, "client")
+        assert hasattr(openrouter_provider, "transformer")
+        # Ensure the base URL is properly overridden for OpenRouter
+        assert (
+            str(openrouter_provider.client.base_url) == "https://openrouter.ai/api/v1/"
+        )
+
+    def test_provider_missing_api_key(self, monkeypatch):
+        """Test initialization fails when API key is missing."""
+        monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+        with pytest.raises(ValueError, match="OpenRouter API key is missing"):
+            OpenrouterProvider()
+
+
+class TestOpenrouterChatCompletions:
+    """Test suite for OpenRouter chat completions functionality."""
+
+    @patch("openai.OpenAI")
+    @patch.object(OpenAICompliantMessageConverter, "convert_request")
+    def test_chat_completions_create_success(
+        self, mock_convert, mock_openai_class, openrouter_provider
+    ):
+        """Test successful chat completion request."""
+        # Setup mock client and response
+        mock_client_instance = mock_openai_class.return_value
+        mock_response = MagicMock()
+        mock_client_instance.chat.completions.create.return_value = mock_response
+
+        # Inject the mock client into our provider
+        openrouter_provider.client = mock_client_instance
+
+        # Mock the message converter
+        mock_converted_messages = [{"role": "user", "content": "Transformed"}]
+        mock_convert.return_value = mock_converted_messages
+
+        original_messages = [{"role": "user", "content": "Hello"}]
+
+        # Execute the method
+        result = openrouter_provider.chat_completions_create(
+            model="openrouter:openai/gpt-4o",
+            messages=original_messages,
+            temperature=0.7,
+        )
+
+        # Assertions
+        mock_convert.assert_called_once_with(original_messages)
+        mock_client_instance.chat.completions.create.assert_called_once_with(
+            model="openrouter:openai/gpt-4o",
+            messages=mock_converted_messages,
+            temperature=0.7,
+        )
+        assert result == mock_response
+
+    @patch("openai.OpenAI")
+    def test_chat_completions_create_error_handling(
+        self, mock_openai_class, openrouter_provider
+    ):
+        """Test error handling for API failures."""
+        # Setup mock client to throw an exception
+        mock_client_instance = mock_openai_class.return_value
+        mock_client_instance.chat.completions.create.side_effect = Exception(
+            "API Error"
+        )
+
+        # Inject the mock client
+        openrouter_provider.client = mock_client_instance
+
+        # Execute and assert the custom LLMError is raised
+        with pytest.raises(LLMError, match="An error occurred: API Error"):
+            openrouter_provider.chat_completions_create(
+                model="openrouter:openai/gpt-4o",
+                messages=[{"role": "user", "content": "Hello"}],
+            )


### PR DESCRIPTION
## Description
This PR fixes two critical bugs in the `OllamaProvider` that previously prevented it from supporting tool calling and multi-turn agentic workflows. 

Previously, when using `max_turns` with the Ollama provider, the `client.chat.completions.create` loop would crash on the second turn with a `TypeError: Object of type Message is not JSON serializable`. Additionally, if an Ollama model successfully generated a tool call payload, the provider's normalization method silently dropped it.

## Changes Made
* **Resolved JSON Serialization Crash:** Imported and implemented the `OpenAICompliantMessageConverter` in the `chat_completions_create` method. This safely sanitizes internal `aisuite` `Message` objects into standard dictionaries before passing them to `httpx.post()`, allowing multi-turn loops to run without crashing.
* **Enabled Tool Call Parsing:** Updated `_normalize_response` to correctly extract `tool_calls` from the raw Ollama response and map them to the normalized `ChatCompletionResponse` object. This allows `aisuite` to recognize and automatically execute tools triggered by local Ollama models.

## Testing
- [x] Verified that single-turn completions still function correctly.
- [x] Tested with `max_turns=3` and a Python function tool. Verified that the `tool_calls` payload is correctly parsed, the tool executes behind the scenes, and the multi-turn loop successfully feeds the tool output back to the model without throwing a `TypeError`.
- [x] Ran `pre-commit run --all-files` to ensure no linting/formatting regressions.
