### PR TITLE
fix: replace generic Exception with RuntimeError

### DIFF
--- a/aisuite/providers/azure_provider.py
+++ b/aisuite/providers/azure_provider.py
@@ -133,4 +133,4 @@ class AzureProvider(Provider):
             error_message = f"The request failed with status code: {error.code}\n"
             error_message += f"Headers: {error.info()}\n"
             error_message += error.read().decode("utf-8", "ignore")
-            raise Exception(error_message)
+            raise RuntimeError(error_message)


### PR DESCRIPTION
Replace raise Exception with RuntimeError in Azure provider.