### PR TITLE
Add agent observability and tracing

### DIFF
--- a/aisuite/__init__.py
+++ b/aisuite/__init__.py
@@ -9,4 +9,19 @@ from .agents import (
     ToolPolicyDecision,
 )
 from .framework.message import Message
+from . import tracing
 from .utils.tools import Tools
+
+__all__ = [
+    "Agent",
+    "Client",
+    "Message",
+    "RunResult",
+    "RunState",
+    "RunStep",
+    "Runner",
+    "ToolPolicyContext",
+    "ToolPolicyDecision",
+    "Tools",
+    "tracing",
+]

--- a/aisuite/agents/context.py
+++ b/aisuite/agents/context.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+from contextvars import ContextVar
+from dataclasses import dataclass
+from typing import Any, Optional
+
+from ..client import Client
+from ..tracing.sinks import TraceSink
+from .types import ToolPolicy
+
+
+@dataclass
+class ActiveRunContext:
+    client: Client
+    trace_id: str
+    group_id: Optional[str]
+    tags: list[str]
+    metadata: dict[str, Any]
+    trace_sinks: list[TraceSink]
+    tool_policy: Optional[ToolPolicy]
+
+
+_active_run_context: ContextVar[Optional[ActiveRunContext]] = ContextVar(
+    "aisuite_active_run_context",
+    default=None,
+)
+
+
+def get_active_run_context() -> Optional[ActiveRunContext]:
+    return _active_run_context.get()
+
+
+def set_active_run_context(context: ActiveRunContext):
+    return _active_run_context.set(context)
+
+
+def reset_active_run_context(token) -> None:
+    _active_run_context.reset(token)

--- a/aisuite/agents/runner.py
+++ b/aisuite/agents/runner.py
@@ -4,6 +4,8 @@ import copy
 from typing import Any, Callable, Optional
 
 from ..client import Client
+from ..tracing.sinks import TraceEvent, TraceSink, emit_event, get_configured_sinks
+from .context import ActiveRunContext, reset_active_run_context, set_active_run_context
 from .types import Agent, RunResult, RunState, RunStatus, RunStep, ToolPolicy
 from .utils import (
     build_input_messages,
@@ -25,10 +27,12 @@ class Runner:
         client: Optional[Client] = None,
         max_turns: int = 5,
         run_name: Optional[str] = None,
+        parent_run_id: Optional[str] = None,
         group_id: Optional[str] = None,
         tags: Optional[list[str]] = None,
         metadata: Optional[dict[str, Any]] = None,
         tool_policy: Optional[ToolPolicy | Callable] = None,
+        trace_sinks: Optional[list[TraceSink]] = None,
         tracing_disabled: bool = False,
         **kwargs: Any,
     ) -> RunResult:
@@ -38,10 +42,12 @@ class Runner:
             client=client,
             max_turns=max_turns,
             run_name=run_name,
+            parent_run_id=parent_run_id,
             group_id=group_id,
             tags=tags,
             metadata=metadata,
             tool_policy=tool_policy,
+            trace_sinks=trace_sinks,
             tracing_disabled=tracing_disabled,
             **kwargs,
         )
@@ -54,18 +60,27 @@ class Runner:
         client: Optional[Client] = None,
         max_turns: int = 5,
         run_name: Optional[str] = None,
+        parent_run_id: Optional[str] = None,
         group_id: Optional[str] = None,
         tags: Optional[list[str]] = None,
         metadata: Optional[dict[str, Any]] = None,
         tool_policy: Optional[ToolPolicy | Callable] = None,
+        trace_sinks: Optional[list[TraceSink]] = None,
         tracing_disabled: bool = False,
         **kwargs: Any,
     ) -> RunResult:
         active_client = client or Client()
         trace_id = None if tracing_disabled else new_id("trace")
+        active_trace_id = trace_id or ""
+        active_sinks = (
+            [] if tracing_disabled else (trace_sinks or get_configured_sinks())
+        )
         if isinstance(input, RunState):
             messages = copy.deepcopy(input.messages)
             effective_run_name = run_name if run_name is not None else input.run_name
+            effective_parent_run_id = (
+                parent_run_id if parent_run_id is not None else input.parent_run_id
+            )
             effective_group_id = group_id if group_id is not None else input.group_id
             effective_tags = merge_tags(agent.tags, input.tags, tags)
             effective_metadata = {
@@ -78,6 +93,7 @@ class Runner:
         else:
             messages = Runner._build_messages(agent, input)
             effective_run_name = run_name
+            effective_parent_run_id = parent_run_id
             effective_group_id = group_id
             effective_tags = merge_tags(agent.tags, tags)
             effective_metadata = {**agent.metadata, **(metadata or {})}
@@ -93,7 +109,8 @@ class Runner:
             request_kwargs["tool_policy_context"] = {
                 "agent_name": agent.name,
                 "run_name": effective_run_name,
-                "trace_id": trace_id,
+                "trace_id": active_trace_id,
+                "parent_run_id": effective_parent_run_id,
                 "group_id": effective_group_id,
                 "tags": effective_tags,
                 "metadata": effective_metadata,
@@ -104,7 +121,7 @@ class Runner:
             id=new_id("step"),
             type="agent",
             name=agent.name,
-            trace_id=trace_id or "",
+            trace_id=active_trace_id,
             started_at=now(),
             data={
                 "agent_name": agent.name,
@@ -113,6 +130,47 @@ class Runner:
             },
         )
 
+        Runner._emit_trace_event(
+            active_sinks,
+            "run.started",
+            active_trace_id,
+            agent.name,
+            run_name=effective_run_name,
+            parent_run_id=effective_parent_run_id,
+            group_id=effective_group_id,
+            tags=effective_tags,
+            metadata=effective_metadata,
+            data={
+                "input": copy.deepcopy(
+                    input.to_dict() if isinstance(input, RunState) else input
+                ),
+                "model": agent.model,
+            },
+        )
+        Runner._emit_trace_event(
+            active_sinks,
+            "model.started",
+            active_trace_id,
+            agent.name,
+            span_id=agent_step.id,
+            run_name=effective_run_name,
+            parent_run_id=effective_parent_run_id,
+            group_id=effective_group_id,
+            tags=effective_tags,
+            metadata=effective_metadata,
+            data={"model": agent.model, "message_count": len(messages)},
+        )
+        context_token = set_active_run_context(
+            ActiveRunContext(
+                client=active_client,
+                trace_id=active_trace_id,
+                group_id=effective_group_id,
+                tags=copy.deepcopy(effective_tags),
+                metadata=copy.deepcopy(effective_metadata),
+                trace_sinks=active_sinks,
+                tool_policy=tool_policy,
+            )
+        )
         try:
             response = active_client.chat.completions.create(
                 model=agent.model,
@@ -120,9 +178,24 @@ class Runner:
                 **request_kwargs,
             )
             status: RunStatus = "completed"
-        except Exception:
+        except Exception as exc:
             agent_step.ended_at = now()
+            Runner._emit_trace_event(
+                active_sinks,
+                "run.failed",
+                active_trace_id,
+                agent.name,
+                span_id=agent_step.id,
+                run_name=effective_run_name,
+                parent_run_id=effective_parent_run_id,
+                group_id=effective_group_id,
+                tags=effective_tags,
+                metadata=effective_metadata,
+                data={"error": str(exc), "error_type": type(exc).__name__},
+            )
             raise
+        finally:
+            reset_active_run_context(context_token)
 
         agent_step.ended_at = now()
         all_messages = extract_response_messages(response, messages)
@@ -133,11 +206,11 @@ class Runner:
         steps = [
             *prior_steps,
             agent_step,
-            *Runner._build_response_steps(raw_responses, trace_id or ""),
-            *Runner._build_tool_steps(response, trace_id or ""),
+            *Runner._build_response_steps(raw_responses, active_trace_id),
+            *Runner._build_tool_steps(response, active_trace_id),
         ]
 
-        return RunResult(
+        result = RunResult(
             final_output=extract_final_output(response),
             status=status,
             agent=agent,
@@ -147,7 +220,8 @@ class Runner:
             new_items=all_messages[len(messages) :],
             raw_responses=raw_responses,
             run_name=effective_run_name,
-            trace_id=trace_id or "",
+            trace_id=active_trace_id,
+            parent_run_id=effective_parent_run_id,
             group_id=effective_group_id,
             tags=effective_tags,
             metadata=effective_metadata,
@@ -155,6 +229,47 @@ class Runner:
             max_turns=effective_max_turns,
             _client=active_client,
         )
+        Runner._emit_trace_event(
+            active_sinks,
+            "model.completed",
+            active_trace_id,
+            agent.name,
+            span_id=agent_step.id,
+            run_name=effective_run_name,
+            parent_run_id=effective_parent_run_id,
+            group_id=effective_group_id,
+            tags=effective_tags,
+            metadata=effective_metadata,
+            data={
+                "final_output": copy.deepcopy(result.final_output),
+                "message_count": len(result.messages),
+            },
+        )
+        for event in getattr(response, "tool_events", []):
+            Runner._emit_tool_event(
+                active_sinks,
+                event,
+                active_trace_id,
+                agent.name,
+                effective_run_name,
+                effective_parent_run_id,
+                effective_group_id,
+                effective_tags,
+                effective_metadata,
+            )
+        Runner._emit_trace_event(
+            active_sinks,
+            "run.completed",
+            active_trace_id,
+            agent.name,
+            run_name=effective_run_name,
+            parent_run_id=effective_parent_run_id,
+            group_id=effective_group_id,
+            tags=effective_tags,
+            metadata=effective_metadata,
+            data={"run": result.trace_to_dict()},
+        )
+        return result
 
     @staticmethod
     async def continue_run(
@@ -238,3 +353,69 @@ class Runner:
                 )
             )
         return steps
+
+    @staticmethod
+    def _emit_trace_event(
+        sinks: list[TraceSink],
+        event_type: str,
+        trace_id: str,
+        agent_name: str,
+        *,
+        span_id: Optional[str] = None,
+        parent_span_id: Optional[str] = None,
+        parent_run_id: Optional[str] = None,
+        group_id: Optional[str] = None,
+        run_name: Optional[str] = None,
+        tags: Optional[list[str]] = None,
+        metadata: Optional[dict[str, Any]] = None,
+        data: Optional[dict[str, Any]] = None,
+    ) -> None:
+        if not sinks or not trace_id:
+            return
+        emit_event(
+            sinks,
+            TraceEvent(
+                event_type=event_type,
+                trace_id=trace_id,
+                span_id=span_id,
+                parent_span_id=parent_span_id,
+                parent_run_id=parent_run_id,
+                group_id=group_id,
+                run_name=run_name,
+                agent_name=agent_name,
+                tags=copy.deepcopy(tags or []),
+                metadata=copy.deepcopy(metadata or {}),
+                data=copy.deepcopy(data or {}),
+            ),
+        )
+
+    @staticmethod
+    def _emit_tool_event(
+        sinks: list[TraceSink],
+        tool_event: dict[str, Any],
+        trace_id: str,
+        agent_name: str,
+        run_name: Optional[str],
+        parent_run_id: Optional[str],
+        group_id: Optional[str],
+        tags: list[str],
+        metadata: dict[str, Any],
+    ) -> None:
+        if tool_event.get("type") == "tool_result":
+            event_type = "tool.completed"
+        elif tool_event.get("allowed") is False:
+            event_type = "tool.denied"
+        else:
+            event_type = "tool.allowed"
+        Runner._emit_trace_event(
+            sinks,
+            event_type,
+            trace_id,
+            agent_name,
+            parent_run_id=parent_run_id,
+            group_id=group_id,
+            run_name=run_name,
+            tags=tags,
+            metadata=metadata,
+            data=copy.deepcopy(tool_event),
+        )

--- a/aisuite/agents/types.py
+++ b/aisuite/agents/types.py
@@ -4,6 +4,7 @@ import copy
 import json
 import sys
 from dataclasses import dataclass, field
+from pathlib import Path
 from typing import Any, Callable, Literal, Optional, Protocol, TextIO
 
 from ..client import Client
@@ -98,6 +99,7 @@ class ToolPolicyContext:
     tags: list[str]
     metadata: dict[str, Any]
     messages: list[dict[str, Any]]
+    parent_run_id: Optional[str] = None
 
 
 class ToolPolicy(Protocol):
@@ -112,6 +114,7 @@ class RunState:
     status: RunStatus = "completed"
     run_name: Optional[str] = None
     trace_id: Optional[str] = None
+    parent_run_id: Optional[str] = None
     group_id: Optional[str] = None
     tags: list[str] = field(default_factory=list)
     metadata: dict[str, Any] = field(default_factory=dict)
@@ -130,6 +133,7 @@ class RunState:
             "status": self.status,
             "run_name": self.run_name,
             "trace_id": self.trace_id,
+            "parent_run_id": self.parent_run_id,
             "group_id": self.group_id,
             "tags": copy.deepcopy(self.tags),
             "metadata": copy.deepcopy(self.metadata),
@@ -146,6 +150,7 @@ class RunState:
             status=data.get("status", "completed"),
             run_name=data.get("run_name"),
             trace_id=data.get("trace_id"),
+            parent_run_id=data.get("parent_run_id"),
             group_id=data.get("group_id"),
             tags=copy.deepcopy(data.get("tags", [])),
             metadata=copy.deepcopy(data.get("metadata", {})),
@@ -166,6 +171,7 @@ class RunResult:
     raw_responses: list[Any]
     run_name: Optional[str]
     trace_id: str
+    parent_run_id: Optional[str]
     group_id: Optional[str]
     tags: list[str]
     metadata: dict[str, Any]
@@ -180,6 +186,7 @@ class RunResult:
             status=self.status,
             run_name=self.run_name,
             trace_id=self.trace_id,
+            parent_run_id=self.parent_run_id,
             group_id=self.group_id,
             tags=copy.deepcopy(self.tags),
             metadata=copy.deepcopy(self.metadata),
@@ -188,16 +195,29 @@ class RunResult:
         )
 
     def trace_to_dict(self) -> dict[str, Any]:
-        return {
+        data = {
             "trace_id": self.trace_id,
+            "parent_run_id": self.parent_run_id,
             "group_id": self.group_id,
             "run_name": self.run_name,
             "agent_name": self.last_agent.name,
             "status": self.status,
             "tags": copy.deepcopy(self.tags),
             "metadata": copy.deepcopy(self.metadata),
+            "final_output": copy.deepcopy(self.final_output),
+            "messages": copy.deepcopy(self.messages),
+            "new_items": copy.deepcopy(self.new_items),
+            "message_count": len(self.messages),
+            "step_count": len(self.steps),
             "steps": [step.to_dict() for step in self.steps],
         }
+        return ensure_json_serializable(data)
+
+    def write_trace_jsonl(self, path: str | Path) -> None:
+        trace_path = Path(path)
+        trace_path.parent.mkdir(parents=True, exist_ok=True)
+        with trace_path.open("a", encoding="utf-8") as trace_file:
+            trace_file.write(json.dumps(self.trace_to_dict()) + "\n")
 
     def print_trace(self, file: Optional[TextIO] = None) -> None:
         output = file or sys.stdout
@@ -217,6 +237,8 @@ class RunResult:
                 f"{key}={value}" for key, value in sorted(self.metadata.items())
             )
             print(f"Metadata: {metadata}", file=output)
+        if self.final_output is not None:
+            print(f"Final output: {self.final_output}", file=output)
 
         for step in self.steps:
             name = step.name or "-"

--- a/aisuite/agents/viewer.py
+++ b/aisuite/agents/viewer.py
@@ -1,0 +1,5 @@
+from ..tracing.viewer import main
+
+
+if __name__ == "__main__":
+    main()

--- a/aisuite/tracing/__init__.py
+++ b/aisuite/tracing/__init__.py
@@ -1,0 +1,26 @@
+from .sinks import (
+    InMemoryTraceSink,
+    LocalTraceSink,
+    TRACE_SCHEMA_VERSION,
+    TraceEvent,
+    TraceSink,
+    configure,
+    get_configured_sinks,
+)
+from .store import JsonlTraceStore, TraceStore
+from .viewer import ViewerServer, read_trace_file, start_viewer
+
+__all__ = [
+    "InMemoryTraceSink",
+    "JsonlTraceStore",
+    "LocalTraceSink",
+    "TRACE_SCHEMA_VERSION",
+    "TraceEvent",
+    "TraceSink",
+    "TraceStore",
+    "ViewerServer",
+    "configure",
+    "get_configured_sinks",
+    "read_trace_file",
+    "start_viewer",
+]

--- a/aisuite/tracing/sinks.py
+++ b/aisuite/tracing/sinks.py
@@ -1,0 +1,108 @@
+from __future__ import annotations
+
+import copy
+import uuid
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Literal, Optional, Protocol
+
+from .store import JsonlTraceStore
+
+
+TRACE_SCHEMA_VERSION = "2026-05-15"
+
+
+TraceEventType = Literal[
+    "run.started",
+    "run.completed",
+    "run.failed",
+    "model.started",
+    "model.completed",
+    "tool.allowed",
+    "tool.denied",
+    "tool.completed",
+]
+
+
+def _now() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _new_id(prefix: str) -> str:
+    return f"{prefix}_{uuid.uuid4().hex}"
+
+
+@dataclass
+class TraceEvent:
+    event_type: TraceEventType
+    trace_id: str
+    agent_name: str
+    event_id: str = field(default_factory=lambda: _new_id("event"))
+    timestamp: str = field(default_factory=_now)
+    span_id: Optional[str] = None
+    parent_span_id: Optional[str] = None
+    parent_run_id: Optional[str] = None
+    group_id: Optional[str] = None
+    run_name: Optional[str] = None
+    tags: list[str] = field(default_factory=list)
+    metadata: dict[str, Any] = field(default_factory=dict)
+    data: dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "record_type": "trace_event",
+            "schema_version": TRACE_SCHEMA_VERSION,
+            "event_id": self.event_id,
+            "event_type": self.event_type,
+            "timestamp": self.timestamp,
+            "trace_id": self.trace_id,
+            "span_id": self.span_id,
+            "parent_span_id": self.parent_span_id,
+            "parent_run_id": self.parent_run_id,
+            "group_id": self.group_id,
+            "run_name": self.run_name,
+            "agent_name": self.agent_name,
+            "tags": copy.deepcopy(self.tags),
+            "metadata": copy.deepcopy(self.metadata),
+            "data": copy.deepcopy(self.data),
+        }
+
+
+class TraceSink(Protocol):
+    def emit(self, event: TraceEvent) -> None:
+        ...
+
+
+class LocalTraceSink:
+    def __init__(self, path: str | Path = ".aisuite/events.jsonl"):
+        self.path = Path(path)
+        self.store = JsonlTraceStore(self.path)
+
+    def emit(self, event: TraceEvent) -> None:
+        self.store.write_event(event)
+
+
+class InMemoryTraceSink:
+    def __init__(self):
+        self.events: list[TraceEvent] = []
+
+    def emit(self, event: TraceEvent) -> None:
+        self.events.append(event)
+
+
+_configured_sinks: list[TraceSink] = []
+
+
+def configure(*sinks: TraceSink | None) -> None:
+    global _configured_sinks
+    _configured_sinks = [sink for sink in sinks if sink is not None]
+
+
+def get_configured_sinks() -> list[TraceSink]:
+    return list(_configured_sinks)
+
+
+def emit_event(sinks: list[TraceSink], event: TraceEvent) -> None:
+    for sink in sinks:
+        sink.emit(event)

--- a/aisuite/tracing/store.py
+++ b/aisuite/tracing/store.py
@@ -1,0 +1,143 @@
+from __future__ import annotations
+
+import copy
+import json
+from pathlib import Path
+from typing import Any, Optional, Protocol
+
+
+class TraceStore(Protocol):
+    def write_event(self, event: Any) -> None:
+        ...
+
+    def list_runs(self) -> list[dict[str, Any]]:
+        ...
+
+    def get_run(self, trace_id: str) -> Optional[dict[str, Any]]:
+        ...
+
+    def list_events(self, trace_id: str) -> list[dict[str, Any]]:
+        ...
+
+
+class JsonlTraceStore:
+    def __init__(self, path: str | Path = ".aisuite/events.jsonl"):
+        self.path = Path(path)
+
+    def write_event(self, event: Any) -> None:
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        with self.path.open("a", encoding="utf-8") as handle:
+            handle.write(json.dumps(event.to_dict()) + "\n")
+
+    def list_records(self) -> list[dict[str, Any]]:
+        if not self.path.exists():
+            return []
+
+        records = []
+        with self.path.open("r", encoding="utf-8") as handle:
+            for line in handle:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    records.append(json.loads(line))
+                except json.JSONDecodeError:
+                    continue
+        return records
+
+    def list_runs(self) -> list[dict[str, Any]]:
+        return reconstruct_runs(self.list_records())
+
+    def get_run(self, trace_id: str) -> Optional[dict[str, Any]]:
+        for run in self.list_runs():
+            if run.get("trace_id") == trace_id:
+                return run
+        return None
+
+    def list_events(self, trace_id: str) -> list[dict[str, Any]]:
+        return [
+            record
+            for record in self.list_records()
+            if record.get("record_type") == "trace_event"
+            and record.get("trace_id") == trace_id
+        ]
+
+
+def reconstruct_runs(records: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    snapshots = []
+    events_by_trace_id: dict[str, list[dict[str, Any]]] = {}
+    for record in records:
+        if record.get("record_type") == "trace_event":
+            trace_id = record.get("trace_id")
+            if trace_id:
+                events_by_trace_id.setdefault(trace_id, []).append(copy.deepcopy(record))
+            continue
+        snapshots.append(copy.deepcopy(record))
+
+    runs_by_trace_id = {
+        snapshot.get("trace_id"): dict(snapshot)
+        for snapshot in snapshots
+        if snapshot.get("trace_id")
+    }
+    for trace_id, events in events_by_trace_id.items():
+        run = runs_by_trace_id.setdefault(trace_id, _empty_run(trace_id))
+        run["events"] = events
+        for event in events:
+            _merge_event_fields(run, event)
+            if event.get("event_type") == "run.completed":
+                completed = event.get("data", {}).get("run")
+                if completed:
+                    run_snapshot = dict(completed)
+                    run_snapshot["events"] = events
+                    runs_by_trace_id[trace_id] = run_snapshot
+                    run = run_snapshot
+                else:
+                    run["status"] = "completed"
+            elif event.get("event_type") == "run.failed":
+                run["status"] = "failed"
+            elif event.get("event_type") == "run.started":
+                run["status"] = run.get("status") or "running"
+
+        run.setdefault("event_count", len(events))
+
+    for run in runs_by_trace_id.values():
+        events = events_by_trace_id.get(run.get("trace_id"), [])
+        run.setdefault("events", events)
+        run.setdefault("event_count", len(events))
+        run.setdefault("message_count", len(run.get("messages", [])))
+        run.setdefault("step_count", len(run.get("steps", [])))
+        run.setdefault("status", "running")
+
+    return sorted(
+        runs_by_trace_id.values(),
+        key=lambda run: _run_sort_key(run),
+        reverse=True,
+    )
+
+
+def _empty_run(trace_id: str) -> dict[str, Any]:
+    return {
+        "trace_id": trace_id,
+        "status": "running",
+        "steps": [],
+        "messages": [],
+        "new_items": [],
+        "tags": [],
+        "metadata": {},
+    }
+
+
+def _merge_event_fields(run: dict[str, Any], event: dict[str, Any]) -> None:
+    run["group_id"] = run.get("group_id") or event.get("group_id")
+    run["run_name"] = run.get("run_name") or event.get("run_name")
+    run["agent_name"] = run.get("agent_name") or event.get("agent_name")
+    run["parent_run_id"] = run.get("parent_run_id") or event.get("parent_run_id")
+    run["tags"] = run.get("tags") or event.get("tags", [])
+    run["metadata"] = run.get("metadata") or event.get("metadata", {})
+
+
+def _run_sort_key(run: dict[str, Any]) -> str:
+    events = run.get("events", [])
+    if events:
+        return events[-1].get("timestamp", "")
+    return run.get("created_at") or run.get("started_at") or ""

--- a/aisuite/tracing/viewer.py
+++ b/aisuite/tracing/viewer.py
@@ -1,0 +1,348 @@
+from __future__ import annotations
+
+import argparse
+import json
+import threading
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+from typing import Any, Optional
+from urllib.parse import urlparse
+
+from .store import JsonlTraceStore
+
+
+VIEWER_HTML = """<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>aisuite runs</title>
+  <style>
+    body { margin: 0; font-family: Inter, ui-sans-serif, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; color: #18212f; background: #f4f6f8; }
+    header { height: 58px; display: flex; align-items: center; justify-content: space-between; padding: 0 20px; background: rgba(255,255,255,0.92); border-bottom: 1px solid #dce2e8; backdrop-filter: blur(12px); }
+    main { display: grid; grid-template-columns: 360px 1fr; min-height: calc(100vh - 58px); }
+    aside { border-right: 1px solid #dce2e8; background: white; overflow: auto; }
+    section { padding: 22px; overflow: auto; }
+    .brand { font-weight: 800; }
+    .top-meta { color: #637083; font-size: 13px; }
+    .run { padding: 12px 14px; border: 1px solid transparent; border-radius: 8px; cursor: pointer; margin: 6px 10px; }
+    .run:hover { background: #f9fafb; border-color: #edf1f5; }
+    .run.active { background: #eaf1ff; border-color: #bfd1ff; }
+    .group { padding: 16px 18px 6px; color: #637083; font-size: 12px; font-weight: 800; text-transform: uppercase; letter-spacing: 0.06em; display: flex; justify-content: space-between; }
+    .name { font-weight: 750; }
+    .meta { color: #637083; font-size: 12px; margin-top: 4px; }
+    .pill { display: inline-block; padding: 2px 8px; border-radius: 999px; background: #edf1f5; color: #354154; font-size: 12px; font-weight: 650; margin: 5px 4px 0 0; }
+    .pill.green { background: #e7f5f0; color: #12715b; }
+    .pill.blue { background: #eaf1ff; color: #174ea6; }
+    .panel { background: white; border: 1px solid #dce2e8; border-radius: 10px; margin-bottom: 16px; box-shadow: 0 10px 24px rgba(24, 33, 47, 0.06); }
+    .panel h2 { margin: 0; padding: 14px 16px; font-size: 15px; border-bottom: 1px solid #edf1f5; }
+    .panel .content { padding: 16px; }
+    .summary { display: grid; grid-template-columns: repeat(4, minmax(0, 1fr)); gap: 10px; margin-top: 16px; }
+    .metric { border: 1px solid #edf1f5; border-radius: 8px; padding: 11px; background: #f9fafb; }
+    .metric .label { color: #637083; font-size: 12px; font-weight: 700; }
+    .metric .value { font-weight: 850; font-size: 18px; margin-top: 4px; }
+    .output { white-space: pre-wrap; word-break: break-word; line-height: 1.48; color: #263244; }
+    .tabs { display: flex; gap: 6px; padding: 0 12px; border-bottom: 1px solid #edf1f5; }
+    .tab { border: 0; border-bottom: 2px solid transparent; background: transparent; padding: 13px 8px 11px; color: #637083; font: inherit; font-weight: 750; cursor: pointer; }
+    .tab.active { color: #276ef1; border-bottom-color: #276ef1; }
+    .tab-panel { display: none; }
+    .tab-panel.active { display: block; }
+    .message { border: 1px solid #edf1f5; border-radius: 8px; margin-bottom: 10px; overflow: hidden; background: #f9fafb; }
+    .message .role { color: #637083; font-size: 12px; font-weight: 800; padding: 8px 10px; text-transform: uppercase; letter-spacing: 0.04em; }
+    .message .body { padding: 0 10px 10px; white-space: pre-wrap; word-break: break-word; line-height: 1.48; }
+    .event { display: grid; grid-template-columns: 12px 1fr auto; gap: 12px; padding: 12px 0; border-bottom: 1px solid #edf1f5; }
+    .event:last-child { border-bottom: 0; }
+    .event-dot { width: 10px; height: 10px; border-radius: 999px; background: #276ef1; margin-top: 5px; }
+    .event-type { font-weight: 750; }
+    .event-summary { color: #637083; font-size: 13px; margin-top: 3px; }
+    .event details { margin-top: 8px; }
+    .event summary { cursor: pointer; color: #276ef1; font-size: 12px; font-weight: 750; }
+    .step { padding: 9px 0; border-bottom: 1px solid #edf0f5; }
+    .step:last-child { border-bottom: 0; }
+    pre { white-space: pre-wrap; word-break: break-word; background: #0b1020; color: #d5e0ff; padding: 12px; border-radius: 6px; overflow: auto; }
+    .empty { color: #607086; padding: 20px; }
+    @media (max-width: 800px) {
+      main { grid-template-columns: 1fr; }
+      aside { max-height: 35vh; border-right: 0; border-bottom: 1px solid #d8dee8; }
+      .summary { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+    }
+  </style>
+</head>
+<body>
+  <header><div><span class="brand">aisuite runs</span><span id="count" class="top-meta" style="margin-left: 10px;"></span></div><span class="top-meta">local viewer</span></header>
+  <main>
+    <aside id="runs"></aside>
+    <section id="detail"><div class="empty">No runs yet.</div></section>
+  </main>
+  <script>
+    let runs = [];
+    let selectedTraceId = null;
+    let selectedTab = "overview";
+
+    function escapeHtml(value) {
+      return String(value ?? "").replace(/[&<>"']/g, ch => ({
+        "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;"
+      }[ch]));
+    }
+
+    function displayValue(value) {
+      if (value === null || value === undefined) return "";
+      if (typeof value === "string") return value;
+      return JSON.stringify(value, null, 2);
+    }
+
+    function messageContent(message) {
+      if (!message || message.content === undefined) return displayValue(message);
+      return displayValue(message.content);
+    }
+
+    function renderRuns() {
+      document.getElementById("count").textContent = `${runs.length} run${runs.length === 1 ? "" : "s"}`;
+      const list = document.getElementById("runs");
+      if (!runs.length) {
+        list.innerHTML = '<div class="empty">Waiting for traces...</div>';
+        return;
+      }
+      const groups = {};
+      for (const run of runs) {
+        const key = run.group_id || "ungrouped";
+        if (!groups[key]) groups[key] = [];
+        groups[key].push(run);
+      }
+      list.innerHTML = Object.entries(groups).map(([group, groupRuns]) => `
+        <div class="group"><span>${escapeHtml(group)}</span><span>${groupRuns.length} run${groupRuns.length === 1 ? "" : "s"}</span></div>
+        ${groupRuns.map(run => {
+        const active = run.trace_id === selectedTraceId ? " active" : "";
+        const title = run.run_name || run.trace_id || "run";
+        const tags = (run.tags || []).map(tag => `<span class="pill">${escapeHtml(tag)}</span>`).join("");
+        const counts = `${run.message_count ?? (run.messages || []).length} messages · ${run.step_count ?? (run.steps || []).length} steps`;
+        return `<div class="run${active}" onclick="selectRun('${escapeHtml(run.trace_id)}')">
+          <div class="name">${escapeHtml(title)}</div>
+          <div class="meta">${escapeHtml(run.agent_name)} · ${escapeHtml(run.status)}</div>
+          <div class="meta">${escapeHtml(counts)}</div>
+          ${run.parent_run_id ? `<div class="meta">parent: ${escapeHtml(run.parent_run_id.slice(0, 12))}</div>` : ""}
+          <div class="meta">${escapeHtml(run.group_id || "")}</div>
+          <div>${tags}</div>
+        </div>`;
+        }).join("")}
+      `).join("");
+    }
+
+    function setTab(tab) {
+      selectedTab = tab;
+      renderDetail();
+    }
+
+    function renderDetail() {
+      const detail = document.getElementById("detail");
+      const run = runs.find(item => item.trace_id === selectedTraceId) || runs[0];
+      if (!run) {
+        detail.innerHTML = '<div class="empty">No runs yet.</div>';
+        return;
+      }
+      selectedTraceId = run.trace_id;
+      const metadata = Object.entries(run.metadata || {}).map(([key, value]) =>
+        `<span class="pill">${escapeHtml(key)}=${escapeHtml(value)}</span>`
+      ).join("");
+      const messages = (run.messages || []).map(message => {
+        const role = message.role || "message";
+        return `<div class="message">
+          <div class="role">${escapeHtml(role)}</div>
+          <div class="body">${escapeHtml(messageContent(message))}</div>
+        </div>`;
+      }).join("") || '<div class="empty">No messages.</div>';
+      const steps = (run.steps || []).map(step => {
+        const data = step.data || {};
+        const bits = [];
+        if (data.allowed !== undefined) bits.push(`allowed=${data.allowed}`);
+        if (data.status) bits.push(`status=${data.status}`);
+        if (data.reason) bits.push(`reason=${data.reason}`);
+        return `<div class="step">
+          <strong>${escapeHtml(step.type)}</strong> ${escapeHtml(step.name || "")}
+          <div class="meta">${escapeHtml(bits.join(" · "))}</div>
+        </div>`;
+      }).join("") || '<div class="empty">No steps.</div>';
+      const events = (run.events || []).map(event => {
+        const detail = event.data ? JSON.stringify(event.data, null, 2) : "";
+        return `<div class="event">
+          <div class="event-dot"></div>
+          <div>
+            <div class="event-type">${escapeHtml(event.event_type)}</div>
+            <div class="event-summary">${escapeHtml(event.agent_name || run.agent_name || "")} ${event.run_name ? "· " + escapeHtml(event.run_name) : ""}</div>
+            <details><summary>Details</summary><pre>${escapeHtml(detail)}</pre></details>
+          </div>
+          <div class="meta">${escapeHtml(event.timestamp || "")}</div>
+        </div>`;
+      }).join("") || '<div class="empty">No events.</div>';
+      const finalOutput = run.final_output === undefined || run.final_output === null
+        ? '<div class="empty">No final output.</div>'
+        : `<div class="output">${escapeHtml(displayValue(run.final_output))}</div>`;
+      const active = tab => tab === selectedTab ? " active" : "";
+      detail.innerHTML = `
+        <div class="panel"><h2>Run</h2><div class="content">
+          <div><strong>${escapeHtml(run.run_name || run.trace_id)}</strong></div>
+          <div class="meta">trace: ${escapeHtml(run.trace_id)}</div>
+          <div class="meta">agent: ${escapeHtml(run.agent_name)} · status: ${escapeHtml(run.status)}</div>
+          <div class="meta">group: ${escapeHtml(run.group_id || "-")}</div>
+          <div class="meta">parent: ${escapeHtml(run.parent_run_id || "-")}</div>
+          <div>${metadata}</div>
+          <div class="summary">
+            <div class="metric"><div class="label">Messages</div><div class="value">${escapeHtml(run.message_count ?? (run.messages || []).length)}</div></div>
+            <div class="metric"><div class="label">Steps</div><div class="value">${escapeHtml(run.step_count ?? (run.steps || []).length)}</div></div>
+            <div class="metric"><div class="label">Events</div><div class="value">${escapeHtml(run.event_count ?? (run.events || []).length)}</div></div>
+            <div class="metric"><div class="label">Trace</div><div class="value">${escapeHtml((run.trace_id || "").slice(0, 12))}</div></div>
+          </div>
+        </div></div>
+        <div class="panel">
+          <div class="tabs">
+            <button class="tab${active("overview")}" onclick="setTab('overview')">Overview</button>
+            <button class="tab${active("transcript")}" onclick="setTab('transcript')">Transcript</button>
+            <button class="tab${active("events")}" onclick="setTab('events')">Events</button>
+            <button class="tab${active("raw")}" onclick="setTab('raw')">Raw</button>
+          </div>
+          <div class="content">
+            <div class="tab-panel${active("overview")}">
+              <h2 style="padding: 0 0 10px; border: 0;">Final Output</h2>
+              ${finalOutput}
+              <h2 style="padding: 18px 0 10px; border: 0;">Steps</h2>
+              ${steps}
+            </div>
+            <div class="tab-panel${active("transcript")}">${messages}</div>
+            <div class="tab-panel${active("events")}">${events}</div>
+            <div class="tab-panel${active("raw")}"><pre>${escapeHtml(JSON.stringify(run, null, 2))}</pre></div>
+          </div>
+        </div>
+      `;
+      renderRuns();
+    }
+
+    function selectRun(traceId) {
+      selectedTraceId = traceId;
+      renderDetail();
+    }
+
+    async function refresh() {
+      const response = await fetch('/api/runs');
+      const payload = await response.json();
+      runs = payload.runs || [];
+      if (!selectedTraceId && runs.length) selectedTraceId = runs[0].trace_id;
+      renderRuns();
+      renderDetail();
+    }
+
+    refresh();
+    setInterval(refresh, 1500);
+  </script>
+</body>
+</html>
+"""
+
+
+def read_trace_file(trace_file: str | Path) -> list[dict[str, Any]]:
+    return JsonlTraceStore(trace_file).list_runs()
+
+
+class ViewerServer:
+    def __init__(
+        self,
+        trace_file: str | Path,
+        host: str = "127.0.0.1",
+        port: int = 8765,
+    ):
+        self.trace_file = Path(trace_file)
+        self.host = host
+        self.port = port
+        self._server: Optional[ThreadingHTTPServer] = None
+        self._thread: Optional[threading.Thread] = None
+
+    @property
+    def url(self) -> str:
+        if self._server:
+            host, port = self._server.server_address
+            return f"http://{host}:{port}"
+        return f"http://{self.host}:{self.port}"
+
+    def start(self) -> "ViewerServer":
+        trace_file = self.trace_file
+
+        class Handler(BaseHTTPRequestHandler):
+            def do_GET(self):
+                parsed = urlparse(self.path)
+                if parsed.path == "/api/runs":
+                    self._send_json({"runs": read_trace_file(trace_file)})
+                    return
+                if parsed.path in {"/", "/index.html"}:
+                    self._send_html(VIEWER_HTML)
+                    return
+                self.send_error(404)
+
+            def log_message(self, format, *args):
+                return
+
+            def _send_json(self, payload):
+                body = json.dumps(payload).encode("utf-8")
+                self.send_response(200)
+                self.send_header("Content-Type", "application/json")
+                self.send_header("Content-Length", str(len(body)))
+                self.end_headers()
+                self.wfile.write(body)
+
+            def _send_html(self, html):
+                body = html.encode("utf-8")
+                self.send_response(200)
+                self.send_header("Content-Type", "text/html; charset=utf-8")
+                self.send_header("Content-Length", str(len(body)))
+                self.end_headers()
+                self.wfile.write(body)
+
+        self.trace_file.parent.mkdir(parents=True, exist_ok=True)
+        self._server = ThreadingHTTPServer((self.host, self.port), Handler)
+        self._thread = threading.Thread(
+            target=self._server.serve_forever,
+            name="aisuite-runs-viewer",
+            daemon=True,
+        )
+        self._thread.start()
+        return self
+
+    def stop(self) -> None:
+        if self._server:
+            self._server.shutdown()
+            self._server.server_close()
+            self._server = None
+        if self._thread:
+            self._thread.join(timeout=2)
+            self._thread = None
+
+
+def start_viewer(
+    trace_file: str | Path = ".aisuite/runs.jsonl",
+    host: str = "127.0.0.1",
+    port: int = 8765,
+) -> ViewerServer:
+    return ViewerServer(trace_file=trace_file, host=host, port=port).start()
+
+
+def main(argv: Optional[list[str]] = None) -> None:
+    parser = argparse.ArgumentParser(description="Start the aisuite runs viewer.")
+    parser.add_argument("--trace-file", default=".aisuite/runs.jsonl")
+    parser.add_argument("--host", default="127.0.0.1")
+    parser.add_argument("--port", type=int, default=8765)
+    args = parser.parse_args(argv)
+
+    if args.host != "127.0.0.1":
+        print("Warning: non-localhost hosts may expose trace data.")
+
+    viewer = start_viewer(args.trace_file, host=args.host, port=args.port)
+    print(f"aisuite runs viewer: {viewer.url}")
+    print(f"Watching {args.trace_file}")
+    print("Press q then Enter to stop.")
+    try:
+        while input().strip().lower() != "q":
+            print("Press q then Enter to stop.")
+    finally:
+        viewer.stop()
+
+
+if __name__ == "__main__":
+    main()

--- a/aisuite/utils/tools.py
+++ b/aisuite/utils/tools.py
@@ -334,6 +334,7 @@ class Tools:
             arguments=arguments,
             run_name=base_context.get("run_name"),
             trace_id=base_context.get("trace_id"),
+            parent_run_id=base_context.get("parent_run_id"),
             group_id=base_context.get("group_id"),
             tags=list(base_context.get("tags", [])),
             metadata=dict(base_context.get("metadata", {})),

--- a/examples/agents/simple_agent.py
+++ b/examples/agents/simple_agent.py
@@ -42,6 +42,7 @@ result = ai.Runner.run_sync(
 
 print(result.final_output)
 result.print_trace()
+result.write_trace_jsonl(".aisuite/runs.jsonl")
 
 next_result = ai.Runner.continue_sync(
     result,
@@ -51,3 +52,4 @@ next_result = ai.Runner.continue_sync(
 
 print(next_result.final_output)
 next_result.print_trace()
+next_result.write_trace_jsonl(".aisuite/runs.jsonl")

--- a/tests/agents/test_agent_integration_flows.py
+++ b/tests/agents/test_agent_integration_flows.py
@@ -1,0 +1,49 @@
+from unittest.mock import Mock
+
+import aisuite as ai
+from aisuite.framework.message import ChatCompletionMessageToolCall, Function, Message
+from tests.agents.helpers import chat_response
+
+
+def tool_call(name, arguments, call_id):
+    return ChatCompletionMessageToolCall(
+        id=call_id,
+        type="function",
+        function=Function(name=name, arguments=arguments),
+    )
+
+
+def test_denied_tool_policy_flow_emits_denial_event():
+    client = ai.Client()
+    provider = Mock()
+    first_response = chat_response(None)
+    first_response.choices[0].message = Message(
+        role="assistant",
+        tool_calls=[tool_call("lookup_secret", '{"key": "token"}', "call_secret")],
+    )
+    provider.chat_completions_create.side_effect = [
+        first_response,
+        chat_response("I cannot access that."),
+    ]
+    client.providers["openai"] = provider
+    sink = ai.tracing.InMemoryTraceSink()
+
+    def lookup_secret(key: str) -> str:
+        return f"secret: {key}"
+
+    def deny_policy(context):
+        return ai.ToolPolicyDecision(allowed=False, reason="blocked")
+
+    result = ai.Runner.run_sync(
+        ai.Agent(name="assistant", model="openai:gpt-4o", tools=[lookup_secret]),
+        "Find the token",
+        client=client,
+        tool_policy=deny_policy,
+        trace_sinks=[sink],
+    )
+
+    assert result.final_output == "I cannot access that."
+    assert "tool.denied" in [event.event_type for event in sink.events]
+    denied = next(event for event in sink.events if event.event_type == "tool.denied")
+    assert denied.data["tool_name"] == "lookup_secret"
+    assert denied.data["reason"] == "blocked"

--- a/tests/agents/test_trace_output.py
+++ b/tests/agents/test_trace_output.py
@@ -29,6 +29,11 @@ def test_trace_to_dict_includes_observability_fields():
     assert trace["status"] == "completed"
     assert trace["tags"] == ["agent", "run"]
     assert trace["metadata"] == {"request_id": "req_1"}
+    assert trace["final_output"] == "ok"
+    assert trace["message_count"] == len(result.messages)
+    assert trace["step_count"] == len(result.steps)
+    assert trace["messages"] == result.messages
+    assert trace["new_items"] == result.new_items
     assert [step["type"] for step in trace["steps"]] == ["agent", "model_response"]
 
 
@@ -55,5 +60,6 @@ def test_print_trace_outputs_human_readable_trace():
     assert "status=completed" in text
     assert "Group: group_1" in text
     assert "Metadata: request_id=req_1" in text
+    assert "Final output: ok" in text
     assert "- agent: assistant" in text
     assert "- model_response: model_response" in text

--- a/tests/agents/test_trace_sinks.py
+++ b/tests/agents/test_trace_sinks.py
@@ -1,0 +1,111 @@
+import json
+from unittest.mock import Mock
+
+import aisuite as ai
+from tests.agents.helpers import chat_response
+
+
+def test_runner_emits_trace_events_to_memory_sink():
+    client = ai.Client()
+    client.chat.completions.create = Mock(return_value=chat_response("ok"))
+    sink = ai.tracing.InMemoryTraceSink()
+    agent = ai.Agent(name="assistant", model="openai:gpt-4o")
+
+    result = ai.Runner.run_sync(
+        agent,
+        "Hello",
+        client=client,
+        run_name="run",
+        group_id="group",
+        trace_sinks=[sink],
+    )
+
+    event_types = [event.event_type for event in sink.events]
+    assert event_types == [
+        "run.started",
+        "model.started",
+        "model.completed",
+        "run.completed",
+    ]
+    assert sink.events[0].trace_id == result.trace_id
+    assert sink.events[0].group_id == "group"
+    assert sink.events[-1].data["run"]["final_output"] == "ok"
+
+
+def test_local_trace_sink_writes_event_jsonl(tmp_path):
+    sink = ai.tracing.LocalTraceSink(tmp_path / "events.jsonl")
+    event = ai.tracing.TraceEvent(
+        event_type="run.started",
+        trace_id="trace_1",
+        agent_name="assistant",
+        group_id="group",
+    )
+
+    sink.emit(event)
+
+    line = (tmp_path / "events.jsonl").read_text(encoding="utf-8").splitlines()[0]
+    payload = json.loads(line)
+    assert payload["record_type"] == "trace_event"
+    assert payload["schema_version"] == ai.tracing.TRACE_SCHEMA_VERSION
+    assert payload["event_type"] == "run.started"
+    assert payload["trace_id"] == "trace_1"
+
+
+def test_jsonl_trace_store_lists_runs_and_events(tmp_path):
+    store = ai.tracing.JsonlTraceStore(tmp_path / "events.jsonl")
+    started = ai.tracing.TraceEvent(
+        event_type="run.started",
+        trace_id="trace_1",
+        agent_name="assistant",
+        group_id="group",
+        run_name="run",
+    )
+    completed = ai.tracing.TraceEvent(
+        event_type="run.completed",
+        trace_id="trace_1",
+        agent_name="assistant",
+        group_id="group",
+        run_name="run",
+        data={
+            "run": {
+                "trace_id": "trace_1",
+                "agent_name": "assistant",
+                "run_name": "run",
+                "group_id": "group",
+                "status": "completed",
+                "messages": [],
+                "steps": [],
+                "tags": [],
+                "metadata": {},
+                "final_output": "ok",
+            }
+        },
+    )
+
+    store.write_event(started)
+    store.write_event(completed)
+
+    run = store.get_run("trace_1")
+    assert run["status"] == "completed"
+    assert run["final_output"] == "ok"
+    assert [event["event_type"] for event in store.list_events("trace_1")] == [
+        "run.started",
+        "run.completed",
+    ]
+
+
+def test_global_trace_configuration_is_used_by_runner():
+    client = ai.Client()
+    client.chat.completions.create = Mock(return_value=chat_response("ok"))
+    sink = ai.tracing.InMemoryTraceSink()
+    ai.tracing.configure(sink)
+    try:
+        ai.Runner.run_sync(
+            ai.Agent(name="assistant", model="openai:gpt-4o"),
+            "Hello",
+            client=client,
+        )
+    finally:
+        ai.tracing.configure()
+
+    assert [event.event_type for event in sink.events][-1] == "run.completed"

--- a/tests/agents/test_viewer.py
+++ b/tests/agents/test_viewer.py
@@ -1,0 +1,92 @@
+import json
+from urllib.request import urlopen
+from unittest.mock import Mock
+
+import pytest
+
+import aisuite as ai
+from aisuite.tracing.viewer import VIEWER_HTML
+from tests.agents.helpers import chat_response
+
+
+def test_write_trace_jsonl_and_read_trace_file(tmp_path):
+    client = ai.Client()
+    client.chat.completions.create = Mock(return_value=chat_response("ok"))
+    agent = ai.Agent(name="assistant", model="openai:gpt-4o")
+    result = ai.Runner.run_sync(agent, "Hello", client=client, run_name="run")
+    trace_file = tmp_path / "runs.jsonl"
+
+    result.write_trace_jsonl(trace_file)
+
+    lines = trace_file.read_text(encoding="utf-8").splitlines()
+    assert len(lines) == 1
+    assert json.loads(lines[0])["trace_id"] == result.trace_id
+    trace = ai.tracing.read_trace_file(trace_file)[0]
+    assert trace["run_name"] == "run"
+    assert trace["final_output"] == "ok"
+    assert trace["messages"] == result.messages
+    assert trace["message_count"] == len(result.messages)
+    assert trace["step_count"] == len(result.steps)
+
+
+def test_start_viewer_serves_runs_api(tmp_path):
+    client = ai.Client()
+    client.chat.completions.create = Mock(return_value=chat_response("ok"))
+    agent = ai.Agent(name="assistant", model="openai:gpt-4o")
+    result = ai.Runner.run_sync(agent, "Hello", client=client, run_name="run")
+    trace_file = tmp_path / "runs.jsonl"
+    result.write_trace_jsonl(trace_file)
+
+    try:
+        viewer = ai.tracing.start_viewer(trace_file, port=0)
+    except PermissionError:
+        pytest.skip("Local socket binding is not permitted in this environment")
+    try:
+        with urlopen(f"{viewer.url}/api/runs", timeout=5) as response:
+            payload = json.loads(response.read().decode("utf-8"))
+    finally:
+        viewer.stop()
+
+    assert payload["runs"][0]["trace_id"] == result.trace_id
+    assert payload["runs"][0]["run_name"] == "run"
+    assert payload["runs"][0]["final_output"] == "ok"
+
+
+def test_viewer_html_renders_run_transcript_sections():
+    assert "Final Output" in VIEWER_HTML
+    assert "Transcript" in VIEWER_HTML
+    assert "message_count" in VIEWER_HTML
+    assert "Events" in VIEWER_HTML
+    assert "Details" in VIEWER_HTML
+
+
+def test_read_trace_file_reconstructs_runs_from_events(tmp_path):
+    trace_file = tmp_path / "events.jsonl"
+    sink = ai.tracing.LocalTraceSink(trace_file)
+    client = ai.Client()
+    client.chat.completions.create = Mock(return_value=chat_response("ok"))
+    agent = ai.Agent(name="assistant", model="openai:gpt-4o")
+
+    result = ai.Runner.run_sync(
+        agent,
+        "Hello",
+        client=client,
+        run_name="run",
+        group_id="group",
+        trace_sinks=[sink],
+    )
+
+    runs = ai.tracing.read_trace_file(trace_file)
+
+    assert len(runs) == 1
+    assert runs[0]["trace_id"] == result.trace_id
+    assert runs[0]["run_name"] == "run"
+    assert runs[0]["group_id"] == "group"
+    assert runs[0]["final_output"] == "ok"
+    assert [event["event_type"] for event in runs[0]["events"]] == [
+        "run.started",
+        "model.started",
+        "model.completed",
+        "run.completed",
+    ]
+    json.dumps({"runs": runs})


### PR DESCRIPTION
Add an observability layer for agent runs on top of the Agent API. The runner now emits structured trace events for each step (model calls, tool calls, tool-policy denials) and routes them to pluggable sinks, with a trace store and viewer model for inspecting past runs.

- aisuite/tracing: trace sinks (in-memory, local JSONL), a JSONL trace store, and a viewer data model for reconstructing runs
- aisuite/agents/runner: emit trace events and propagate run context
- aisuite/agents/context: ActiveRunContext to correlate nested runs
- Runner accepts trace_sinks; RunResult/RunStep carry trace data
- tests/agents: trace sink, viewer, trace-output, and tool-policy denial integration coverage