### PR TITLE
Add async support across providers, client, tools, and the agent Runner

### DIFF
--- a/aisuite/agents/runner.py
+++ b/aisuite/agents/runner.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import copy
 from typing import Any, Callable, Optional
 
@@ -30,6 +31,34 @@ class ThreadAlreadyExistsError(RuntimeError):
     """Raised when a new persisted run would overwrite an existing thread."""
 
 
+def _run_blocking(coro):
+    """Run an async coroutine to completion from synchronous code.
+
+    Uses asyncio.run when no loop is active. If called from within a running
+    event loop (e.g. a notebook), falls back to nest_asyncio so the sync
+    wrappers still work.
+    """
+    try:
+        loop = asyncio.get_running_loop()
+    except RuntimeError:
+        loop = None
+
+    if loop is None:
+        return asyncio.run(coro)
+
+    try:
+        import nest_asyncio
+    except ImportError as exc:  # pragma: no cover - depends on optional extra
+        raise RuntimeError(
+            "Runner.run_sync was called from within a running event loop. "
+            "Install the 'mcp' extra (which provides nest_asyncio) or call the "
+            "async Runner.run(...) instead."
+        ) from exc
+
+    nest_asyncio.apply()
+    return loop.run_until_complete(coro)
+
+
 class Runner:
     @staticmethod
     async def run(
@@ -51,7 +80,7 @@ class Runner:
         artifact_store: Optional[ArtifactStore] = None,
         **kwargs: Any,
     ) -> RunResult:
-        return Runner.run_sync(
+        return await Runner._run_impl(
             agent,
             input,
             client=client,
@@ -74,6 +103,21 @@ class Runner:
     def run_sync(
         agent: Agent,
         input: str | list[dict[str, Any]] | RunState,
+        **kwargs: Any,
+    ) -> RunResult:
+        """Synchronous wrapper around the async Runner.run.
+
+        Drives the provider's synchronous completion path so existing callers
+        (and tests that patch ``client.chat.completions.create``) are unaffected.
+        """
+        return _run_blocking(
+            Runner._run_impl(agent, input, use_async_client=False, **kwargs)
+        )
+
+    @staticmethod
+    async def _run_impl(
+        agent: Agent,
+        input: str | list[dict[str, Any]] | RunState,
         *,
         client: Optional[Client] = None,
         max_turns: int = 5,
@@ -88,6 +132,7 @@ class Runner:
         state_store: Optional[StateStore] = None,
         thread_id: Optional[str] = None,
         artifact_store: Optional[ArtifactStore] = None,
+        use_async_client: bool = True,
         **kwargs: Any,
     ) -> RunResult:
         if (state_store is None) != (thread_id is None):
@@ -208,11 +253,18 @@ class Runner:
             )
         )
         try:
-            response = active_client.chat.completions.create(
-                model=agent.model,
-                messages=copy.deepcopy(messages),
-                **request_kwargs,
-            )
+            if use_async_client:
+                response = await active_client.chat.completions.acreate(
+                    model=agent.model,
+                    messages=copy.deepcopy(messages),
+                    **request_kwargs,
+                )
+            else:
+                response = active_client.chat.completions.create(
+                    model=agent.model,
+                    messages=copy.deepcopy(messages),
+                    **request_kwargs,
+                )
             status: RunStatus = "completed"
         except Exception as exc:
             agent_step.ended_at = now()
@@ -335,26 +387,39 @@ class Runner:
         input: str | list[dict[str, Any]],
         **overrides: Any,
     ) -> RunResult:
-        return Runner.continue_sync(target, input, **overrides)
+        return await Runner._continue_impl(target, input, **overrides)
 
     @staticmethod
     def continue_sync(
+        target: RunResult | Agent,
+        input: str | list[dict[str, Any]],
+        **overrides: Any,
+    ) -> RunResult:
+        """Synchronous wrapper around the async Runner.continue_run."""
+        return _run_blocking(
+            Runner._continue_impl(target, input, use_async_client=False, **overrides)
+        )
+
+    @staticmethod
+    async def _continue_impl(
         target: RunResult | Agent,
         input: str | list[dict[str, Any]],
         *,
         state_store: Optional[StateStore] = None,
         thread_id: Optional[str] = None,
         artifact_store: Optional[ArtifactStore] = None,
+        use_async_client: bool = True,
         **overrides: Any,
     ) -> RunResult:
         if isinstance(target, RunResult):
             state = target.to_state()
             state.add_user_message(input)
-            result = Runner.run_sync(
+            result = await Runner._run_impl(
                 target.last_agent,
                 state,
                 client=overrides.pop("client", target._client),
                 artifact_store=artifact_store,
+                use_async_client=use_async_client,
                 **overrides,
             )
             if state_store is not None or thread_id is not None:
@@ -382,10 +447,11 @@ class Runner:
 
         state = stored.state
         state.add_user_message(input)
-        result = Runner.run_sync(
+        result = await Runner._run_impl(
             target,
             state,
             artifact_store=artifact_store,
+            use_async_client=use_async_client,
             **overrides,
         )
         next_state = result.to_state()

--- a/aisuite/client.py
+++ b/aisuite/client.py
@@ -510,22 +510,26 @@ class Completions:
                 )
 
             # Manual tool calling (no max_turns): the provider must still see the tool
-            # schemas, so re-add the processed tools to kwargs — schema dicts pass
-            # through as-is, callables (including MCP-derived ones) become OpenAI-format
-            # specs. Regression guard: a plain `kwargs.pop("tools")` here used to drop
-            # them entirely (#266).
+            # schemas, so re-add the processed tools to kwargs. Regression guard: a
+            # plain `kwargs.pop("tools")` here used to drop them entirely (#266).
             if tools is not None:
-                converted = []
-                for tool in tools:
-                    if callable(tool):
-                        converted.extend(Tools(tools=[tool]).tools())
-                    else:
-                        converted.append(tool)
-                kwargs["tools"] = converted
+                kwargs["tools"] = self._provider_ready_tools(tools)
 
             # Delegate the chat completion to the correct provider's implementation
             response = provider.chat_completions_create(model_name, messages, **kwargs)
             return self._extract_thinking_content(response)
+
+    @staticmethod
+    def _provider_ready_tools(tools: list) -> list:
+        """Tools as a provider request can carry them: schema dicts pass through
+        as-is; callables (including MCP-derived ones) become OpenAI-format specs."""
+        converted = []
+        for tool in tools:
+            if callable(tool):
+                converted.extend(Tools(tools=[tool]).tools())
+            else:
+                converted.append(tool)
+        return converted
 
     async def acreate(self, model: str, messages: list, **kwargs):
         """Async variant of ``create``.
@@ -560,6 +564,11 @@ class Completions:
                     tool_policy_context=tool_policy_context,
                     **kwargs,
                 )
+
+            # Manual tool calling (no max_turns): same regression guard as create()
+            # (#266) — the provider must still see the tool schemas.
+            if tools is not None:
+                kwargs["tools"] = self._provider_ready_tools(tools)
 
             response = await provider.achat_completions_create(
                 model_name, messages, **kwargs

--- a/aisuite/client.py
+++ b/aisuite/client.py
@@ -234,6 +234,65 @@ class Completions:
 
         return response
 
+    def _init_tool_runner(self, tools, kwargs):
+        """Validate/convert tools and set OpenAI-format specs on kwargs."""
+        if isinstance(tools, Tools):
+            tools_instance = tools
+        else:
+            if not all(callable(tool) for tool in tools):
+                raise ValueError("One or more tools is not callable")
+            tools_instance = Tools(tools)
+        kwargs["tools"] = tools_instance.tools()
+        return tools_instance
+
+    def _emit_model_send(self, messages, model_identifier):
+        self._emit_model_event(
+            "model.send",
+            normalize_model_input(messages, model=model_identifier),
+        )
+
+    def _emit_model_error(self, exc, model_identifier):
+        self._emit_model_event(
+            "model.error",
+            {
+                "model": model_identifier,
+                "error": str(exc),
+                "error_type": type(exc).__name__,
+            },
+        )
+
+    def _handle_model_response(self, response, model_identifier):
+        response = self._extract_thinking_content(response)
+        self._emit_model_event(
+            "model.response",
+            normalize_model_response(response, model=model_identifier),
+        )
+        return response
+
+    @staticmethod
+    def _response_tool_calls(response):
+        return (
+            getattr(response.choices[0].message, "tool_calls", None)
+            if hasattr(response, "choices")
+            else None
+        )
+
+    def _finalize_runner_response(
+        self,
+        response,
+        intermediate_responses,
+        intermediate_messages,
+        tool_policy_events,
+        tool_events,
+    ):
+        # Exclude the final response from the intermediate list.
+        response.intermediate_responses = intermediate_responses[:-1]
+        response.choices[0].intermediate_messages = intermediate_messages
+        response.tool_policy_events = tool_policy_events
+        response.tool_events = tool_events
+        response.tool_events_emitted = self._active_trace_context() is not None
+        return response
+
     def _tool_runner(
         self,
         provider,
@@ -260,16 +319,7 @@ class Completions:
         Returns:
             The final response from the model with intermediate responses and messages
         """
-        # Handle tools validation and conversion
-        if isinstance(tools, Tools):
-            tools_instance = tools
-            kwargs["tools"] = tools_instance.tools()
-        else:
-            # Check if passed tools are callable
-            if not all(callable(tool) for tool in tools):
-                raise ValueError("One or more tools is not callable")
-            tools_instance = Tools(tools)
-            kwargs["tools"] = tools_instance.tools()
+        tools_instance = self._init_tool_runner(tools, kwargs)
 
         turns = 0
         intermediate_responses = []  # Store intermediate responses
@@ -278,56 +328,29 @@ class Completions:
         tool_events = []
 
         while turns < max_turns:
-            # Make the API call
-            self._emit_model_event(
-                "model.send",
-                normalize_model_input(messages, model=model_identifier),
-            )
+            self._emit_model_send(messages, model_identifier)
             try:
                 response = provider.chat_completions_create(
                     model_name, messages, **kwargs
                 )
             except Exception as exc:
-                self._emit_model_event(
-                    "model.error",
-                    {
-                        "model": model_identifier,
-                        "error": str(exc),
-                        "error_type": type(exc).__name__,
-                    },
-                )
+                self._emit_model_error(exc, model_identifier)
                 raise
-            response = self._extract_thinking_content(response)
-            self._emit_model_event(
-                "model.response",
-                normalize_model_response(response, model=model_identifier),
-            )
+            response = self._handle_model_response(response, model_identifier)
 
-            # Store intermediate response
             intermediate_responses.append(response)
-
-            # Check if there are tool calls in the response
-            tool_calls = (
-                getattr(response.choices[0].message, "tool_calls", None)
-                if hasattr(response, "choices")
-                else None
-            )
-
-            # Store the model's message
+            tool_calls = self._response_tool_calls(response)
             intermediate_messages.append(response.choices[0].message)
 
             if not tool_calls:
-                # Set the intermediate data in the final response
-                response.intermediate_responses = intermediate_responses[
-                    :-1
-                ]  # Exclude final response
-                response.choices[0].intermediate_messages = intermediate_messages
-                response.tool_policy_events = tool_policy_events
-                response.tool_events = tool_events
-                response.tool_events_emitted = self._active_trace_context() is not None
-                return response
+                return self._finalize_runner_response(
+                    response,
+                    intermediate_responses,
+                    intermediate_messages,
+                    tool_policy_events,
+                    tool_events,
+                )
 
-            # Execute tools and get results
             results, tool_messages = tools_instance.execute_tool(
                 tool_calls,
                 tool_policy=tool_policy,
@@ -335,30 +358,89 @@ class Completions:
             )
             tool_policy_events.extend(getattr(tools_instance, "last_policy_events", []))
             tool_events.extend(getattr(tools_instance, "last_tool_events", []))
-
-            # Add tool messages to intermediate messages
             intermediate_messages.extend(tool_messages)
-
-            # Add the assistant's response and tool results to messages
             messages.extend([response.choices[0].message, *tool_messages])
-
             turns += 1
 
-        # Set the intermediate data in the final response
-        response.intermediate_responses = intermediate_responses[
-            :-1
-        ]  # Exclude final response
-        response.choices[0].intermediate_messages = intermediate_messages
-        response.tool_policy_events = tool_policy_events
-        response.tool_events = tool_events
-        response.tool_events_emitted = self._active_trace_context() is not None
-        return response
+        return self._finalize_runner_response(
+            response,
+            intermediate_responses,
+            intermediate_messages,
+            tool_policy_events,
+            tool_events,
+        )
 
-    def create(self, model: str, messages: list, **kwargs):
+    async def _atool_runner(
+        self,
+        provider,
+        model_name: str,
+        model_identifier: str,
+        messages: list,
+        tools: Any,
+        max_turns: int,
+        tool_policy=None,
+        tool_policy_context=None,
+        **kwargs,
+    ):
+        """Async variant of ``_tool_runner``.
+
+        Awaits the provider's async completion and the async tool execution.
+        Event emission, response handling, and bookkeeping are shared with the
+        sync path via helper methods.
         """
-        Create chat completion based on the model, messages, and any extra arguments.
-        Supports automatic tool execution when max_turns is specified.
-        """
+        tools_instance = self._init_tool_runner(tools, kwargs)
+
+        turns = 0
+        intermediate_responses = []
+        intermediate_messages = []
+        tool_policy_events = []
+        tool_events = []
+
+        while turns < max_turns:
+            self._emit_model_send(messages, model_identifier)
+            try:
+                response = await provider.achat_completions_create(
+                    model_name, messages, **kwargs
+                )
+            except Exception as exc:
+                self._emit_model_error(exc, model_identifier)
+                raise
+            response = self._handle_model_response(response, model_identifier)
+
+            intermediate_responses.append(response)
+            tool_calls = self._response_tool_calls(response)
+            intermediate_messages.append(response.choices[0].message)
+
+            if not tool_calls:
+                return self._finalize_runner_response(
+                    response,
+                    intermediate_responses,
+                    intermediate_messages,
+                    tool_policy_events,
+                    tool_events,
+                )
+
+            results, tool_messages = await tools_instance.aexecute_tool(
+                tool_calls,
+                tool_policy=tool_policy,
+                tool_policy_context=tool_policy_context,
+            )
+            tool_policy_events.extend(getattr(tools_instance, "last_policy_events", []))
+            tool_events.extend(getattr(tools_instance, "last_tool_events", []))
+            intermediate_messages.extend(tool_messages)
+            messages.extend([response.choices[0].message, *tool_messages])
+            turns += 1
+
+        return self._finalize_runner_response(
+            response,
+            intermediate_responses,
+            intermediate_messages,
+            tool_policy_events,
+            tool_events,
+        )
+
+    def _resolve_provider(self, model: str):
+        """Validate the model string and return ``(provider, model_name)``."""
         # Check that correct format is used
         if ":" not in model:
             raise ValueError(
@@ -388,6 +470,14 @@ class Completions:
         provider = self.client.providers.get(provider_key)
         if not provider:
             raise ValueError(f"Could not load provider for '{provider_key}'.")
+        return provider, model_name
+
+    def create(self, model: str, messages: list, **kwargs):
+        """
+        Create chat completion based on the model, messages, and any extra arguments.
+        Supports automatic tool execution when max_turns is specified.
+        """
+        provider, model_name = self._resolve_provider(model)
 
         # Extract tool-related parameters
         max_turns = kwargs.pop("max_turns", None)
@@ -435,6 +525,45 @@ class Completions:
 
             # Delegate the chat completion to the correct provider's implementation
             response = provider.chat_completions_create(model_name, messages, **kwargs)
+            return self._extract_thinking_content(response)
+
+    async def acreate(self, model: str, messages: list, **kwargs):
+        """Async variant of ``create``.
+
+        Awaits the provider's async completion and, when ``max_turns`` and
+        ``tools`` are supplied, the async tool-execution loop. MCP client
+        cleanup remains synchronous and is handled by the ExitStack.
+        """
+        provider, model_name = self._resolve_provider(model)
+
+        max_turns = kwargs.pop("max_turns", None)
+        tools = kwargs.pop("tools", None)
+        tool_policy = kwargs.pop("tool_policy", None)
+        tool_policy_context = kwargs.pop("tool_policy_context", None)
+
+        with ExitStack() as stack:
+            mcp_clients = []
+            if tools is not None:
+                tools, mcp_clients = self._process_mcp_configs(tools)
+                for mcp_client in mcp_clients:
+                    stack.enter_context(mcp_client)
+
+            if max_turns is not None and tools is not None:
+                return await self._atool_runner(
+                    provider,
+                    model_name,
+                    model,
+                    messages.copy(),
+                    tools,
+                    max_turns,
+                    tool_policy=tool_policy,
+                    tool_policy_context=tool_policy_context,
+                    **kwargs,
+                )
+
+            response = await provider.achat_completions_create(
+                model_name, messages, **kwargs
+            )
             return self._extract_thinking_content(response)
 
 

--- a/aisuite/provider.py
+++ b/aisuite/provider.py
@@ -1,5 +1,6 @@
 from abc import ABC, abstractmethod
 from pathlib import Path
+import asyncio
 import importlib
 import os
 import functools
@@ -29,6 +30,18 @@ class Provider(ABC):
     def chat_completions_create(self, model, messages):
         """Abstract method for chat completion calls, to be implemented by each provider."""
         pass
+
+    async def achat_completions_create(self, model, messages, **kwargs):
+        """Async chat completion.
+
+        Default implementation offloads the provider's synchronous
+        ``chat_completions_create`` to a worker thread, so every provider is
+        awaitable without per-provider work. Providers with a native async
+        SDK (e.g. OpenAI) should override this for true non-blocking I/O.
+        """
+        return await asyncio.to_thread(
+            lambda: self.chat_completions_create(model, messages, **kwargs)
+        )
 
 
 class ProviderFactory:

--- a/aisuite/providers/openai_provider.py
+++ b/aisuite/providers/openai_provider.py
@@ -30,6 +30,8 @@ class OpenaiProvider(Provider):
 
         # Pass the entire config to the OpenAI client constructor
         self.client = openai.OpenAI(**config)
+        # Async client shares the same config for true non-blocking I/O.
+        self.aclient = openai.AsyncOpenAI(**config)
         self.transformer = OpenAICompliantMessageConverter()
 
         # Initialize audio functionality
@@ -42,6 +44,19 @@ class OpenaiProvider(Provider):
         try:
             transformed_messages = self.transformer.convert_request(messages)
             response = self.client.chat.completions.create(
+                model=model,
+                messages=transformed_messages,
+                **kwargs,  # Pass any additional arguments to the OpenAI API
+            )
+            return response
+        except Exception as e:
+            raise LLMError(f"An error occurred: {e}")
+
+    async def achat_completions_create(self, model, messages, **kwargs):
+        # Native async path via openai.AsyncOpenAI.
+        try:
+            transformed_messages = self.transformer.convert_request(messages)
+            response = await self.aclient.chat.completions.create(
                 model=model,
                 messages=transformed_messages,
                 **kwargs,  # Pass any additional arguments to the OpenAI API

--- a/aisuite/utils/tools.py
+++ b/aisuite/utils/tools.py
@@ -1,5 +1,6 @@
 from typing import Callable, Dict, Any, Type, Optional
 from pydantic import BaseModel, create_model, Field, ValidationError
+import asyncio
 import inspect
 import json
 from docstring_parser import parse
@@ -436,6 +437,182 @@ class Tools:
             "Tool policy must return a bool or ToolPolicyDecision instance."
         )
 
+    def _prepare_tool_call(self, tool_call, tool_policy, tool_policy_context) -> dict:
+        """Parse, validate, evaluate policy, and emit pre-invocation events.
+
+        Returns a context dict shared by the sync and async execution paths. If
+        the call is denied, ``ctx["denied"]`` is True and ``ctx["result"]`` holds
+        the denial result; otherwise the caller invokes ``ctx["tool_func"]`` with
+        ``ctx["args"]``.
+        """
+        # Handle both dictionary and object-style tool calls
+        if isinstance(tool_call, dict):
+            tool_name = tool_call["function"]["name"]
+            arguments = tool_call["function"]["arguments"]
+            tool_call_id = tool_call["id"]
+        else:
+            tool_name = tool_call.function.name
+            arguments = tool_call.function.arguments
+            tool_call_id = tool_call.id
+
+        # Ensure arguments is a dict
+        if isinstance(arguments, str):
+            arguments = json.loads(arguments)
+
+        if tool_name not in self._tools:
+            raise ValueError(f"Tool '{tool_name}' not registered.")
+
+        tool = self._tools[tool_name]
+        tool_func = tool["function"]
+        param_model = tool["param_model"]
+        tool_metadata = tool.get("metadata")
+        tool_metadata_dict = (
+            tool_metadata.to_dict() if tool_metadata is not None else None
+        )
+
+        # Validate and parse the arguments with Pydantic if a model exists
+        try:
+            validated_args = param_model(**arguments)
+        except ValidationError as e:
+            raise ValueError(f"Error in tool '{tool_name}' parameters: {e}")
+        validated_args_dict = validated_args.model_dump()
+        trace_arguments, argument_artifacts = self._artifactized_trace_value(
+            validated_args_dict
+        )
+        decision = self._evaluate_tool_policy(
+            tool_policy,
+            tool_policy_context,
+            tool_name,
+            validated_args_dict,
+            tool_metadata,
+        )
+        if decision is not None:
+            policy_event = {
+                "tool_name": tool_name,
+                "allowed": decision.allowed,
+                "reason": decision.reason,
+                "metadata": decision.metadata,
+            }
+            if tool_metadata_dict is not None:
+                policy_event["tool_metadata"] = tool_metadata_dict
+            self.last_policy_events.append(policy_event)
+
+        ctx = {
+            "tool_name": tool_name,
+            "tool_call_id": tool_call_id,
+            "tool_func": tool_func,
+            "args": validated_args_dict,
+            "tool_metadata_dict": tool_metadata_dict,
+            "denied": False,
+            "result": None,
+        }
+
+        if decision is not None and not decision.allowed:
+            tool_event = {
+                "type": "tool_call",
+                "tool_name": tool_name,
+                "tool_call_id": tool_call_id,
+                "arguments": trace_arguments,
+                "allowed": False,
+                "reason": decision.reason,
+                "metadata": decision.metadata,
+            }
+            if argument_artifacts:
+                tool_event["argument_artifacts"] = argument_artifacts
+            if tool_metadata_dict is not None:
+                tool_event["tool_metadata"] = tool_metadata_dict
+            self.last_tool_events.append(tool_event)
+            self._emit_tool_trace_event("tool.denied", tool_event)
+            ctx["denied"] = True
+            ctx["result"] = {
+                "error": "Tool call denied by policy",
+                "reason": decision.reason,
+            }
+            return ctx
+
+        tool_event = {
+            "type": "tool_call",
+            "tool_name": tool_name,
+            "tool_call_id": tool_call_id,
+            "arguments": trace_arguments,
+            "allowed": True,
+            "reason": decision.reason if decision else None,
+            "metadata": decision.metadata if decision else {},
+        }
+        if argument_artifacts:
+            tool_event["argument_artifacts"] = argument_artifacts
+        if tool_metadata_dict is not None:
+            tool_event["tool_metadata"] = tool_metadata_dict
+        self.last_tool_events.append(tool_event)
+        self._emit_tool_trace_event("tool.allowed", tool_event)
+        self._emit_tool_trace_event("tool.started", tool_event)
+        return ctx
+
+    def _record_tool_failure(self, ctx: dict, exc: Exception) -> None:
+        failed_event = {
+            "type": "tool_result",
+            "tool_name": ctx["tool_name"],
+            "tool_call_id": ctx["tool_call_id"],
+            "status": "failed",
+            "error": str(exc),
+            "error_type": type(exc).__name__,
+        }
+        if ctx["tool_metadata_dict"] is not None:
+            failed_event["tool_metadata"] = ctx["tool_metadata_dict"]
+        self.last_tool_events.append(failed_event)
+        self._emit_tool_trace_event("tool.failed", failed_event)
+
+    def _invoke_tool_sync(self, ctx: dict):
+        try:
+            return ctx["tool_func"](**ctx["args"])
+        except Exception as exc:
+            self._record_tool_failure(ctx, exc)
+            raise
+
+    async def _invoke_tool_async(self, ctx: dict):
+        tool_func = ctx["tool_func"]
+        try:
+            if inspect.iscoroutinefunction(tool_func):
+                return await tool_func(**ctx["args"])
+            # Run blocking sync tools off the event loop.
+            return await asyncio.to_thread(lambda: tool_func(**ctx["args"]))
+        except Exception as exc:
+            self._record_tool_failure(ctx, exc)
+            raise
+
+    def _finalize_tool_call(
+        self, ctx: dict, result, results: list, messages: list
+    ) -> None:
+        if not ctx["denied"]:
+            result_event = {
+                "type": "tool_result",
+                "tool_name": ctx["tool_name"],
+                "tool_call_id": ctx["tool_call_id"],
+                "status": "success",
+                "result_preview": _preview_tool_result(result),
+            }
+            artifactized_result, result_artifacts = self._artifactized_trace_value(
+                result
+            )
+            if result_artifacts:
+                result_event["result_artifacts"] = result_artifacts
+                result_event["result_preview"] = _preview_tool_result(
+                    artifactized_result
+                )
+            if ctx["tool_metadata_dict"] is not None:
+                result_event["tool_metadata"] = ctx["tool_metadata_dict"]
+            self.last_tool_events.append(result_event)
+            self._emit_tool_trace_event("tool.completed", result_event)
+        results.append(result)
+        messages.append(
+            {
+                "role": "tool",
+                "name": ctx["tool_name"],
+                "content": json.dumps(result),
+                "tool_call_id": ctx["tool_call_id"],
+            }
+        )
+
     def execute_tool(
         self, tool_calls, tool_policy=None, tool_policy_context=None
     ) -> tuple[list, list]:
@@ -457,137 +634,34 @@ class Tools:
             tool_calls = [tool_calls]
 
         for tool_call in tool_calls:
-            # Handle both dictionary and object-style tool calls
-            if isinstance(tool_call, dict):
-                tool_name = tool_call["function"]["name"]
-                arguments = tool_call["function"]["arguments"]
-                tool_call_id = tool_call["id"]
-            else:
-                tool_name = tool_call.function.name
-                arguments = tool_call.function.arguments
-                tool_call_id = tool_call.id
+            ctx = self._prepare_tool_call(tool_call, tool_policy, tool_policy_context)
+            result = ctx["result"] if ctx["denied"] else self._invoke_tool_sync(ctx)
+            self._finalize_tool_call(ctx, result, results, messages)
 
-            # Ensure arguments is a dict
-            if isinstance(arguments, str):
-                arguments = json.loads(arguments)
+        return results, messages
 
-            if tool_name not in self._tools:
-                raise ValueError(f"Tool '{tool_name}' not registered.")
+    async def aexecute_tool(
+        self, tool_calls, tool_policy=None, tool_policy_context=None
+    ) -> tuple[list, list]:
+        """Async variant of ``execute_tool``.
 
-            tool = self._tools[tool_name]
-            tool_func = tool["function"]
-            param_model = tool["param_model"]
-            tool_metadata = tool.get("metadata")
-            tool_metadata_dict = (
-                tool_metadata.to_dict() if tool_metadata is not None else None
+        Awaits ``async def`` tool callables and runs blocking sync tools in a
+        worker thread. Policy evaluation, validation, event recording, and
+        message building are shared with the sync path.
+        """
+        results = []
+        messages = []
+        self.last_policy_events = []
+        self.last_tool_events = []
+
+        if not isinstance(tool_calls, list):
+            tool_calls = [tool_calls]
+
+        for tool_call in tool_calls:
+            ctx = self._prepare_tool_call(tool_call, tool_policy, tool_policy_context)
+            result = (
+                ctx["result"] if ctx["denied"] else await self._invoke_tool_async(ctx)
             )
-
-            # Validate and parse the arguments with Pydantic if a model exists
-            try:
-                validated_args = param_model(**arguments)
-                validated_args_dict = validated_args.model_dump()
-                trace_arguments, argument_artifacts = self._artifactized_trace_value(
-                    validated_args_dict
-                )
-                decision = self._evaluate_tool_policy(
-                    tool_policy,
-                    tool_policy_context,
-                    tool_name,
-                    validated_args_dict,
-                    tool_metadata,
-                )
-                if decision is not None:
-                    policy_event = {
-                        "tool_name": tool_name,
-                        "allowed": decision.allowed,
-                        "reason": decision.reason,
-                        "metadata": decision.metadata,
-                    }
-                    if tool_metadata_dict is not None:
-                        policy_event["tool_metadata"] = tool_metadata_dict
-                    self.last_policy_events.append(policy_event)
-                if decision is not None and not decision.allowed:
-                    tool_event = {
-                        "type": "tool_call",
-                        "tool_name": tool_name,
-                        "tool_call_id": tool_call_id,
-                        "arguments": trace_arguments,
-                        "allowed": False,
-                        "reason": decision.reason,
-                        "metadata": decision.metadata,
-                    }
-                    if argument_artifacts:
-                        tool_event["argument_artifacts"] = argument_artifacts
-                    if tool_metadata_dict is not None:
-                        tool_event["tool_metadata"] = tool_metadata_dict
-                    self.last_tool_events.append(tool_event)
-                    self._emit_tool_trace_event("tool.denied", tool_event)
-                    result = {
-                        "error": "Tool call denied by policy",
-                        "reason": decision.reason,
-                    }
-                else:
-                    tool_event = {
-                        "type": "tool_call",
-                        "tool_name": tool_name,
-                        "tool_call_id": tool_call_id,
-                        "arguments": trace_arguments,
-                        "allowed": True,
-                        "reason": decision.reason if decision else None,
-                        "metadata": decision.metadata if decision else {},
-                    }
-                    if argument_artifacts:
-                        tool_event["argument_artifacts"] = argument_artifacts
-                    if tool_metadata_dict is not None:
-                        tool_event["tool_metadata"] = tool_metadata_dict
-                    self.last_tool_events.append(tool_event)
-                    self._emit_tool_trace_event("tool.allowed", tool_event)
-                    self._emit_tool_trace_event("tool.started", tool_event)
-                    try:
-                        result = tool_func(**validated_args_dict)
-                    except Exception as exc:
-                        failed_event = {
-                            "type": "tool_result",
-                            "tool_name": tool_name,
-                            "tool_call_id": tool_call_id,
-                            "status": "failed",
-                            "error": str(exc),
-                            "error_type": type(exc).__name__,
-                        }
-                        if tool_metadata_dict is not None:
-                            failed_event["tool_metadata"] = tool_metadata_dict
-                        self.last_tool_events.append(failed_event)
-                        self._emit_tool_trace_event("tool.failed", failed_event)
-                        raise
-                    result_event = {
-                        "type": "tool_result",
-                        "tool_name": tool_name,
-                        "tool_call_id": tool_call_id,
-                        "status": "success",
-                        "result_preview": _preview_tool_result(result),
-                    }
-                    artifactized_result, result_artifacts = (
-                        self._artifactized_trace_value(result)
-                    )
-                    if result_artifacts:
-                        result_event["result_artifacts"] = result_artifacts
-                        result_event["result_preview"] = _preview_tool_result(
-                            artifactized_result
-                        )
-                    if tool_metadata_dict is not None:
-                        result_event["tool_metadata"] = tool_metadata_dict
-                    self.last_tool_events.append(result_event)
-                    self._emit_tool_trace_event("tool.completed", result_event)
-                results.append(result)
-                messages.append(
-                    {
-                        "role": "tool",
-                        "name": tool_name,
-                        "content": json.dumps(result),
-                        "tool_call_id": tool_call_id,
-                    }
-                )
-            except ValidationError as e:
-                raise ValueError(f"Error in tool '{tool_name}' parameters: {e}")
+            self._finalize_tool_call(ctx, result, results, messages)
 
         return results, messages

--- a/tests/agents/test_async_runner.py
+++ b/tests/agents/test_async_runner.py
@@ -1,0 +1,85 @@
+"""Tests for the async Runner (Runner.run / continue_run) and sync wrappers."""
+
+import asyncio
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+
+from aisuite import Agent, Client, Runner
+from tests.agents.helpers import chat_response
+
+
+@pytest.mark.asyncio
+async def test_run_drives_async_client():
+    client = Client()
+    client.chat.completions.acreate = AsyncMock(return_value=chat_response("hello"))
+    agent = Agent(name="assistant", model="openai:gpt-4o")
+
+    result = await Runner.run(agent, "Say hi", client=client)
+
+    assert result.final_output == "hello"
+    assert result.status == "completed"
+    client.chat.completions.acreate.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_run_matches_run_sync_output():
+    """Async run and sync run produce equivalent results for the same input."""
+    sync_client = Client()
+    sync_client.chat.completions.create = Mock(return_value=chat_response("hi"))
+    async_client = Client()
+    async_client.chat.completions.acreate = AsyncMock(return_value=chat_response("hi"))
+    agent = Agent(name="assistant", model="openai:gpt-4o")
+
+    sync_result = Runner.run_sync(agent, "hey", client=sync_client)
+    async_result = await Runner.run(agent, "hey", client=async_client)
+
+    assert async_result.final_output == sync_result.final_output
+    assert async_result.messages == sync_result.messages
+
+
+@pytest.mark.asyncio
+async def test_concurrent_runs_overlap():
+    """Multiple Runner.run calls can be gathered and run concurrently."""
+    client = Client()
+
+    async def fake_acreate(*, model, messages, **kwargs):
+        await asyncio.sleep(0.05)
+        return chat_response(f"reply-{messages[-1]['content']}")
+
+    client.chat.completions.acreate = fake_acreate
+    agent = Agent(name="a", model="openai:gpt-4o")
+
+    results = await asyncio.gather(
+        *[Runner.run(agent, f"q{i}", client=client) for i in range(5)]
+    )
+
+    assert [r.final_output for r in results] == [f"reply-q{i}" for i in range(5)]
+
+
+@pytest.mark.asyncio
+async def test_run_sync_works_inside_running_loop():
+    """run_sync must still work when called from within an active event loop."""
+    client = Client()
+    client.chat.completions.create = Mock(return_value=chat_response("hi"))
+    agent = Agent(name="a", model="openai:gpt-4o")
+
+    # We are inside the pytest-asyncio loop here; the nest_asyncio fallback runs.
+    result = Runner.run_sync(agent, "hello", client=client)
+
+    assert result.final_output == "hi"
+
+
+@pytest.mark.asyncio
+async def test_continue_run_async():
+    client = Client()
+    client.chat.completions.acreate = AsyncMock(
+        side_effect=[chat_response("first"), chat_response("second")]
+    )
+    agent = Agent(name="assistant", model="openai:gpt-4o")
+
+    first = await Runner.run(agent, "one", client=client)
+    second = await Runner.continue_run(first, "two")
+
+    assert first.final_output == "first"
+    assert second.final_output == "second"

--- a/tests/client/test_async_client.py
+++ b/tests/client/test_async_client.py
@@ -1,0 +1,97 @@
+"""Tests for the async client path (Completions.acreate)."""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, Mock, patch
+
+import pytest
+
+from aisuite import Client
+from aisuite.framework.message import ChatCompletionMessageToolCall, Function, Message
+
+
+def _chat_response(content=None, tool_calls=None):
+    message = Message(role="assistant", content=content, tool_calls=tool_calls)
+    return SimpleNamespace(choices=[SimpleNamespace(message=message)])
+
+
+def _tool_call(name, arguments, call_id="call_1"):
+    return ChatCompletionMessageToolCall(
+        id=call_id, type="function", function=Function(name=name, arguments=arguments)
+    )
+
+
+@pytest.mark.asyncio
+@patch("aisuite.provider.ProviderFactory.create_provider")
+async def test_acreate_runs_full_tool_loop(mock_create_provider):
+    provider = Mock()
+    provider.achat_completions_create = AsyncMock(
+        side_effect=[
+            _chat_response(
+                tool_calls=[_tool_call("get_weather", '{"location": "San Francisco"}')]
+            ),
+            _chat_response(content="It is sunny in San Francisco."),
+        ]
+    )
+    mock_create_provider.return_value = provider
+
+    def get_weather(location: str):
+        """Get the weather for a location."""
+        return {"location": location, "condition": "sunny"}
+
+    client = Client()
+    response = await client.chat.completions.acreate(
+        model="openai:gpt-4o",
+        messages=[{"role": "user", "content": "What is the weather?"}],
+        tools=[get_weather],
+        max_turns=2,
+    )
+
+    assert response.choices[0].message.content == "It is sunny in San Francisco."
+    assert provider.achat_completions_create.await_count == 2
+
+
+@pytest.mark.asyncio
+@patch("aisuite.provider.ProviderFactory.create_provider")
+async def test_acreate_without_tools(mock_create_provider):
+    provider = Mock()
+    provider.achat_completions_create = AsyncMock(
+        return_value=_chat_response(content="hello")
+    )
+    mock_create_provider.return_value = provider
+
+    client = Client()
+    response = await client.chat.completions.acreate(
+        model="openai:gpt-4o",
+        messages=[{"role": "user", "content": "hi"}],
+    )
+
+    assert response.choices[0].message.content == "hello"
+    provider.achat_completions_create.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+@patch("aisuite.provider.ProviderFactory.create_provider")
+async def test_acreate_awaits_async_tool(mock_create_provider):
+    """An async def tool is awaited inside the async tool loop."""
+    provider = Mock()
+    provider.achat_completions_create = AsyncMock(
+        side_effect=[
+            _chat_response(tool_calls=[_tool_call("lookup", '{"q": "x"}')]),
+            _chat_response(content="done"),
+        ]
+    )
+    mock_create_provider.return_value = provider
+
+    async def lookup(q: str):
+        """An async tool."""
+        return {"q": q, "value": 42}
+
+    client = Client()
+    response = await client.chat.completions.acreate(
+        model="openai:gpt-4o",
+        messages=[{"role": "user", "content": "look it up"}],
+        tools=[lookup],
+        max_turns=3,
+    )
+
+    assert response.choices[0].message.content == "done"

--- a/tests/client/test_async_client.py
+++ b/tests/client/test_async_client.py
@@ -71,6 +71,41 @@ async def test_acreate_without_tools(mock_create_provider):
 
 @pytest.mark.asyncio
 @patch("aisuite.provider.ProviderFactory.create_provider")
+async def test_acreate_manual_tool_calling_passes_tools(mock_create_provider):
+    """Manual mode (no max_turns): the provider must receive the tool schemas.
+
+    Async twin of the #266 regression: tools are popped from kwargs, so the
+    manual path must re-add provider-ready specs before delegating.
+    """
+    provider = Mock()
+    provider.achat_completions_create = AsyncMock(
+        return_value=_chat_response(content="ok")
+    )
+    mock_create_provider.return_value = provider
+
+    def get_weather(location: str):
+        """Get the weather for a location."""
+        return {"location": location}
+
+    schema = {
+        "type": "function",
+        "function": {"name": "manual_tool", "parameters": {"type": "object", "properties": {}}},
+    }
+
+    client = Client()
+    await client.chat.completions.acreate(
+        model="openai:gpt-4o",
+        messages=[{"role": "user", "content": "hi"}],
+        tools=[schema, get_weather],  # no max_turns → manual mode
+    )
+
+    sent = provider.achat_completions_create.await_args.kwargs["tools"]
+    assert sent[0] == schema  # dicts pass through untouched
+    assert sent[1]["function"]["name"] == "get_weather"  # callables become specs
+
+
+@pytest.mark.asyncio
+@patch("aisuite.provider.ProviderFactory.create_provider")
 async def test_acreate_awaits_async_tool(mock_create_provider):
     """An async def tool is awaited inside the async tool loop."""
     provider = Mock()

--- a/tests/client/test_async_client.py
+++ b/tests/client/test_async_client.py
@@ -89,7 +89,10 @@ async def test_acreate_manual_tool_calling_passes_tools(mock_create_provider):
 
     schema = {
         "type": "function",
-        "function": {"name": "manual_tool", "parameters": {"type": "object", "properties": {}}},
+        "function": {
+            "name": "manual_tool",
+            "parameters": {"type": "object", "properties": {}},
+        },
     }
 
     client = Client()

--- a/tests/providers/test_async_provider.py
+++ b/tests/providers/test_async_provider.py
@@ -1,0 +1,53 @@
+"""Tests for the async provider contract (achat_completions_create)."""
+
+import threading
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from aisuite.provider import Provider
+from aisuite.providers.openai_provider import OpenaiProvider
+
+
+class _SyncOnlyProvider(Provider):
+    """A provider that only implements the sync method (no native async)."""
+
+    def __init__(self):
+        super().__init__()
+        self.called_on_thread = None
+
+    def chat_completions_create(self, model, messages, **kwargs):
+        self.called_on_thread = threading.current_thread().name
+        return SimpleNamespace(model=model, messages=messages, kwargs=kwargs)
+
+
+@pytest.mark.asyncio
+async def test_default_async_offloads_sync_to_thread():
+    """The base achat_completions_create runs the sync method off the loop."""
+    provider = _SyncOnlyProvider()
+    result = await provider.achat_completions_create(
+        "m", [{"role": "user", "content": "hi"}], temperature=0.5
+    )
+    assert result.model == "m"
+    assert result.kwargs == {"temperature": 0.5}
+    # It ran in a worker thread, not the event loop's main thread.
+    assert provider.called_on_thread != threading.main_thread().name
+
+
+@pytest.mark.asyncio
+async def test_openai_native_async(monkeypatch):
+    """OpenAI overrides with a native AsyncOpenAI-backed implementation."""
+    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+    provider = OpenaiProvider()
+
+    mock_response = SimpleNamespace(
+        choices=[SimpleNamespace(message=SimpleNamespace(content="async hi"))]
+    )
+    provider.aclient.chat.completions.create = AsyncMock(return_value=mock_response)
+
+    response = await provider.achat_completions_create(
+        "gpt-4o", [{"role": "user", "content": "hi"}]
+    )
+    assert response.choices[0].message.content == "async hi"
+    provider.aclient.chat.completions.create.assert_awaited_once()

--- a/tests/utils/test_async_tools.py
+++ b/tests/utils/test_async_tools.py
@@ -1,0 +1,83 @@
+"""Tests for async tool execution (Tools.aexecute_tool)."""
+
+import asyncio
+import json
+import threading
+
+import pytest
+
+from aisuite.utils.tools import Tools
+
+
+def _tool_call(name, arguments, call_id="call_1"):
+    return {"id": call_id, "function": {"name": name, "arguments": arguments}}
+
+
+@pytest.mark.asyncio
+async def test_aexecute_awaits_async_tool():
+    """An async def tool is awaited and its result captured."""
+
+    async def fetch(city: str):
+        """Fetch the weather for a city."""
+        await asyncio.sleep(0)
+        return {"city": city, "weather": "sunny"}
+
+    tools = Tools([fetch])
+    results, messages = await tools.aexecute_tool(_tool_call("fetch", {"city": "SF"}))
+
+    assert results[0] == {"city": "SF", "weather": "sunny"}
+    assert messages[0]["role"] == "tool"
+    assert json.loads(messages[0]["content"]) == {"city": "SF", "weather": "sunny"}
+    assert messages[0]["tool_call_id"] == "call_1"
+
+
+@pytest.mark.asyncio
+async def test_aexecute_runs_sync_tool_off_the_loop():
+    """A blocking sync tool runs in a worker thread, not the event loop."""
+    seen = {}
+
+    def blocking(city: str):
+        """A synchronous tool."""
+        seen["thread"] = threading.current_thread().name
+        return {"city": city}
+
+    tools = Tools([blocking])
+    results, _ = await tools.aexecute_tool(_tool_call("blocking", {"city": "SF"}))
+
+    assert results[0] == {"city": "SF"}
+    assert seen["thread"] != threading.main_thread().name
+
+
+@pytest.mark.asyncio
+async def test_aexecute_respects_deny_policy():
+    """Policy denial short-circuits before the tool runs, same as sync."""
+    ran = {"value": False}
+
+    async def secret(key: str):
+        """A tool that should never run when denied."""
+        ran["value"] = True
+        return {"key": key}
+
+    tools = Tools([secret])
+    results, messages = await tools.aexecute_tool(
+        _tool_call("secret", {"key": "token"}),
+        tool_policy=lambda context: False,
+    )
+
+    assert ran["value"] is False
+    assert results[0]["error"] == "Tool call denied by policy"
+    # The pre-invocation events record the denial.
+    assert any(e.get("allowed") is False for e in tools.last_tool_events)
+
+
+def test_sync_execute_tool_still_works():
+    """The sync path is unchanged after the refactor."""
+
+    def add(a: int, b: int):
+        """Add two numbers."""
+        return a + b
+
+    tools = Tools([add])
+    results, messages = tools.execute_tool(_tool_call("add", {"a": 2, "b": 3}))
+    assert results[0] == 5
+    assert messages[0]["tool_call_id"] == "call_1"


### PR DESCRIPTION
Makes the core path genuinely async (`provider → client → tools → Runner`) so agent workloads can actually overlap I/O. Design: async-core with a single tool loop — `run`/`run_sync` both funnel into one `_run_impl`, so there's one source of truth rather than two divergent code paths.

Every provider gets `achat_completions_create` via a thread-executor default (`asyncio.to_thread`), so all existing providers are immediately awaitable; `OpenaiProvider` overrides natively via `openai.AsyncOpenAI`. `Tools.aexecute_tool` awaits `async def` tools and offloads sync ones; policy, validation, and event-recording are shared helpers used by both sync and async paths. `Completions.acreate` drives the async tool loop. `Runner.run`/`continue_run` are now `async`; `run_sync`/`continue_sync` are thin wrappers with a `nest_asyncio` fallback for notebook contexts. Concurrent runs are now gatherable.

Follow-ups: parallel tool-call fan-out within a single turn; native async for non-OpenAI providers (currently thread-executor, which is correct but not zero-overhead).