### PR TITLE
Release CI: build dmg and msi/nsis installers

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,127 @@
+# Desktop release builds — macOS (.dmg, arm64 + Intel) and Windows (.msi + NSIS .exe).
+#
+# CI calls the SAME scripts developers run locally (platform/packaging/build_dmg.sh and
+# build_windows.ps1); this file only provisions the toolchain (Node, Rust, a Python venv at
+# platform/.venv with PyInstaller) and publishes the results.
+#
+# Triggers:
+#   - tag push `v*`  → builds all targets and attaches them to a DRAFT GitHub Release
+#                      (review, then publish by hand).
+#   - manual run     → builds and uploads workflow artifacts only (no release).
+#
+# Each installer is uploaded twice: once with its versioned name (archive) and once with a
+# stable name (OpenCoworker-macos-arm64.dmg, …) so the website can link to
+#   github.com/<repo>/releases/latest/download/<stable-name>
+# and never need updating.
+#
+# Builds are UNSIGNED for now (macOS: right-click → Open past Gatekeeper; Windows:
+# SmartScreen "More info" → "Run anyway"). When signing lands, add the cert secrets and a
+# signing step here — the build scripts won't change.
+
+name: Release
+
+on:
+  push:
+    tags: ["v*"]
+  workflow_dispatch:
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: macos-latest # Apple Silicon
+            slug: macos-arm64
+          - os: macos-13 # last Intel runner image
+            slug: macos-intel
+          - os: windows-latest
+            slug: windows
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: platform/surfaces/gui/package-lock.json
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: platform/surfaces/gui/src-tauri
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Set up the sidecar venv (platform/.venv)
+        # The build scripts expect a venv at platform/.venv with the package + PyInstaller.
+        # typer/tzdata are build-time-only (PyInstaller walks mcp.cli, which needs typer;
+        # tzdata ships zoneinfo for Windows). The .pth puts the repo-root `aisuite` package
+        # on the venv's path (it isn't pip-installed — same as local dev).
+        run: |
+          python -m venv platform/.venv
+          if [ "$RUNNER_OS" = "Windows" ]; then VPY=platform/.venv/Scripts/python; else VPY=platform/.venv/bin/python; fi
+          "$VPY" -m pip install --upgrade pip
+          "$VPY" -m pip install -e platform pyinstaller typer tzdata
+          "$VPY" -c "import sysconfig, pathlib; pathlib.Path(sysconfig.get_paths()['purelib'], 'aisuite-repo.pth').write_text(str(pathlib.Path('.').resolve()))"
+          "$VPY" -c "import aisuite, coworker"  # fail fast if either import breaks
+
+      - name: npm ci
+        working-directory: platform/surfaces/gui
+        run: npm ci
+
+      - name: Build .dmg (macOS)
+        if: runner.os == 'macOS'
+        run: bash platform/packaging/build_dmg.sh
+
+      - name: Build .msi + NSIS .exe (Windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: ./platform/packaging/build_windows.ps1
+
+      - name: Stage artifacts (versioned + stable names)
+        run: |
+          mkdir -p out
+          BUNDLE=platform/surfaces/gui/src-tauri/target/release/bundle
+          if [ "$RUNNER_OS" = "Windows" ]; then
+            cp "$BUNDLE"/nsis/*.exe out/
+            cp "$BUNDLE"/nsis/*.exe out/OpenCoworker-windows-setup.exe
+            cp "$BUNDLE"/msi/*.msi out/
+            cp "$BUNDLE"/msi/*.msi out/OpenCoworker-windows.msi
+          else
+            cp "$BUNDLE"/dmg/*.dmg out/
+            cp "$BUNDLE"/dmg/*.dmg out/OpenCoworker-${{ matrix.slug }}.dmg
+          fi
+          ls -la out
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.slug }}
+          path: out/*
+          if-no-files-found: error
+
+  release:
+    if: startsWith(github.ref, 'refs/tags/v')
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          path: dist
+          merge-multiple: true
+
+      - uses: softprops/action-gh-release@v2
+        with:
+          draft: true
+          files: dist/*
+          generate_release_notes: true

--- a/platform/packaging/build_dmg.sh
+++ b/platform/packaging/build_dmg.sh
@@ -3,7 +3,7 @@
 #
 #   1. PyInstaller-bundle the server into a standalone binary (no venv needed at runtime).
 #   2. Drop it into Tauri's externalBin slot (binaries/coworker-server-<triple>).
-#   3. `tauri build --bundles app` → Coworker.app (the externalBin is copied in).
+#   3. `tauri build --bundles app` → OpenCoworker.app (the externalBin is copied in).
 #   4. Wrap the .app in a compressed .dmg via hdiutil (reliable + headless; Tauri's own
 #      bundle_dmg.sh uses Finder AppleScript and fails in non-interactive sessions).
 #
@@ -14,7 +14,9 @@ set -euo pipefail
 HERE="$(cd "$(dirname "$0")" && pwd)"
 PLATFORM="$(cd "$HERE/.." && pwd)"
 GUI="$PLATFORM/surfaces/gui"
-VERSION="0.1.0"
+APP="OpenCoworker"
+# Single source of truth for the version: tauri.conf.json (also stamps the bundle).
+VERSION="$(node -p "require('$GUI/src-tauri/tauri.conf.json').version")"
 TRIPLE="$(rustc -vV | sed -n 's/host: //p')"   # e.g. aarch64-apple-darwin
 ARCH="${TRIPLE%%-*}"
 
@@ -33,12 +35,12 @@ echo "==> [3/4] tauri build (.app)"
 echo "==> [4/4] hdiutil: wrapping into .dmg"
 BUNDLE="$GUI/src-tauri/target/release/bundle"
 STAGING="$(mktemp -d)"
-cp -R "$BUNDLE/macos/Coworker.app" "$STAGING/"
+cp -R "$BUNDLE/macos/$APP.app" "$STAGING/"
 ln -s /Applications "$STAGING/Applications"
-DMG="$BUNDLE/dmg/Coworker_${VERSION}_${ARCH}.dmg"
+DMG="$BUNDLE/dmg/${APP}_${VERSION}_${ARCH}.dmg"
 mkdir -p "$(dirname "$DMG")"
 rm -f "$DMG"
-hdiutil create -volname "Coworker" -srcfolder "$STAGING" -ov -format UDZO "$DMG"
+hdiutil create -volname "$APP" -srcfolder "$STAGING" -ov -format UDZO "$DMG"
 rm -rf "$STAGING"
 
 echo ""

--- a/platform/surfaces/gui/index.html
+++ b/platform/surfaces/gui/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>OpenWork</title>
+    <title>OpenCoworker</title>
     <!-- Resolve the theme before first paint (no white flash for dark users).
          Must match src/theme.ts: key "openwork-theme", absent/invalid = auto = follow macOS. -->
     <script>

--- a/platform/surfaces/gui/src-tauri/Cargo.toml
+++ b/platform/surfaces/gui/src-tauri/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "coworker-desktop"
 version = "0.1.0"
-description = "Coworker desktop shell"
+description = "OpenCoworker desktop shell"
 edition = "2021"
 rust-version = "1.77"
 

--- a/platform/surfaces/gui/src-tauri/src/lib.rs
+++ b/platform/surfaces/gui/src-tauri/src/lib.rs
@@ -1,4 +1,4 @@
-//! Coworker desktop shell.
+//! OpenCoworker desktop shell.
 //!
 //! Tauri is a thin native window over the existing React SPA. It:
 //!   1. picks a free localhost port and starts the Python `coworker-server` as a managed
@@ -324,7 +324,7 @@ pub fn run() {
             //    Overlay title bar (macOS): traffic lights float over the edge-to-edge UI.
             let mut builder =
                 WebviewWindowBuilder::new(app, "main", WebviewUrl::App("index.html".into()))
-                    .title("Open Coworker")
+                    .title("OpenCoworker")
                     .inner_size(1360.0, 900.0)
                     .min_inner_size(980.0, 640.0)
                     .initialization_script(&inject);
@@ -346,7 +346,7 @@ pub fn run() {
             });
 
             // 3. System tray: Open / Settings / Quit.
-            let open_i = MenuItem::with_id(app, "open", "Open Coworker", true, None::<&str>)?;
+            let open_i = MenuItem::with_id(app, "open", "Open OpenCoworker", true, None::<&str>)?;
             let settings_i = MenuItem::with_id(app, "settings", "Settings", true, None::<&str>)?;
             let quit_i = MenuItem::with_id(app, "quit", "Quit", true, None::<&str>)?;
             let menu = Menu::with_items(app, &[&open_i, &settings_i, &quit_i])?;
@@ -355,7 +355,7 @@ pub fn run() {
             // it for light/dark automatically — not the full-color app icon.
             let tray_icon = tauri::image::Image::new(include_bytes!("../icons/tray.rgba"), 44, 44);
             TrayIconBuilder::new()
-                .tooltip("Coworker")
+                .tooltip("OpenCoworker")
                 .icon(tray_icon)
                 .icon_as_template(true)
                 .menu(&menu)
@@ -377,7 +377,7 @@ pub fn run() {
             Ok(())
         })
         .build(tauri::generate_context!())
-        .expect("error while building the Coworker desktop app")
+        .expect("error while building the OpenCoworker desktop app")
         .run(|app, event| {
             if let RunEvent::ExitRequested { .. } = event {
                 if let Some(state) = app.try_state::<ServerProcess>() {

--- a/platform/surfaces/gui/src-tauri/tauri.conf.json
+++ b/platform/surfaces/gui/src-tauri/tauri.conf.json
@@ -1,8 +1,8 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
-  "productName": "Coworker",
+  "productName": "OpenCoworker",
   "version": "0.1.0",
-  "identifier": "ai.coworker.desktop",
+  "identifier": "app.opencoworker.desktop",
   "build": {
     "frontendDist": "../dist",
     "devUrl": "http://localhost:1420",
@@ -19,7 +19,7 @@
   "bundle": {
     "active": true,
     "targets": "all",
-    "publisher": "Coworker",
+    "publisher": "OpenCoworker",
     "icon": [
       "icons/32x32.png",
       "icons/128x128.png",

--- a/platform/surfaces/gui/src/App.tsx
+++ b/platform/surfaces/gui/src/App.tsx
@@ -619,7 +619,7 @@ export function App() {
         {desktop && (
           <div className="titlebar-drag" data-tauri-drag-region>
             <span className="titlebar-brand">
-              <Icon name="sparkle" size={13} className="mark" /> Open Coworker
+              <Icon name="sparkle" size={13} className="mark" /> OpenCoworker
             </span>
           </div>
         )}

--- a/platform/surfaces/gui/src/components/ManageModal.tsx
+++ b/platform/surfaces/gui/src/components/ManageModal.tsx
@@ -247,7 +247,7 @@ function ModelsTab() {
         </>
       ) : (
         <div className="conn-meta dim" style={{ marginBottom: 12 }}>
-          Run models locally with <code>ollama serve</code>. Coworker uses Ollama's
+          Run models locally with <code>ollama serve</code>. OpenCoworker uses Ollama's
           OpenAI-compatible API, so tools work. No API key needed.
         </div>
       )}
@@ -475,7 +475,7 @@ function SettingsTab() {
             <input type="checkbox" checked={autostart} onChange={(e) => toggleAuto(e.target.checked)} />
             <span>
               <strong>Open at login</strong>
-              <small>Launch Coworker automatically when you sign in.</small>
+              <small>Launch OpenCoworker automatically when you sign in.</small>
             </span>
           </label>
           <label className="ob-toggle">

--- a/platform/surfaces/gui/src/components/Onboarding.tsx
+++ b/platform/surfaces/gui/src/components/Onboarding.tsx
@@ -160,7 +160,7 @@ export function Onboarding({ onDone }: { onDone: () => void }) {
           {step === 0 && (
             <div className="ob-step">
               <div className="ob-mark">✳</div>
-              <h2>Welcome to Coworker</h2>
+              <h2>Welcome to OpenCoworker</h2>
               <p className="ob-sub">
                 A quick setup: choose where your files are saved, then connect a model — an API
                 key or a local Ollama model. Takes about a minute.
@@ -353,14 +353,14 @@ export function Onboarding({ onDone }: { onDone: () => void }) {
             <div className="ob-step">
               <h2>Staying on</h2>
               <p className="ob-sub">
-                Scheduled automations only run while Coworker is running.
+                Scheduled automations only run while OpenCoworker is running.
                 {!isTauri() && " (Desktop app only.)"}
               </p>
               <label className={"ob-toggle" + (isTauri() ? "" : " disabled")}>
                 <input type="checkbox" checked={autostart} disabled={!isTauri()} onChange={(e) => toggleAuto(e.target.checked)} />
                 <span>
                   <strong>Open at login</strong>
-                  <small>Launch Coworker automatically when you sign in.</small>
+                  <small>Launch OpenCoworker automatically when you sign in.</small>
                 </span>
               </label>
               <label className={"ob-toggle" + (isTauri() ? "" : " disabled")}>

--- a/platform/surfaces/gui/src/components/Sidebar.tsx
+++ b/platform/surfaces/gui/src/components/Sidebar.tsx
@@ -6,7 +6,7 @@ import { Icon } from "./Icon";
 // Session surfaces shown as accordions, in display order. Cowork is always visible; Chat/Code
 // are toggled via Settings. Each has a colored icon square.
 const SURFACES: { key: string; label: string; icon: "diamond" | "chat" | "code"; cls: string }[] = [
-  { key: "cowork", label: "Coworker", icon: "diamond", cls: "ico-cowork" },
+  { key: "cowork", label: "Cowork", icon: "diamond", cls: "ico-cowork" },
   { key: "chat", label: "Chat", icon: "chat", cls: "ico-chat" },
   { key: "code", label: "Code", icon: "code", cls: "ico-code" },
 ];
@@ -295,7 +295,7 @@ export function Sidebar(props: Props) {
             fill="url(#ow-mark)"
           />
         </svg>
-        <span className="name">OpenWork</span>
+        <span className="name">OpenCoworker</span>
       </div>
 
       <div className="surfaces">


### PR DESCRIPTION
## What

GitHub Actions release pipeline for the desktop app: a `v*` tag push builds installers for all targets and attaches them to a **draft** GitHub Release (review, then publish by hand). Manual runs (`workflow_dispatch`) build and upload workflow artifacts only.

| Target | Runner | Output |
|---|---|---|
| macOS Apple Silicon | `macos-latest` | `.dmg` |
| macOS Intel | `macos-13` | `.dmg` |
| Windows x64 | `windows-latest` | `.msi` + NSIS setup `.exe` |

## How

- CI calls the **same packaging scripts developers run locally** (`platform/packaging/build_dmg.sh`, `build_windows.ps1`) — the workflow only provisions the toolchain: Node 20, stable Rust (+ cache), and a Python 3.12 venv at `platform/.venv` with the package, PyInstaller, and build-time deps (`typer`, `tzdata`), plus a `.pth` for the repo-root `aisuite` package (mirrors local dev).
- Every installer is uploaded twice: versioned, and under a **stable name** (`OpenCoworker-macos-arm64.dmg`, `OpenCoworker-windows-setup.exe`, `OpenCoworker-windows.msi`) so the website can deep-link `releases/latest/download/<name>` and never need updating.
- Desktop bundle metadata is aligned with the public site (product name `OpenCoworker`, identifier `app.opencoworker.desktop`) across the installer, window title, tray, and in-app copy. `build_dmg.sh` now derives the version from `tauri.conf.json` instead of hardcoding it.

## Notes

- Builds are **unsigned** for now (macOS: right-click → Open; Windows: SmartScreen "Run anyway"). Signing/notarization slots into the workflow later without touching the build scripts.
- To test before merge: tag this branch's commit (e.g. `v0.1.0-rc1`) and push the tag — tag triggers use the workflow file at the tagged commit. The manual run button appears once this lands on `main`.

## Testing

- GUI type-check (`tsc --noEmit`) and `cargo check` clean; workflow YAML and shell syntax validated.
- Both packaging scripts previously proven locally on macOS/Windows; first CI run on a tag will validate the runner environments.
