### PR TITLE
Sign and notarize macOS release builds; drop Intel target

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,9 +14,17 @@
 #   github.com/<repo>/releases/latest/download/<stable-name>
 # and never need updating.
 #
-# Builds are UNSIGNED for now (macOS: right-click → Open past Gatekeeper; Windows:
-# SmartScreen "More info" → "Run anyway"). When signing lands, add the cert secrets and a
-# signing step here — the build scripts won't change.
+# macOS signing + notarization: Tauri's bundler handles both during `tauri build` when the
+# APPLE_* env vars are present (import cert → sign app + sidecar with hardened runtime →
+# notarize via notarytool → staple). Driven by repo secrets:
+#   APPLE_CERTIFICATE            base64 .p12 (Developer ID Application cert + key)
+#   APPLE_CERTIFICATE_PASSWORD   the .p12 export password
+#   APPLE_SIGNING_IDENTITY       e.g. "Developer ID Application: Name (TEAMID)"
+#   APPLE_API_KEY_CONTENT        base64 App Store Connect API .p8 (notarytool)
+#   APPLE_API_KEY                the API key id
+#   APPLE_API_ISSUER             the API issuer id
+# When the secrets are absent (forks, scratch runs) the build degrades to unsigned —
+# installable via `xattr -cr`. Windows remains unsigned (Authenticode is a later step).
 
 name: Release
 
@@ -80,7 +88,25 @@ jobs:
 
       - name: Build .dmg (macOS)
         if: runner.os == 'macOS'
-        run: bash platform/packaging/build_dmg.sh
+        env:
+          APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
+          APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
+          APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
+          APPLE_API_KEY_CONTENT: ${{ secrets.APPLE_API_KEY_CONTENT }}
+          APPLE_API_KEY: ${{ secrets.APPLE_API_KEY }}
+          APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
+        run: |
+          # Unset empty APPLE_* vars so runs without secrets stay cleanly unsigned
+          # (Tauri treats a present-but-empty var as a config error).
+          for v in APPLE_CERTIFICATE APPLE_CERTIFICATE_PASSWORD APPLE_SIGNING_IDENTITY APPLE_API_KEY APPLE_API_ISSUER; do
+            [ -n "$(eval echo "\${$v:-}")" ] || unset "$v"
+          done
+          if [ -n "${APPLE_API_KEY_CONTENT:-}" ]; then
+            echo "$APPLE_API_KEY_CONTENT" | base64 -d > "$RUNNER_TEMP/AuthKey.p8"
+            export APPLE_API_KEY_PATH="$RUNNER_TEMP/AuthKey.p8"
+          fi
+          unset APPLE_API_KEY_CONTENT
+          bash platform/packaging/build_dmg.sh
 
       - name: Build .msi + NSIS .exe (Windows)
         if: runner.os == 'Windows'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,10 +43,11 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          # No Intel macOS target: macos-13 (the last Intel runner image) is deprecated and
+          # its queue waits run to hours, which blocks the release job. Intel Macs are
+          # 2020-and-earlier hardware — revisit only if beta users actually ask.
           - os: macos-latest # Apple Silicon
             slug: macos-arm64
-          - os: macos-13 # last Intel runner image
-            slug: macos-intel
           - os: windows-latest
             slug: windows
     runs-on: ${{ matrix.os }}

--- a/platform/surfaces/gui/src-tauri/entitlements.plist
+++ b/platform/surfaces/gui/src-tauri/entitlements.plist
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!-- Hardened-runtime entitlements applied when code-signing the app and its binaries.
+     disable-library-validation is required by the PyInstaller onefile sidecar: it extracts
+     the Python shared library (signed by python.org, a different Team ID) at runtime, which
+     library validation would otherwise refuse to load. Accepted by notarization. -->
+<plist version="1.0">
+  <dict>
+    <key>com.apple.security.cs.disable-library-validation</key>
+    <true/>
+  </dict>
+</plist>

--- a/platform/surfaces/gui/src-tauri/tauri.conf.json
+++ b/platform/surfaces/gui/src-tauri/tauri.conf.json
@@ -28,6 +28,9 @@
       "icons/icon.ico"
     ],
     "externalBin": ["binaries/coworker-server"],
+    "macOS": {
+      "entitlements": "entitlements.plist"
+    },
     "windows": {
       "webviewInstallMode": { "type": "downloadBootstrapper" },
       "nsis": {


### PR DESCRIPTION
macOS release builds are now code-signed and notarized: Tauri's bundler handles sign → notarize → staple during `tauri build` when the `APPLE_*` env vars are present (passed through from repo secrets, already configured), so the packaging scripts are unchanged and secretless runs still build unsigned. A new `src-tauri/entitlements.plist` grants `disable-library-validation`, which the PyInstaller sidecar needs under the hardened runtime to load its bundled Python library — verified locally with a full signed build (codesign verify clean, sidecar boots and serves). Also drops the Intel macOS target: the deprecated `macos-13` runner sat queued 4.5+ hours and blocked the release job; Apple Silicon and Windows remain.
