### PR TITLE
Rename the Cowork surface to OpenCoworker in visible UI text

### DIFF
--- a/platform/surfaces/gui/src/components/IntegrationsView.tsx
+++ b/platform/surfaces/gui/src/components/IntegrationsView.tsx
@@ -10,7 +10,7 @@ export function IntegrationsView() {
           <Icon name="plug" size={19} className="mark" /> Integrations
         </div>
         <div className="sa-view-sub">
-          External accounts and tools Cowork can use — messaging connectors and MCP servers, with
+          External accounts and tools OpenCoworker can use — messaging connectors and MCP servers, with
           per-tool controls and approval boundaries.
         </div>
       </div>

--- a/platform/surfaces/gui/src/components/ManageModal.tsx
+++ b/platform/surfaces/gui/src/components/ManageModal.tsx
@@ -406,9 +406,9 @@ function SettingsTab() {
         Auto follows your Mac&rsquo;s appearance.
       </div>
 
-      <div className="sa-sub" style={{ marginTop: 22 }}>Cowork files</div>
+      <div className="sa-sub" style={{ marginTop: 22 }}>OpenCoworker files</div>
       <div className="conn-meta dim" style={{ marginBottom: 10 }}>
-        Each Cowork conversation gets its own scratch folder under this location, where the agent
+        Each OpenCoworker conversation gets its own scratch folder under this location, where the agent
         saves files by default. You can grant access to more folders inside any conversation.
       </div>
       <label className="conn-field">
@@ -441,7 +441,7 @@ function SettingsTab() {
 
       <div className="sa-sub" style={{ marginTop: 22 }}>Surfaces</div>
       <div className="conn-meta dim" style={{ marginBottom: 10 }}>
-        Cowork is always shown. Turn on Chat and Code to add them to the left panel.
+        OpenCoworker is always shown. Turn on Chat and Code to add them to the left panel.
       </div>
       <label className="ob-toggle">
         <input
@@ -687,7 +687,7 @@ export function ConnectorsTab() {
   return (
     <div className="conn-tab">
       <div className="mcp-intro">
-        Connect the accounts and tools Cowork can use. You bring the token for this local
+        Connect the accounts and tools OpenCoworker can use. You bring the token for this local
         build; managed one-click sign-in can replace this setup later.
       </div>
       <div className="conn-list">
@@ -781,7 +781,7 @@ function ConnectorTools({ c, onChanged }: { c: Connector; onChanged: () => void 
   if (!c.tools?.length) return <div className="conn-setup">No tools for this connector yet.</div>;
   return (
     <div className="conn-setup">
-      <div className="sa-sub">Tools exposed to Cowork</div>
+      <div className="sa-sub">Tools exposed to OpenCoworker</div>
       <div className="tool-settings">
         {c.tools.map((tool) => (
           <label className="tool-setting-row" key={tool.name}>

--- a/platform/surfaces/gui/src/components/RightRail.tsx
+++ b/platform/surfaces/gui/src/components/RightRail.tsx
@@ -156,7 +156,7 @@ function ProgressSummary({ running, toolNames, todo }: { running: boolean; toolN
   }
   return (
     <div className="rail-muted">
-      For longer multi-step tasks, progress will appear here while Cowork plans, uses tools, waits for approval, and produces artifacts.
+      For longer multi-step tasks, progress will appear here while OpenCoworker plans, uses tools, waits for approval, and produces artifacts.
     </div>
   );
 }

--- a/platform/surfaces/gui/src/components/ScheduledView.tsx
+++ b/platform/surfaces/gui/src/components/ScheduledView.tsx
@@ -45,7 +45,7 @@ export function ScheduledView({ onOpenRun, onRunNow }: Props) {
           <span className="mark">⏰</span> Scheduled tasks
         </div>
         <div className="sa-view-sub">
-          Run tasks on a schedule. Ask Cowork or MyHelper to "set up an automation…".
+          Run tasks on a schedule. Ask OpenCoworker or MyHelper to "set up an automation…".
         </div>
       </div>
       <div className="main-scroll">
@@ -60,7 +60,7 @@ export function ScheduledView({ onOpenRun, onRunNow }: Props) {
           <div className="hero">
             <h1 className="greeting"><span className="mark">⏰</span> No scheduled tasks yet.</h1>
             <div className="suggest-head">
-              In a Cowork session, try: "Search the web and give me a news briefing every day at 7:10pm."
+              In an OpenCoworker session, try: "Search the web and give me a news briefing every day at 7:10pm."
             </div>
           </div>
         ) : (

--- a/platform/surfaces/gui/src/components/Sidebar.tsx
+++ b/platform/surfaces/gui/src/components/Sidebar.tsx
@@ -6,7 +6,7 @@ import { Icon } from "./Icon";
 // Session surfaces shown as accordions, in display order. Cowork is always visible; Chat/Code
 // are toggled via Settings. Each has a colored icon square.
 const SURFACES: { key: string; label: string; icon: "diamond" | "chat" | "code"; cls: string }[] = [
-  { key: "cowork", label: "Cowork", icon: "diamond", cls: "ico-cowork" },
+  { key: "cowork", label: "OpenCoworker", icon: "diamond", cls: "ico-cowork" },
   { key: "chat", label: "Chat", icon: "chat", cls: "ico-chat" },
   { key: "code", label: "Code", icon: "code", cls: "ico-code" },
 ];


### PR DESCRIPTION
Renames the Cowork surface to OpenCoworker in user-visible copy (sidebar header, Manage, Scheduled, Integrations, right rail); internal keys unchanged.