### PR TITLE
Add OAuth support for remote MCP servers

### DIFF
--- a/platform/coworker/mcp/client.py
+++ b/platform/coworker/mcp/client.py
@@ -21,6 +21,7 @@ from mcp.client.stdio import stdio_client
 from mcp.client.streamable_http import streamablehttp_client
 
 from .config import MCPServerDef
+from .oauth import build_auth
 
 
 class _Conn:
@@ -82,9 +83,12 @@ class MCPManager:
                         raise ValueError(
                             f"MCP server '{server.name}' is http but has no url"
                         )
+                    auth = (
+                        build_auth(server.name, server.oauth) if server.oauth else None
+                    )
                     read, write, *_ = await stack.enter_async_context(
                         streamablehttp_client(
-                            server.url, headers=server.headers or None
+                            server.url, headers=server.headers or None, auth=auth
                         )
                     )
                 else:

--- a/platform/coworker/mcp/config.py
+++ b/platform/coworker/mcp/config.py
@@ -34,6 +34,8 @@ class MCPServerDef:
     include_tools: Optional[list[str]] = None
     exclude_tools: Optional[list[str]] = None
     requires_approval: bool = True
+    # OAuth client settings for http servers (see mcp/oauth.py); `${VAR}` refs resolved.
+    oauth: Optional[dict[str, Any]] = None
 
 
 def global_mcp_path() -> Path:
@@ -71,6 +73,7 @@ def _parse(name: str, raw: dict[str, Any], secrets: SecretStore) -> MCPServerDef
         include_tools=raw.get("include_tools"),
         exclude_tools=raw.get("exclude_tools"),
         requires_approval=bool(raw.get("requires_approval", True)),
+        oauth=raw.get("oauth") if isinstance(raw.get("oauth"), dict) else None,
     )
 
 

--- a/platform/coworker/mcp/oauth.py
+++ b/platform/coworker/mcp/oauth.py
@@ -1,0 +1,283 @@
+"""OAuth 2.0 (authorization-code + PKCE) for remote MCP servers.
+
+Built for Google's hosted Workspace MCP servers (Calendar/Gmail) but provider-agnostic:
+any authorization server speaking the standard authorization-code + refresh-token grants
+works via `authorize_url`/`token_url` overrides. The interactive consent runs once in the
+system browser with a localhost loopback redirect; tokens are cached in the SecretStore
+(profile `mcp-oauth:<server>`) so later sessions refresh silently. Google does NOT support
+dynamic client registration, so the OAuth client id/secret come from config.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+import hashlib
+import secrets as pysecrets
+import time
+import urllib.parse
+import webbrowser
+from dataclasses import dataclass, field
+from typing import Any, AsyncGenerator, Callable, Optional
+
+import httpx
+
+from ..secrets import SecretStore
+
+GOOGLE_AUTHORIZE_URL = "https://accounts.google.com/o/oauth2/v2/auth"
+GOOGLE_TOKEN_URL = "https://oauth2.googleapis.com/token"
+DEFAULT_CALLBACK_PORT = 51789
+CALLBACK_PATH = "/oauth/callback"
+_EXPIRY_SLACK = 60.0  # treat tokens expiring within this window as already expired
+_FLOW_TIMEOUT = 300.0  # seconds the user has to finish the browser consent
+
+_SUCCESS_HTML = (
+    "<html><body style='font-family:sans-serif;text-align:center;padding-top:4em'>"
+    "<h2>Connected</h2><p>Authorization complete &mdash; you can close this tab and "
+    "return to OpenCoworker.</p></body></html>"
+)
+_FAILURE_HTML = (
+    "<html><body style='font-family:sans-serif;text-align:center;padding-top:4em'>"
+    "<h2>Authorization failed</h2><p>{reason}</p></body></html>"
+)
+
+
+class OAuthError(RuntimeError):
+    pass
+
+
+@dataclass
+class OAuthSpec:
+    """Static OAuth client settings for one MCP server (defaults target Google)."""
+
+    client_id: str
+    client_secret: str = ""
+    scopes: list[str] = field(default_factory=list)
+    authorize_url: str = GOOGLE_AUTHORIZE_URL
+    token_url: str = GOOGLE_TOKEN_URL
+    callback_port: int = DEFAULT_CALLBACK_PORT
+
+    @property
+    def redirect_uri(self) -> str:
+        return f"http://localhost:{self.callback_port}{CALLBACK_PATH}"
+
+    @classmethod
+    def from_config(cls, raw: dict[str, Any]) -> "OAuthSpec":
+        client_id = str(raw.get("client_id") or "")
+        if not client_id:
+            raise ValueError("MCP oauth config requires a client_id")
+        return cls(
+            client_id=client_id,
+            client_secret=str(raw.get("client_secret") or ""),
+            scopes=[str(s) for s in (raw.get("scopes") or [])],
+            authorize_url=str(raw.get("authorize_url") or GOOGLE_AUTHORIZE_URL),
+            token_url=str(raw.get("token_url") or GOOGLE_TOKEN_URL),
+            callback_port=int(raw.get("callback_port") or DEFAULT_CALLBACK_PORT),
+        )
+
+
+def _pkce_pair() -> tuple[str, str]:
+    verifier = base64.urlsafe_b64encode(pysecrets.token_bytes(32)).rstrip(b"=").decode()
+    digest = hashlib.sha256(verifier.encode("ascii")).digest()
+    challenge = base64.urlsafe_b64encode(digest).rstrip(b"=").decode()
+    return verifier, challenge
+
+
+def build_authorize_url(spec: OAuthSpec, state: str, challenge: str) -> str:
+    params = {
+        "client_id": spec.client_id,
+        "redirect_uri": spec.redirect_uri,
+        "response_type": "code",
+        "scope": " ".join(spec.scopes),
+        "state": state,
+        "code_challenge": challenge,
+        "code_challenge_method": "S256",
+        # Google-specific but harmless elsewhere: offline => refresh_token issued;
+        # prompt=consent forces re-issue even if previously granted.
+        "access_type": "offline",
+        "prompt": "consent",
+    }
+    return f"{spec.authorize_url}?{urllib.parse.urlencode(params)}"
+
+
+async def _start_callback_server(
+    port: int, expected_state: str
+) -> tuple[asyncio.AbstractServer, "asyncio.Future[str]"]:
+    """Bind the loopback redirect server; the future resolves to the auth code."""
+    loop = asyncio.get_running_loop()
+    result: asyncio.Future[str] = loop.create_future()
+
+    async def handle(
+        reader: asyncio.StreamReader, writer: asyncio.StreamWriter
+    ) -> None:
+        status, body = "200 OK", _SUCCESS_HTML
+        try:
+            request_line = await reader.readline()
+            while await reader.readline() not in (b"\r\n", b"\n", b""):
+                pass  # drain headers
+            parts = request_line.split()
+            target = parts[1].decode("latin-1") if len(parts) >= 2 else "/"
+            parsed = urllib.parse.urlsplit(target)
+            if parsed.path != CALLBACK_PATH:
+                status, body = "404 Not Found", _FAILURE_HTML.format(reason="Not found")
+            else:
+                query = urllib.parse.parse_qs(parsed.query)
+                error = (query.get("error") or [None])[0]
+                code = (query.get("code") or [None])[0]
+                state = (query.get("state") or [None])[0]
+                if error or not code:
+                    reason = error or "no authorization code in callback"
+                    status = "400 Bad Request"
+                    body = _FAILURE_HTML.format(reason=reason)
+                    if not result.done():
+                        result.set_exception(
+                            OAuthError(f"authorization failed: {reason}")
+                        )
+                elif state != expected_state:
+                    status = "400 Bad Request"
+                    body = _FAILURE_HTML.format(reason="state mismatch")
+                    if not result.done():
+                        result.set_exception(OAuthError("state mismatch in callback"))
+                elif not result.done():
+                    result.set_result(code)
+        finally:
+            writer.write(
+                f"HTTP/1.1 {status}\r\nContent-Type: text/html; charset=utf-8\r\n"
+                f"Content-Length: {len(body.encode())}\r\nConnection: close\r\n\r\n{body}".encode()
+            )
+            try:
+                await writer.drain()
+            except OSError:
+                pass
+            writer.close()
+
+    server = await asyncio.start_server(handle, host="localhost", port=port)
+    return server, result
+
+
+class OAuthTokenManager:
+    """Caches/refreshes one MCP server's tokens; runs browser consent when needed."""
+
+    def __init__(
+        self,
+        server_name: str,
+        spec: OAuthSpec,
+        secrets: Optional[SecretStore] = None,
+        *,
+        open_browser: Callable[[str], Any] = webbrowser.open,
+        transport: Optional[httpx.AsyncBaseTransport] = None,
+        flow_timeout: float = _FLOW_TIMEOUT,
+    ) -> None:
+        self.spec = spec
+        self._profile = f"mcp-oauth:{server_name}"
+        self._secrets = secrets or SecretStore()
+        self._open_browser = open_browser
+        self._transport = transport
+        self._flow_timeout = flow_timeout
+        self._lock = asyncio.Lock()
+
+    async def get_token(self, *, force_refresh: bool = False) -> str:
+        async with self._lock:
+            tokens = self._secrets.get(self._profile) or {}
+            fresh = tokens.get("expires", 0) > time.time() + _EXPIRY_SLACK
+            if tokens.get("access_token") and fresh and not force_refresh:
+                return str(tokens["access_token"])
+            if tokens.get("refresh_token"):
+                try:
+                    tokens = await self._refresh(tokens)
+                except OAuthError:
+                    tokens = await self._interactive()
+            else:
+                tokens = await self._interactive()
+            return str(tokens["access_token"])
+
+    # -- grant flows --------------------------------------------------------------
+    async def _refresh(self, tokens: dict[str, Any]) -> dict[str, Any]:
+        data = {
+            "grant_type": "refresh_token",
+            "refresh_token": tokens["refresh_token"],
+            "client_id": self.spec.client_id,
+        }
+        if self.spec.client_secret:
+            data["client_secret"] = self.spec.client_secret
+        payload = await self._post_token(data)
+        return self._store(payload, previous=tokens)
+
+    async def _interactive(self) -> dict[str, Any]:
+        verifier, challenge = _pkce_pair()
+        state = pysecrets.token_urlsafe(16)
+        url = build_authorize_url(self.spec, state, challenge)
+        server, result = await _start_callback_server(self.spec.callback_port, state)
+        try:
+            self._open_browser(url)
+            code = await asyncio.wait_for(result, self._flow_timeout)
+        except asyncio.TimeoutError:
+            raise OAuthError(
+                f"timed out after {int(self._flow_timeout)}s waiting for "
+                "browser authorization"
+            ) from None
+        finally:
+            server.close()
+            await server.wait_closed()
+        data = {
+            "grant_type": "authorization_code",
+            "code": code,
+            "redirect_uri": self.spec.redirect_uri,
+            "client_id": self.spec.client_id,
+            "code_verifier": verifier,
+        }
+        if self.spec.client_secret:
+            data["client_secret"] = self.spec.client_secret
+        payload = await self._post_token(data)
+        return self._store(payload, previous={})
+
+    # -- plumbing -------------------------------------------------------------------
+    async def _post_token(self, data: dict[str, str]) -> dict[str, Any]:
+        async with httpx.AsyncClient(transport=self._transport, timeout=30) as client:
+            response = await client.post(self.spec.token_url, data=data)
+        if response.status_code != 200:
+            raise OAuthError(
+                f"token endpoint returned {response.status_code}: {response.text[:200]}"
+            )
+        return response.json()
+
+    def _store(
+        self, payload: dict[str, Any], *, previous: dict[str, Any]
+    ) -> dict[str, Any]:
+        access_token = payload.get("access_token")
+        if not access_token:
+            raise OAuthError("token endpoint response had no access_token")
+        tokens = {
+            "type": "oauth",
+            "access_token": access_token,
+            # Google omits refresh_token on refresh responses — keep the old one.
+            "refresh_token": payload.get("refresh_token")
+            or previous.get("refresh_token"),
+            "expires": time.time() + float(payload.get("expires_in") or 3600),
+            "scopes": self.spec.scopes,
+        }
+        self._secrets.put(self._profile, tokens)
+        return tokens
+
+
+class OAuthBearer(httpx.Auth):
+    """httpx auth hook: fresh Bearer token per request, one forced refresh on 401."""
+
+    def __init__(self, manager: OAuthTokenManager) -> None:
+        self._manager = manager
+
+    async def async_auth_flow(
+        self, request: httpx.Request
+    ) -> AsyncGenerator[httpx.Request, httpx.Response]:
+        request.headers["Authorization"] = f"Bearer {await self._manager.get_token()}"
+        response = yield request
+        if response is not None and response.status_code == 401:
+            token = await self._manager.get_token(force_refresh=True)
+            request.headers["Authorization"] = f"Bearer {token}"
+            yield request
+
+
+def build_auth(server_name: str, oauth_config: dict[str, Any]) -> OAuthBearer:
+    """Config dict -> ready `httpx.Auth` for `streamablehttp_client`."""
+    spec = OAuthSpec.from_config(oauth_config)
+    return OAuthBearer(OAuthTokenManager(server_name, spec))

--- a/platform/tests/test_mcp_oauth.py
+++ b/platform/tests/test_mcp_oauth.py
@@ -1,0 +1,289 @@
+"""Tests for MCP OAuth (authorization-code + PKCE) — token cache, refresh, consent
+flow against a local loopback redirect, 401 retry, and config plumbing. No network:
+token endpoints are httpx.MockTransport; the "browser" is a stub that fetches the
+redirect URI itself.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+import hashlib
+import json
+import socket
+import time
+import urllib.parse
+
+import httpx
+import pytest
+
+from coworker.mcp import load_mcp_servers
+from coworker.mcp.oauth import (
+    GOOGLE_AUTHORIZE_URL,
+    GOOGLE_TOKEN_URL,
+    OAuthBearer,
+    OAuthError,
+    OAuthSpec,
+    OAuthTokenManager,
+    _pkce_pair,
+    build_authorize_url,
+)
+from coworker.secrets import SecretStore
+
+
+def _free_port() -> int:
+    with socket.socket() as s:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
+
+
+def _store(tmp_path, monkeypatch) -> SecretStore:
+    monkeypatch.setenv("COWORKER_STATE_DIR", str(tmp_path / "state"))
+    return SecretStore()
+
+
+def _spec(**overrides) -> OAuthSpec:
+    base = dict(
+        client_id="cid.apps.googleusercontent.com",
+        client_secret="csecret",
+        scopes=["https://www.googleapis.com/auth/calendar.events.readonly"],
+    )
+    base.update(overrides)
+    return OAuthSpec(**base)
+
+
+# -- pure pieces -----------------------------------------------------------------
+def test_pkce_pair_is_s256():
+    verifier, challenge = _pkce_pair()
+    expected = (
+        base64.urlsafe_b64encode(hashlib.sha256(verifier.encode()).digest())
+        .rstrip(b"=")
+        .decode()
+    )
+    assert challenge == expected
+    assert "=" not in verifier and len(verifier) >= 43
+
+
+def test_authorize_url_params():
+    url = build_authorize_url(_spec(), state="st4te", challenge="ch4llenge")
+    parsed = urllib.parse.urlsplit(url)
+    query = {k: v[0] for k, v in urllib.parse.parse_qs(parsed.query).items()}
+    assert url.startswith(GOOGLE_AUTHORIZE_URL)
+    assert query["client_id"] == "cid.apps.googleusercontent.com"
+    assert query["response_type"] == "code"
+    assert query["state"] == "st4te"
+    assert query["code_challenge"] == "ch4llenge"
+    assert query["code_challenge_method"] == "S256"
+    assert query["access_type"] == "offline"
+    assert query["prompt"] == "consent"
+    assert query["scope"].startswith("https://www.googleapis.com/auth/calendar")
+    assert query["redirect_uri"].startswith("http://localhost:")
+
+
+def test_spec_from_config_defaults_and_validation():
+    spec = OAuthSpec.from_config({"client_id": "abc", "scopes": ["s1", "s2"]})
+    assert spec.authorize_url == GOOGLE_AUTHORIZE_URL
+    assert spec.token_url == GOOGLE_TOKEN_URL
+    assert spec.client_secret == ""
+    assert spec.scopes == ["s1", "s2"]
+    with pytest.raises(ValueError):
+        OAuthSpec.from_config({"scopes": ["s1"]})
+
+
+# -- token cache / refresh ---------------------------------------------------------
+async def test_cached_token_skips_network(tmp_path, monkeypatch):
+    store = _store(tmp_path, monkeypatch)
+    store.put(
+        "mcp-oauth:cal",
+        {"access_token": "cached", "refresh_token": "r", "expires": time.time() + 600},
+    )
+
+    def _no_network(request):  # pragma: no cover - failure path
+        raise AssertionError("token endpoint should not be called")
+
+    manager = OAuthTokenManager(
+        "cal", _spec(), store, transport=httpx.MockTransport(_no_network)
+    )
+    assert await manager.get_token() == "cached"
+
+
+async def test_refresh_preserves_refresh_token(tmp_path, monkeypatch):
+    store = _store(tmp_path, monkeypatch)
+    store.put(
+        "mcp-oauth:cal",
+        {"access_token": "stale", "refresh_token": "rtok", "expires": time.time() - 5},
+    )
+    seen: dict = {}
+
+    def _token_endpoint(request):
+        seen.update(urllib.parse.parse_qsl(request.content.decode()))
+        return httpx.Response(200, json={"access_token": "fresh", "expires_in": 3600})
+
+    manager = OAuthTokenManager(
+        "cal", _spec(), store, transport=httpx.MockTransport(_token_endpoint)
+    )
+    assert await manager.get_token() == "fresh"
+    assert seen["grant_type"] == "refresh_token"
+    assert seen["refresh_token"] == "rtok"
+    assert seen["client_secret"] == "csecret"
+    saved = store.get("mcp-oauth:cal")
+    assert saved["access_token"] == "fresh"
+    assert saved["refresh_token"] == "rtok"  # kept although response omitted it
+    assert saved["expires"] > time.time() + 3000
+
+
+# -- interactive consent flow ------------------------------------------------------
+async def test_interactive_flow_roundtrip(tmp_path, monkeypatch):
+    store = _store(tmp_path, monkeypatch)
+    spec = _spec(callback_port=_free_port())
+    exchanged: dict = {}
+
+    def _token_endpoint(request):
+        exchanged.update(urllib.parse.parse_qsl(request.content.decode()))
+        return httpx.Response(
+            200,
+            json={"access_token": "live", "refresh_token": "rnew", "expires_in": 3599},
+        )
+
+    def _browser(url: str):
+        query = dict(urllib.parse.parse_qsl(urllib.parse.urlsplit(url).query))
+
+        async def _consent():
+            redirect = (
+                f"{query['redirect_uri']}?code=authcode123&state={query['state']}"
+            )
+            async with httpx.AsyncClient() as client:
+                response = await client.get(redirect)
+            assert response.status_code == 200
+            assert "close this tab" in response.text
+
+        asyncio.get_running_loop().create_task(_consent())
+
+    manager = OAuthTokenManager(
+        "cal",
+        spec,
+        store,
+        open_browser=_browser,
+        transport=httpx.MockTransport(_token_endpoint),
+        flow_timeout=10,
+    )
+    assert await manager.get_token() == "live"
+    assert exchanged["grant_type"] == "authorization_code"
+    assert exchanged["code"] == "authcode123"
+    assert exchanged["code_verifier"]
+    assert exchanged["redirect_uri"] == spec.redirect_uri
+    saved = store.get("mcp-oauth:cal")
+    assert saved["refresh_token"] == "rnew"
+
+
+async def test_interactive_flow_rejects_bad_state_and_errors(tmp_path, monkeypatch):
+    store = _store(tmp_path, monkeypatch)
+    spec = _spec(callback_port=_free_port())
+
+    def _browser(url: str):
+        query = dict(urllib.parse.parse_qsl(urllib.parse.urlsplit(url).query))
+
+        async def _consent():
+            redirect = f"{query['redirect_uri']}?code=x&state=WRONG"
+            async with httpx.AsyncClient() as client:
+                response = await client.get(redirect)
+            assert response.status_code == 400
+
+        asyncio.get_running_loop().create_task(_consent())
+
+    manager = OAuthTokenManager(
+        "cal", spec, store, open_browser=_browser, flow_timeout=10
+    )
+    with pytest.raises(OAuthError, match="state mismatch"):
+        await manager.get_token()
+
+
+async def test_failed_refresh_falls_back_to_interactive(tmp_path, monkeypatch):
+    store = _store(tmp_path, monkeypatch)
+    spec = _spec(callback_port=_free_port())
+    store.put(
+        "mcp-oauth:cal",
+        {"access_token": "stale", "refresh_token": "dead", "expires": time.time() - 5},
+    )
+
+    def _token_endpoint(request):
+        data = dict(urllib.parse.parse_qsl(request.content.decode()))
+        if data["grant_type"] == "refresh_token":
+            return httpx.Response(400, json={"error": "invalid_grant"})
+        return httpx.Response(200, json={"access_token": "anew", "expires_in": 3600})
+
+    def _browser(url: str):
+        query = dict(urllib.parse.parse_qsl(urllib.parse.urlsplit(url).query))
+
+        async def _consent():
+            redirect = f"{query['redirect_uri']}?code=c2&state={query['state']}"
+            async with httpx.AsyncClient() as client:
+                await client.get(redirect)
+
+        asyncio.get_running_loop().create_task(_consent())
+
+    manager = OAuthTokenManager(
+        "cal",
+        spec,
+        store,
+        open_browser=_browser,
+        transport=httpx.MockTransport(_token_endpoint),
+        flow_timeout=10,
+    )
+    assert await manager.get_token() == "anew"
+
+
+# -- bearer auth hook ---------------------------------------------------------------
+async def test_bearer_retries_once_on_401():
+    class _FakeManager:
+        def __init__(self):
+            self.calls = []
+
+        async def get_token(self, *, force_refresh: bool = False) -> str:
+            self.calls.append(force_refresh)
+            return "tok2" if force_refresh else "tok1"
+
+    manager = _FakeManager()
+
+    def _server(request):
+        if request.headers["Authorization"] == "Bearer tok1":
+            return httpx.Response(401)
+        assert request.headers["Authorization"] == "Bearer tok2"
+        return httpx.Response(200, json={"ok": True})
+
+    async with httpx.AsyncClient(
+        transport=httpx.MockTransport(_server), auth=OAuthBearer(manager)
+    ) as client:
+        response = await client.get("https://mcp.example/v1")
+    assert response.status_code == 200
+    assert manager.calls == [False, True]
+
+
+# -- config plumbing -----------------------------------------------------------------
+def test_config_parses_oauth_block_with_var_resolution(tmp_path, monkeypatch):
+    monkeypatch.setenv("COWORKER_STATE_DIR", str(tmp_path / "state"))
+    monkeypatch.setenv("GCP_CLIENT_SECRET", "resolved-secret")
+    path = tmp_path / "state" / "mcp.json"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(
+            {
+                "mcpServers": {
+                    "calendar": {
+                        "url": "https://calendarmcp.googleapis.com/mcp/v1",
+                        "oauth": {
+                            "client_id": "cid",
+                            "client_secret": "${GCP_CLIENT_SECRET}",
+                            "scopes": ["s"],
+                        },
+                    },
+                    "plain": {"command": "echo"},
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+    servers = {s.name: s for s in load_mcp_servers(secrets=SecretStore())}
+    assert servers["calendar"].transport == "http"
+    assert servers["calendar"].oauth["client_secret"] == "resolved-secret"
+    assert servers["plain"].oauth is None


### PR DESCRIPTION
HTTP MCP servers can declare an oauth block (client id/secret + scopes) in mcp.json: first use opens a one-time browser consent (PKCE + localhost redirect), tokens are cached in the SecretStore and refreshed automatically, with a forced refresh on 401. Defaults target Google's hosted Calendar/Gmail MCP servers; endpoints are overridable for other providers. Tested with 10 new unit tests; full platform suite green.