### PR TITLE
Fix sidecar process leak on quit and mid-turn session loss

### DIFF
--- a/platform/coworker/server/app.py
+++ b/platform/coworker/server/app.py
@@ -451,10 +451,24 @@ def create_app(manager: SessionManager) -> FastAPI:
             }
         )
 
+        # Checkpoint events: persist mid-turn so a crash/quit can't eat the conversation.
+        # turn_start = the user message just landed (a brand-new session gets its row here,
+        # not at connect — empty never-used sessions shouldn't appear in Recents);
+        # permission_required/directory_requested = parked indefinitely on the user;
+        # iteration_end = a model response + its tool results completed.
+        _CHECKPOINTS = {
+            "turn_start",
+            "permission_required",
+            "directory_requested",
+            "iteration_end",
+        }
+
         async def run_turn(content) -> None:
             try:
                 async for event in engine.run(content):
                     await ws.send_json({"type": event.type.value, "data": event.data})
+                    if event.type.value in _CHECKPOINTS:
+                        manager.save(session_id, engine)
             finally:
                 manager.save(session_id, engine)
                 await ws.send_json({"type": "turn_done", "data": {}})

--- a/platform/coworker/server/run.py
+++ b/platform/coworker/server/run.py
@@ -20,32 +20,50 @@ def _exit_when_orphaned() -> None:
     crash) that skips the shell's graceful child-kill. Standalone `coworker-server` runs are
     unaffected.
 
-    POSIX: detected via re-parenting — when our parent dies, getppid() flips to 1 (init/launchd).
-    Windows: there is no re-parenting and getppid() keeps returning the stale PID, so instead we
-    block on a handle to the parent process and exit the moment it signals (i.e. the parent
-    exited)."""
+    The GUI passes its own PID in `COWORKER_PARENT_PID`. Watching that explicit PID (not
+    getppid) is what makes this work under PyInstaller onefile, where this process is a
+    *grandchild* of the GUI — the bootloader sits in between, so getppid() points at the
+    bootloader and a re-parenting check never fires when the GUI dies (the bug that leaked
+    a server pair on every app quit).
+
+    POSIX: poll the PID with kill(pid, 0). Windows: no re-parenting semantics at all, so
+    block on a process handle and exit the moment it signals (i.e. the parent exited).
+    """
     if os.environ.get("COWORKER_EXIT_WITH_PARENT") != "1":
         return
     import threading
 
+    try:
+        parent = int(os.environ.get("COWORKER_PARENT_PID") or 0)
+    except ValueError:
+        parent = 0
+    parent = parent or os.getppid()  # standalone fallback: our direct spawner
+
     if sys.platform == "win32":
-        _watch_parent_windows()
+        _watch_parent_windows(parent)
         return
 
     import time
 
-    original = os.getppid()
+    original_ppid = os.getppid()
 
     def watch() -> None:
         while True:
             time.sleep(1.5)
-            if os.getppid() != original:
+            try:
+                os.kill(parent, 0)  # liveness probe only; signal 0 delivers nothing
+            except ProcessLookupError:
+                os._exit(0)
+            except PermissionError:
+                pass  # alive, but owned by someone else (shouldn't happen) — keep waiting
+            # Secondary signal: our direct parent died (covers PID-reuse edge cases).
+            if os.getppid() != original_ppid:
                 os._exit(0)
 
     threading.Thread(target=watch, daemon=True).start()
 
 
-def _watch_parent_windows() -> None:
+def _watch_parent_windows(parent: int) -> None:
     """Block on a handle to the parent process; exit only when it actually terminates.
 
     Best-effort — any failure leaves the parent's RunEvent::ExitRequested kill as the primary
@@ -69,7 +87,7 @@ def _watch_parent_windows() -> None:
     kernel32.WaitForSingleObject.restype = wintypes.DWORD
     kernel32.WaitForSingleObject.argtypes = [wintypes.HANDLE, wintypes.DWORD]
 
-    handle = kernel32.OpenProcess(SYNCHRONIZE, False, os.getppid())
+    handle = kernel32.OpenProcess(SYNCHRONIZE, False, parent)
     if not handle:
         return
 

--- a/platform/surfaces/gui/src-tauri/src/lib.rs
+++ b/platform/surfaces/gui/src-tauri/src/lib.rs
@@ -289,7 +289,11 @@ pub fn run() {
                 .args(["--host", "127.0.0.1", "--port", &port.to_string()])
                 // The sidecar self-exits if we die abruptly (dev-watcher restart, crash) —
                 // belt-and-suspenders alongside the RunEvent::ExitRequested kill below.
+                // The explicit PID matters: under PyInstaller onefile the python process is a
+                // *grandchild* (bootloader in between), so getppid() never points at us and a
+                // reparenting check alone leaks both processes on quit.
                 .env("COWORKER_EXIT_WITH_PARENT", "1")
+                .env("COWORKER_PARENT_PID", std::process::id().to_string())
                 // This GUI app has no console, so a console-subsystem child would inherit
                 // invalid std handles and crash a few seconds in when uvicorn writes its logs
                 // (the "Starting coworker…" freeze on Windows). Hand it null handles instead.
@@ -379,7 +383,9 @@ pub fn run() {
         .build(tauri::generate_context!())
         .expect("error while building the OpenCoworker desktop app")
         .run(|app, event| {
-            if let RunEvent::ExitRequested { .. } = event {
+            // Also on Exit: belt-and-suspenders in case a quit path reaches teardown without
+            // a preceding ExitRequested (observed with macOS Cmd+Q under the tray setup).
+            if matches!(event, RunEvent::ExitRequested { .. } | RunEvent::Exit) {
                 if let Some(state) = app.try_state::<ServerProcess>() {
                     if let Some(mut child) = state.0.lock().unwrap().take() {
                         let _ = child.kill();

--- a/platform/tests/test_server.py
+++ b/platform/tests/test_server.py
@@ -292,6 +292,32 @@ def test_ws_approval_round_trip(tmp_path):
     assert (tmp_path / "made.py").read_text() == "print(1)\n"
 
 
+def test_ws_session_persisted_while_parked_on_approval(tmp_path):
+    """A crash mid-turn must not eat the conversation: by the time the engine parks on an
+    approval, the session (user message + assistant tool call) is already on disk."""
+    manager = SessionManager(
+        workspace=tmp_path,
+        provider=ScriptedProvider(
+            [_tool("write_file", {"path": "x.py", "content": "1\n"}), _text("done")]
+        ),
+    )
+    client = TestClient(create_app(manager))
+    with client.websocket_connect("/ws/session/persist1") as ws:
+        assert ws.receive_json()["type"] == "ready"
+        ws.send_json({"type": "user_message", "text": "make x.py"})
+        while ws.receive_json()["type"] != "permission_required":
+            pass
+        # Parked on the approval — nothing approved, turn far from done. Already saved?
+        rec = manager.session_store.load("persist1")
+        assert rec is not None
+        roles = [m.get("role") for m in rec.messages]
+        assert "user" in roles  # turn_start checkpoint
+        assert "assistant" in roles  # iteration progress checkpoint
+        ws.send_json({"type": "approval", "decision": "deny"})
+        while ws.receive_json()["type"] != "turn_done":
+            pass
+
+
 def test_ws_browser_tool_audit_round_trip(tmp_path):
     client = _client(tmp_path, [_tool("browser_close", {}), _text("closed")])
     with client.websocket_connect("/ws/session/browser-audit?agent=cowork") as ws:


### PR DESCRIPTION
Two launch-quality bugs: quitting the app leaked the sidecar server pair (PyInstaller onefile makes the server a grandchild of the GUI, defeating both the getppid watchdog and the Rust child-kill — the GUI now passes its PID and the watchdog polls it directly), and conversations were only saved when a turn finished, so a crash or quit mid-first-turn silently lost the session (the turn loop now checkpoints at turn start, approval pauses, and each iteration end). Verified with a live parent-kill test and a new WS regression test; full platform suite green.