### PR TITLE
Prepare app release 0.1.1: app-v tag trigger and version bump

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,7 +30,7 @@ name: Release
 
 on:
   push:
-    tags: ["v*"]
+    tags: ["v*", "app-v*"]
   workflow_dispatch:
 
 defaults:

--- a/platform/surfaces/gui/src-tauri/tauri.conf.json
+++ b/platform/surfaces/gui/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "OpenCoworker",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "identifier": "app.opencoworker.desktop",
   "build": {
     "frontendDist": "../dist",


### PR DESCRIPTION
Adds app-v* to the release workflow tag trigger (desktop releases use that namespace; v* is the Python library's) and bumps the app version to 0.1.1. After merge, tagging app-v0.1.1 builds, signs, and notarizes the installers into a draft release.