### PR TITLE
Run the release job for app-v tags too

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -136,7 +136,7 @@ jobs:
           if-no-files-found: error
 
   release:
-    if: startsWith(github.ref, 'refs/tags/v')
+    if: startsWith(github.ref, 'refs/tags/v') || startsWith(github.ref, 'refs/tags/app-v')
     needs: build
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
One-line fix: the release job's if-condition only matched v* tags, so the app-v0.1.1 run built both platforms but skipped creating the draft release (assembled manually from artifacts this time).