### PR TITLE
Restructure the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,38 +41,23 @@
 
 ## Installation
 
-You can install just the base `aisuite` package, or install a provider's package along with `aisuite`.
+### The aisuite library (Python)
 
-Install just the base package without any provider SDKs:
-
-```shell
-pip install aisuite
-```
-
-Install aisuite with a specific provider (e.g., Anthropic):
+Install the base package, or include the SDKs of the providers you plan to use:
 
 ```shell
-pip install 'aisuite[anthropic]'
+pip install aisuite               # base package, no provider SDKs
+pip install 'aisuite[anthropic]'  # with a specific provider's SDK
+pip install 'aisuite[all]'        # with all provider SDKs
 ```
 
-Install aisuite with all provider libraries:
+You'll also need API keys for the providers you call — the [Chat Completions quickstart](docs/chat-completions-quickstart.md) covers key setup and your first calls.
 
-```shell
-pip install 'aisuite[all]'
-```
+### The OpenCoworker app (desktop)
 
-## Setup
+No Python needed — download the installer and bring your own API key (or run local models with Ollama):
 
-To get started, you will need API Keys for the providers you intend to use. You'll need to
-install the provider-specific library either separately or when installing aisuite.
-
-The API Keys can be set as environment variables, or can be passed as config to the aisuite Client constructor.
-You can use tools like [`python-dotenv`](https://pypi.org/project/python-dotenv/) or [`direnv`](https://direnv.net/) to set the environment variables manually. Please take a look at the `examples` folder to see usage.
-
-```shell
-export OPENAI_API_KEY="your-openai-api-key"
-export ANTHROPIC_API_KEY="your-anthropic-api-key"
-```
+[**⬇ macOS (Apple Silicon)**](https://github.com/andrewyng/aisuite/releases/latest/download/OpenCoworker-macos-arm64.dmg) &nbsp;·&nbsp; [**⬇ Windows 10/11 (x64)**](https://github.com/andrewyng/aisuite/releases/latest/download/OpenCoworker-windows-setup.exe) &nbsp;·&nbsp; [OpenCoworker quickstart](docs/opencoworker-quickstart.md)
 
 ---
 
@@ -103,7 +88,7 @@ for model in models:
     print(response.choices[0].message.content)
 ```
 
-For the list of supported providers, see the `aisuite/providers/` directory (`<provider>_provider.py`). For more examples, check out the `examples` directory, which contains several runnable notebooks.
+**→ Quickstart:** [docs/chat-completions-quickstart.md](docs/chat-completions-quickstart.md) — install, key setup, local models, and more examples.
 
 ---
 
@@ -187,7 +172,9 @@ response = client.chat.completions.create(
 print(response.choices[0].message.content)
 ```
 
-For reusable connections, security filters, and tool prefixing, use the explicit `MCPClient` — see [docs/mcp-tools.md](docs/mcp-tools.md) and `examples/mcp_tools_example.ipynb`.
+For reusable connections, security filters, and tool prefixing, use the explicit `MCPClient`.
+
+**→ Quickstart:** [docs/agents-quickstart.md](docs/agents-quickstart.md) — manual tool handling, the full Agents API, policies, state stores, and MCP in depth.
 
 ---
 
@@ -199,6 +186,8 @@ For reusable connections, security filters, and tool prefixing, use the explicit
 [**⬇ Download for macOS**](https://github.com/andrewyng/aisuite/releases/latest/download/OpenCoworker-macos-arm64.dmg) (Apple Silicon) &nbsp;·&nbsp; [**⬇ Download for Windows**](https://github.com/andrewyng/aisuite/releases/latest/download/OpenCoworker-windows-setup.exe) (10/11 x64)
 
 Its source lives in this repository under `platform/` — a working reference for building your own agent harness on aisuite.
+
+**→ Quickstart:** [docs/opencoworker-quickstart.md](docs/opencoworker-quickstart.md) — install, connect a model, first tasks, automations.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ You'll also need API keys for the providers you call — the [Chat Completions q
 
 ### The OpenCoworker app (desktop)
 
-No Python needed — download the installer and bring your own API key (or run local models with Ollama):
+Download the installer and bring your own API key (or run local models with Ollama):
 
 [**⬇ macOS (Apple Silicon)**](https://github.com/andrewyng/aisuite/releases/latest/download/OpenCoworker-macos-arm64.dmg) &nbsp;·&nbsp; [**⬇ Windows 10/11 (x64)**](https://github.com/andrewyng/aisuite/releases/latest/download/OpenCoworker-windows-setup.exe) &nbsp;·&nbsp; [OpenCoworker quickstart](docs/opencoworker-quickstart.md)
 
@@ -179,7 +179,7 @@ For reusable connections, security filters, and tool prefixing, use the explicit
 ---
 
 <a id="opencoworker"></a>
-## OpenCoworker — the stack, shipped as an app
+## OpenCoworker — an AI coworker on your desktop
 
 [OpenCoworker](https://www.opencoworker.app) is a desktop AI coworker built using aisuite — the Agents API, Toolkits, and MCP support above are the same machinery it runs in production. Point it at a folder, give it a task, and it researches, analyzes, and produces real files on your machine, with approvals before risky actions and your API keys stored locally.
 

--- a/README.md
+++ b/README.md
@@ -19,25 +19,23 @@
 [![PyPI](https://img.shields.io/pypi/v/aisuite)](https://pypi.org/project/aisuite/)
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
 
-`aisuite` is a lightweight Python library that provides a **unified API for working with multiple Generative AI providers**.  
-It offers a consistent interface for models from *OpenAI, Anthropic, Google, Hugging Face, AWS, Cohere, Mistral, Ollama, OpenRouter*, and others—abstracting away SDK differences, authentication details, and parameter variations.  
-Its design is modeled after OpenAI’s API style, making it instantly familiar and easy to adopt.
+`aisuite` is one open stack for building with LLMs — three layers, each useful on its own:
 
-`aisuite` lets developers build and **run LLM-based or agentic applications across providers** with minimal setup.  
-While it’s not a full-blown agents framework, it includes simple abstractions for creating standalone, lightweight agents.  
-It’s designed for low learning curve — so you can focus on building AI systems, not integrating APIs.
+```text
+┌───────────────────────────────────────────────┐
+│                 OpenCoworker                  │   agent harness for doing everyday tasks
+├───────────────────────────────────────────────┤
+│        Agents API  ·  Toolkits  ·  MCP        │   build agents across multiple LLMs
+├───────────────────────────────────────────────┤
+│             Chat Completions API              │   one API across multiple LLM providers
+├────────┬───────────┬────────┬────────┬────────┤
+│ OpenAI │ Anthropic │ Google │ Ollama │ Others │
+└────────┴───────────┴────────┴────────┴────────┘
+```
 
----
-
-## Key Features
-
-`aisuite` is designed to eliminate the complexity of working with multiple LLM providers while keeping your code simple and portable. Whether you're building a chatbot, an agentic application, or experimenting with different models, `aisuite` provides the abstractions you need without getting in your way.
-
-* **Unified API for multiple model providers** – Write your code once and run it with any supported provider. Switch between OpenAI, Anthropic, Google, and others with a single parameter change.
-* **Easy agentic app or agent creation** – Build multi-turn agentic applications using a single parameter `max_turns`. No need to manually manage tool execution loops.
-* **Pass Tool calls easily** – Pass real Python functions instead of JSON specs; aisuite handles schema generation and execution automatically.
-* **MCP tools** – Connect to MCP-based tools without writing boilerplate; aisuite handles connection, schema and execution seamlessly.
-* **Modular and extensible provider architecture** – Add support for new providers with minimal code. The plugin-style architecture makes extensions straightforward.
+* **[Chat Completions API](#chat-completions)** — a unified, OpenAI-style interface for *OpenAI, Anthropic, Google, Mistral, Hugging Face, AWS, Cohere, Ollama, OpenRouter*, and more. Swap providers by changing one string.
+* **[Agents API · Toolkits · MCP](#agents)** — give models real Python functions as tools, run multi-turn loops, attach ready-made toolkits (files, git, shell) or any MCP server, and govern it all with tool policies.
+* **[OpenCoworker](#opencoworker)** — a desktop AI coworker built using aisuite: the layers above, shipped as an app for everyday tasks.
 
 ---
 
@@ -71,23 +69,25 @@ install the provider-specific library either separately or when installing aisui
 The API Keys can be set as environment variables, or can be passed as config to the aisuite Client constructor.
 You can use tools like [`python-dotenv`](https://pypi.org/project/python-dotenv/) or [`direnv`](https://direnv.net/) to set the environment variables manually. Please take a look at the `examples` folder to see usage.
 
-Here is a short example of using `aisuite` to generate chat completion responses from gpt-4o and claude-3-5-sonnet.
-
-Set the API keys.
-
 ```shell
 export OPENAI_API_KEY="your-openai-api-key"
 export ANTHROPIC_API_KEY="your-anthropic-api-key"
-export OPENROUTER_API_KEY="your-openrouter-api-key"
 ```
 
-Use the python client.
+---
+
+<a id="chat-completions"></a>
+## Chat Completions — one API across providers
+
+The chat API provides a high-level abstraction for model interactions. It supports all core parameters (`temperature`, `max_tokens`, `tools`, etc.) in a provider-agnostic way, and standardizes request and response structures so you can focus on logic rather than SDK differences.
+
+Model names use the format `<provider>:<model-name>`; aisuite routes the call to the right provider with the right parameters:
 
 ```python
 import aisuite as ai
 client = ai.Client()
 
-models = ["openai:gpt-4o", "anthropic:claude-3-5-sonnet-20240620","openrouter:google/gemma-4-26b-a4b-it:free"]
+models = ["openai:gpt-4o", "anthropic:claude-3-5-sonnet-20240620"]
 
 messages = [
     {"role": "system", "content": "Respond in Pirate English."},
@@ -101,98 +101,23 @@ for model in models:
         temperature=0.75
     )
     print(response.choices[0].message.content)
-
 ```
 
-Note that the model name in the create() call uses the format - `<provider>:<model-name>`.
-`aisuite` will call the appropriate provider with the right parameters based on the provider value.
-For a list of provider values, you can look at the directory - `aisuite/providers/`. The list of supported providers are of the format - `<provider>_provider.py` in that directory. We welcome providers to add support to this library by adding an implementation file in this directory. Please see section below for how to contribute.
-
-For more examples, check out the `examples` directory where you will find several notebooks that you can run to experiment with the interface.
+For the list of supported providers, see the `aisuite/providers/` directory (`<provider>_provider.py`). For more examples, check out the `examples` directory, which contains several runnable notebooks.
 
 ---
 
-## Chat Completions
+<a id="agents"></a>
+## Agents — give models real tools
 
-The chat API provides a high-level abstraction for model interactions. It supports all core parameters (`temperature`, `max_tokens`, `tools`, etc.) in a provider-agnostic way.
+aisuite turns tool calling into a one-liner: pass plain Python functions and it generates the schemas, executes the calls, and feeds results back to the model.
 
-```python
-response = client.chat.completions.create(
-    model="google:gemini-pro",
-    messages=[{"role": "user", "content": "Summarize this paragraph."}],
-)
-print(response.choices[0].message.content)
-```
-
-`aisuite` standardizes request and response structures so you can focus on logic rather than SDK differences.
-
----
-
-## Tool Calling & Agentic apps
-
-`aisuite` provides a simple abstraction for tool/function calling that works across supported providers. This is in addition to the regular abstraction of passing JSON spec of the tool to the `tools` parameter. The tool calling abstraction makes it easy to use tools with different LLMs without changing your code.
-
-There are two ways to use tools with `aisuite`:
-
-### 1. Manual Tool Handling
-
-This is the default behavior when `max_turns` is not specified. In this mode, you have full control over the tool execution flow. You pass tools using the standard OpenAI JSON schema format, and `aisuite` returns the LLM's tool call requests in the response. You're then responsible for executing the tools, processing results, and sending them back to the model in subsequent requests.
-
-This approach is useful when you need:
-- Fine-grained control over tool execution logic
-- Custom error handling or validation before executing tools
-- The ability to selectively execute or skip certain tool calls
-- Integration with existing tool execution pipelines
-
-You can pass tools in the OpenAI tool format:
+### Tool calling with `max_turns`
 
 ```python
 def will_it_rain(location: str, time_of_day: str):
     """Check if it will rain in a location at a given time today.
-    
-    Args:
-        location (str): Name of the city
-        time_of_day (str): Time of the day in HH:MM format.
-    """
-    return "YES"
 
-tools = [{
-    "type": "function",
-    "function": {
-        "name": "will_it_rain",
-        "description": "Check if it will rain in a location at a given time today",
-        "parameters": {
-            "type": "object",
-            "properties": {
-                "location": {
-                    "type": "string",
-                    "description": "Name of the city"
-                },
-                "time_of_day": {
-                    "type": "string",
-                    "description": "Time of the day in HH:MM format."
-                }
-            },
-            "required": ["location", "time_of_day"]
-        }
-    }
-}]
-
-response = client.chat.completions.create(
-    model="openai:gpt-4o",
-    messages=messages,
-    tools=tools
-)
-```
-
-### 2. Automatic Tool Execution
-
-When `max_turns` is specified, you can pass a list of callable Python functions as the `tools` parameter. `aisuite` will automatically handle the tool calling flow:
-
-```python
-def will_it_rain(location: str, time_of_day: str):
-    """Check if it will rain in a location at a given time today.
-    
     Args:
         location (str): Name of the city
         time_of_day (str): Time of the day in HH:MM format.
@@ -200,55 +125,53 @@ def will_it_rain(location: str, time_of_day: str):
     return "YES"
 
 client = ai.Client()
-messages = [{
-    "role": "user",
-    "content": "I live in San Francisco. Can you check for weather "
-               "and plan an outdoor picnic for me at 2pm?"
-}]
-
-# Automatic tool execution with max_turns
 response = client.chat.completions.create(
     model="openai:gpt-4o",
-    messages=messages,
+    messages=[{
+        "role": "user",
+        "content": "I live in San Francisco. Can you check for weather "
+                   "and plan an outdoor picnic for me at 2pm?"
+    }],
     tools=[will_it_rain],
     max_turns=2  # Maximum number of back-and-forth tool calls
 )
 print(response.choices[0].message.content)
 ```
 
-When `max_turns` is specified, `aisuite` will:
-1. Send your message to the LLM
-2. Execute any tool calls the LLM requests
-3. Send the tool results back to the LLM
-4. Repeat until the conversation is complete or max_turns is reached
+With `max_turns` set, aisuite sends your message, executes any tool calls the model requests, returns the results to the model, and repeats until the conversation completes. `response.choices[0].intermediate_messages` carries the full tool interaction history if you want to continue the conversation.
 
-In addition to `response.choices[0].message`, there is an additional field `response.choices[0].intermediate_messages` which contains the list of all messages including tool interactions used. This can be used to continue the conversation with the model.
-For more detailed examples of tool calling, check out the `examples/tool_calling_abstraction.ipynb` notebook.
+Prefer full manual control? Omit `max_turns` and pass OpenAI-format JSON tool specs — aisuite returns the model's tool-call requests and you run the loop yourself. See `examples/tool_calling_abstraction.ipynb` for both styles.
 
-### Model Context Protocol (MCP) Integration
+### The Agents API
 
-`aisuite` natively supports **MCP**, a standard protocol that allows LLMs to securely call external tools and access data. You can connect to MCP servers—such as a filesystem or database—and expose their tools directly to your model.
-Read more about MCP here - https://modelcontextprotocol.io/docs/getting-started/intro
-
-Install aisuite with MCP support:
-
-```shell
-pip install 'aisuite[mcp]'
-```
-
-You'll also need an MCP server. For example, to use the filesystem server:
-
-```shell
-npm install -g @modelcontextprotocol/server-filesystem
-```
-
-There are two ways to use MCP tools with aisuite:
-
-#### Option 1: Config Dict Format (Recommended for Simple Use Cases)
+For longer-running, structured work there is a first-class Agents API: declare an agent once, run it with a `Runner`, and attach **toolkits** — prebuilt, sandboxed tool families for files, git, and shell:
 
 ```python
 import aisuite as ai
+from aisuite import Agent, Runner
 
+agent = Agent(
+    name="repo-helper",
+    model="anthropic:claude-sonnet-4-6",
+    instructions="You are a careful repo assistant. Use your tools to answer from the code.",
+    tools=[*ai.toolkits.files(root="."), *ai.toolkits.git(root=".")],
+)
+
+result = Runner.run(agent, "What changed in the last commit? Summarize in 3 bullets.")
+print(result.final_output)
+```
+
+The Agents API also gives you the pieces a production harness needs:
+
+* **Tool policies** — `RequireApprovalPolicy`, allow/deny lists, or your own callable deciding which tool calls run.
+* **State stores** — persist and resume runs (in-memory, file, or Postgres) and continue conversations across processes.
+* **Artifacts & tracing** — capture what an agent produced and every step it took along the way.
+
+### MCP tools
+
+aisuite natively supports the [Model Context Protocol](https://modelcontextprotocol.io/docs/getting-started/intro), so any MCP server's tools can be handed to a model without boilerplate (`pip install 'aisuite[mcp]'`):
+
+```python
 client = ai.Client()
 response = client.chat.completions.create(
     model="openai:gpt-4o",
@@ -261,37 +184,21 @@ response = client.chat.completions.create(
     }],
     max_turns=3
 )
-
 print(response.choices[0].message.content)
 ```
 
-#### Option 2: Explicit MCPClient (Recommended for Advanced Use Cases)
+For reusable connections, security filters, and tool prefixing, use the explicit `MCPClient` — see [docs/mcp-tools.md](docs/mcp-tools.md) and `examples/mcp_tools_example.ipynb`.
 
-```python
-import aisuite as ai
-from aisuite.mcp import MCPClient
+---
 
-# Create MCP client once, reuse across requests
-mcp = MCPClient(
-    command="npx",
-    args=["-y", "@modelcontextprotocol/server-filesystem", "/path/to/directory"]
-)
+<a id="opencoworker"></a>
+## OpenCoworker — the stack, shipped as an app
 
-# Use with aisuite
-client = ai.Client()
-response = client.chat.completions.create(
-    model="openai:gpt-4o",
-    messages=[{"role": "user", "content": "List the files"}],
-    tools=mcp.get_callable_tools(),
-    max_turns=3
-)
+[OpenCoworker](https://www.opencoworker.app) is a desktop AI coworker built using aisuite — the Agents API, Toolkits, and MCP support above are the same machinery it runs in production. Point it at a folder, give it a task, and it researches, analyzes, and produces real files on your machine, with approvals before risky actions and your API keys stored locally.
 
-print(response.choices[0].message.content)
-mcp.close()  # Clean up
-```
+[**⬇ Download for macOS**](https://github.com/andrewyng/aisuite/releases/latest/download/OpenCoworker-macos-arm64.dmg) (Apple Silicon) &nbsp;·&nbsp; [**⬇ Download for Windows**](https://github.com/andrewyng/aisuite/releases/latest/download/OpenCoworker-windows-setup.exe) (10/11 x64)
 
-For detailed usage (security filters, tool prefixing, and `MCPClient` management), see [docs/mcp-tools.md](docs/mcp-tools.md).
-For detailed examples, see `examples/mcp_tools_example.ipynb`.
+Its source lives in this repository under `platform/` — a working reference for building your own agent harness on aisuite.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@
 
 * **[Chat Completions API](#chat-completions)** — a unified, OpenAI-style interface for *OpenAI, Anthropic, Google, Mistral, Hugging Face, AWS, Cohere, Ollama, OpenRouter*, and more. Swap providers by changing one string.
 * **[Agents API · Toolkits · MCP](#agents)** — give models real Python functions as tools, run multi-turn loops, attach ready-made toolkits (files, git, shell) or any MCP server, and govern it all with tool policies.
-* **[OpenCoworker](#opencoworker)** — a desktop AI coworker built using aisuite: the layers above, shipped as an app for everyday tasks.
+* **[OpenCoworker](#opencoworker)** — a desktop AI coworker built using aisuite, shipped as an app for everyday tasks.
 
 ---
 
@@ -181,7 +181,7 @@ For reusable connections, security filters, and tool prefixing, use the explicit
 <a id="opencoworker"></a>
 ## OpenCoworker — an AI coworker on your desktop
 
-[OpenCoworker](https://www.opencoworker.app) is a desktop AI coworker built using aisuite — the Agents API, Toolkits, and MCP support above are the same machinery it runs in production. Point it at a folder, give it a task, and it researches, analyzes, and produces real files on your machine, with approvals before risky actions and your API keys stored locally.
+[OpenCoworker](https://www.opencoworker.app) is a desktop AI coworker built using aisuite. Point it at a folder, give it a task, and it researches, analyzes, and produces real files on your machine, with approvals before risky actions and your API keys stored locally.
 
 [**⬇ Download for macOS**](https://github.com/andrewyng/aisuite/releases/latest/download/OpenCoworker-macos-arm64.dmg) (Apple Silicon) &nbsp;·&nbsp; [**⬇ Download for Windows**](https://github.com/andrewyng/aisuite/releases/latest/download/OpenCoworker-windows-setup.exe) (10/11 x64)
 

--- a/docs/agents-quickstart.md
+++ b/docs/agents-quickstart.md
@@ -1,0 +1,139 @@
+# Agents quickstart
+
+Build agents across multiple LLMs: pass real Python functions as tools, run multi-turn loops, attach toolkits and MCP servers, and govern execution with policies.
+
+Start with the [Chat Completions quickstart](chat-completions-quickstart.md) if you haven't installed aisuite and set up keys yet.
+
+## Tool calling with `max_turns`
+
+Pass plain Python functions — aisuite generates the schemas from signatures and docstrings, executes the calls, and feeds results back to the model until it finishes (or `max_turns` is reached):
+
+```python
+import aisuite as ai
+
+def will_it_rain(location: str, time_of_day: str):
+    """Check if it will rain in a location at a given time today.
+
+    Args:
+        location (str): Name of the city
+        time_of_day (str): Time of the day in HH:MM format.
+    """
+    return "YES"
+
+client = ai.Client()
+response = client.chat.completions.create(
+    model="openai:gpt-4o",
+    messages=[{
+        "role": "user",
+        "content": "I live in San Francisco. Can you check for weather "
+                   "and plan an outdoor picnic for me at 2pm?"
+    }],
+    tools=[will_it_rain],
+    max_turns=2
+)
+print(response.choices[0].message.content)
+```
+
+`response.choices[0].intermediate_messages` carries the full tool-interaction history — append it to your messages to continue the conversation.
+
+## Manual tool handling
+
+Omit `max_turns` for full control of the loop: pass OpenAI-format JSON tool specs, and aisuite returns the model's tool-call requests for you to execute, validate, or filter yourself.
+
+```python
+tools = [{
+    "type": "function",
+    "function": {
+        "name": "will_it_rain",
+        "description": "Check if it will rain in a location at a given time today",
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "location": {"type": "string", "description": "Name of the city"},
+                "time_of_day": {"type": "string", "description": "Time of the day in HH:MM format."}
+            },
+            "required": ["location", "time_of_day"]
+        }
+    }
+}]
+
+response = client.chat.completions.create(
+    model="openai:gpt-4o",
+    messages=messages,
+    tools=tools
+)
+```
+
+This mode suits custom error handling, selective execution, or integrating an existing tool pipeline. Both styles are shown in [`examples/tool_calling_abstraction.ipynb`](../examples/tool_calling_abstraction.ipynb).
+
+## The Agents API
+
+For longer-running, structured work, declare an `Agent` once and run it with the `Runner`. **Toolkits** are prebuilt, sandboxed tool families — files, git, and shell — ready to attach:
+
+```python
+import aisuite as ai
+from aisuite import Agent, Runner
+
+agent = Agent(
+    name="repo-helper",
+    model="anthropic:claude-sonnet-4-6",
+    instructions="You are a careful repo assistant. Use your tools to answer from the code.",
+    tools=[*ai.toolkits.files(root="."), *ai.toolkits.git(root=".")],
+)
+
+result = Runner.run(agent, "What changed in the last commit? Summarize in 3 bullets.")
+print(result.final_output)
+```
+
+Pieces a production harness needs:
+
+- **Tool policies** — gate execution with `RequireApprovalPolicy`, `AllowToolsPolicy` / `DenyAllToolPolicy`, or any callable receiving a `ToolPolicyContext`.
+- **State stores** — persist runs and resume them across processes: `InMemoryStateStore`, `FileStateStore`, or `PostgresStateStore` with `thread_id`.
+- **Artifacts** — store what the agent produced (`FileArtifactStore`, `InMemoryArtifactStore`).
+- **Tracing** — every `RunResult` carries its steps, raw responses, and a `trace_id`; plug in trace sinks for observability.
+
+## MCP tools
+
+Any [Model Context Protocol](https://modelcontextprotocol.io/docs/getting-started/intro) server's tools can be handed to a model (`pip install 'aisuite[mcp]'`).
+
+Inline config for simple cases:
+
+```python
+response = client.chat.completions.create(
+    model="openai:gpt-4o",
+    messages=[{"role": "user", "content": "List the files in the current directory"}],
+    tools=[{
+        "type": "mcp",
+        "name": "filesystem",
+        "command": "npx",
+        "args": ["-y", "@modelcontextprotocol/server-filesystem", "/path/to/directory"]
+    }],
+    max_turns=3
+)
+```
+
+Or an explicit client you create once and reuse — with security filters and tool prefixing:
+
+```python
+from aisuite.mcp import MCPClient
+
+mcp = MCPClient(
+    command="npx",
+    args=["-y", "@modelcontextprotocol/server-filesystem", "/path/to/directory"]
+)
+
+response = client.chat.completions.create(
+    model="openai:gpt-4o",
+    messages=[{"role": "user", "content": "List the files"}],
+    tools=mcp.get_callable_tools(),
+    max_turns=3
+)
+mcp.close()
+```
+
+See [`examples/mcp_tools_example.ipynb`](../examples/mcp_tools_example.ipynb) for detailed usage.
+
+## Going further
+
+- Want this machinery as a ready-made desktop app? See the [OpenCoworker quickstart](opencoworker-quickstart.md).
+- OpenCoworker's source under [`platform/`](../platform/) is a working reference for building a full agent harness on these APIs.

--- a/docs/agents-quickstart.md
+++ b/docs/agents-quickstart.md
@@ -135,5 +135,5 @@ See [`examples/mcp_tools_example.ipynb`](../examples/mcp_tools_example.ipynb) fo
 
 ## Going further
 
-- Want this machinery as a ready-made desktop app? See the [OpenCoworker quickstart](opencoworker-quickstart.md).
-- OpenCoworker's source under [`platform/`](../platform/) is a working reference for building a full agent harness on these APIs.
+- Want a ready-made desktop AI coworker instead of building your own? See the [OpenCoworker quickstart](opencoworker-quickstart.md).
+- OpenCoworker's source under [`platform/`](../platform/) is a working reference for building a full agent harness with aisuite.

--- a/docs/chat-completions-quickstart.md
+++ b/docs/chat-completions-quickstart.md
@@ -1,0 +1,71 @@
+# Chat Completions quickstart
+
+One API across multiple LLM providers: write your code once, switch models by changing a string.
+
+## 1. Install
+
+```shell
+pip install aisuite               # base package, no provider SDKs
+pip install 'aisuite[anthropic]'  # with one provider's SDK
+pip install 'aisuite[all]'        # with every provider SDK
+```
+
+## 2. Set your API keys
+
+You need keys only for the providers you call. The [provider guides](../guides/README.md) walk through obtaining a key for each one.
+
+Set them as environment variables (tools like [`python-dotenv`](https://pypi.org/project/python-dotenv/) or [`direnv`](https://direnv.net/) help manage them):
+
+```shell
+export OPENAI_API_KEY="your-openai-api-key"
+export ANTHROPIC_API_KEY="your-anthropic-api-key"
+```
+
+Keys can also be passed programmatically to the `Client` constructor:
+
+```python
+client = ai.Client({"openai": {"api_key": "..."}})
+```
+
+## 3. Your first completions
+
+Model names use the format `<provider>:<model-name>` — aisuite routes each call to the right provider and translates parameters and responses:
+
+```python
+import aisuite as ai
+client = ai.Client()
+
+models = ["openai:gpt-4o", "anthropic:claude-3-5-sonnet-20240620"]
+
+messages = [
+    {"role": "system", "content": "Respond in Pirate English."},
+    {"role": "user", "content": "Tell me a joke."},
+]
+
+for model in models:
+    response = client.chat.completions.create(
+        model=model,
+        messages=messages,
+        temperature=0.75
+    )
+    print(response.choices[0].message.content)
+```
+
+Core parameters (`temperature`, `max_tokens`, `tools`, …) work provider-agnostically; aisuite maps them to each SDK's conventions.
+
+## Local models
+
+Run fully local via [Ollama](https://ollama.com) — no API key required:
+
+```python
+response = client.chat.completions.create(
+    model="ollama:llama3.3",
+    messages=[{"role": "user", "content": "Hello!"}],
+)
+```
+
+## Going further
+
+- The list of supported providers lives in [`aisuite/providers/`](../aisuite/providers/) (`<provider>_provider.py`).
+- Runnable notebooks live in [`examples/`](../examples/).
+- Ready to give the model tools? Continue with the [Agents quickstart](agents-quickstart.md).

--- a/docs/opencoworker-quickstart.md
+++ b/docs/opencoworker-quickstart.md
@@ -1,0 +1,50 @@
+# OpenCoworker quickstart
+
+[OpenCoworker](https://www.opencoworker.app) is a desktop AI coworker built using aisuite. Give it a folder and a task, and it works the way a colleague would — researching, analyzing, and producing real files on your machine.
+
+No Python required: it ships as a regular desktop app.
+
+## 1. Install
+
+| Platform | Download |
+|---|---|
+| macOS 13+ (Apple Silicon, M1 or later) | [OpenCoworker-macos-arm64.dmg](https://github.com/andrewyng/aisuite/releases/latest/download/OpenCoworker-macos-arm64.dmg) |
+| Windows 10/11 (x64) | [OpenCoworker-windows-setup.exe](https://github.com/andrewyng/aisuite/releases/latest/download/OpenCoworker-windows-setup.exe) |
+
+The macOS app is signed and notarized — it opens like any other app. On Windows, SmartScreen may warn on first run: choose **More info → Run anyway** (the build isn't Authenticode-signed yet).
+
+## 2. Connect a model
+
+On first launch, pick a provider and paste your API key — OpenAI, Anthropic (Claude), or Google (Gemini) — or select **Ollama** to run fully local with no key at all. Keys are stored on your machine and sent only to the provider you chose; there is no OpenCoworker server.
+
+You can connect several providers and switch models per conversation.
+
+## 3. Give it work
+
+Grant access to a folder (read-only or read-write) and ask in plain language. Some first tasks that show what it can do:
+
+- *"Organize this folder — group files by type and project, and rename the screenshots based on what's in them."*
+- *"Read the five vendor proposals in this folder and build me a comparison spreadsheet: pricing, terms, deadlines, red flags."*
+- *"Go through the receipts in this folder and produce a monthly expense report with totals by category."*
+
+Everything the agent produces is a real file in your folder. The built-in viewer previews documents, spreadsheets, images, and PDFs without leaving the app, and risky actions (shell commands, file writes outside granted folders) ask for your approval first.
+
+## 4. Automations
+
+Ask for recurring work and OpenCoworker schedules it:
+
+> *"Every weekday at 7am, search the web for news about my industry and write a one-page brief to my briefings folder."*
+
+Scheduled automations run while the app is running (enable *Launch at login* in settings to keep them going).
+
+## 5. Extend with MCP
+
+OpenCoworker speaks the Model Context Protocol. Add servers in **Manage → Integrations** using the same `mcpServers` JSON format as Claude Desktop and Cursor — stdio or HTTP, with per-tool approval controls.
+
+## Privacy
+
+Your API keys, your conversations, and your files stay on your machine. OpenCoworker has no backend — model calls go directly from your computer to the provider you configured.
+
+## For developers
+
+OpenCoworker's source lives in this repository under [`platform/`](../platform/). It is built on the [Agents API and Toolkits](agents-quickstart.md) — a working reference for building your own agent harness with aisuite.

--- a/docs/opencoworker-quickstart.md
+++ b/docs/opencoworker-quickstart.md
@@ -1,8 +1,6 @@
 # OpenCoworker quickstart
 
-[OpenCoworker](https://www.opencoworker.app) is a desktop AI coworker built using aisuite. Give it a folder and a task, and it works the way a colleague would — researching, analyzing, and producing real files on your machine.
-
-No Python required: it ships as a regular desktop app.
+[OpenCoworker](https://www.opencoworker.app) is a desktop AI coworker built using aisuite. Give it a folder and a task, and it works the way a colleague would — researching, analyzing, and producing reports, Pdfs, CSVs and HTML presentations on your machine.
 
 ## 1. Install
 
@@ -11,7 +9,7 @@ No Python required: it ships as a regular desktop app.
 | macOS 13+ (Apple Silicon, M1 or later) | [OpenCoworker-macos-arm64.dmg](https://github.com/andrewyng/aisuite/releases/latest/download/OpenCoworker-macos-arm64.dmg) |
 | Windows 10/11 (x64) | [OpenCoworker-windows-setup.exe](https://github.com/andrewyng/aisuite/releases/latest/download/OpenCoworker-windows-setup.exe) |
 
-The macOS app is signed and notarized — it opens like any other app. On Windows, SmartScreen may warn on first run: choose **More info → Run anyway** (the build isn't Authenticode-signed yet).
+NOTE: On Windows, SmartScreen may warn on first run: choose **More info → Run anyway** (the build isn't Authenticode-signed yet).
 
 ## 2. Connect a model
 
@@ -27,7 +25,7 @@ Grant access to a folder (read-only or read-write) and ask in plain language. So
 - *"Read the five vendor proposals in this folder and build me a comparison spreadsheet: pricing, terms, deadlines, red flags."*
 - *"Go through the receipts in this folder and produce a monthly expense report with totals by category."*
 
-Everything the agent produces is a real file in your folder. The built-in viewer previews documents, spreadsheets, images, and PDFs without leaving the app, and risky actions (shell commands, file writes outside granted folders) ask for your approval first.
+Everything the agent produces is saved to a scratch folder by default, but you can ask it to save it to a folder of your choice. The built-in viewer previews documents, spreadsheets, images, and PDFs without leaving the app, and risky actions (shell commands, file writes outside granted folders) ask for your approval first.
 
 ## 4. Automations
 

--- a/docs/opencoworker-quickstart.md
+++ b/docs/opencoworker-quickstart.md
@@ -47,4 +47,4 @@ Your API keys, your conversations, and your files stay on your machine. OpenCowo
 
 ## For developers
 
-OpenCoworker's source lives in this repository under [`platform/`](../platform/). It is built on the [Agents API and Toolkits](agents-quickstart.md) — a working reference for building your own agent harness with aisuite.
+OpenCoworker's source lives in this repository under [`platform/`](../platform/). It is built using aisuite (see the [Agents quickstart](agents-quickstart.md)) — a working reference for building your own agent harness.


### PR DESCRIPTION
First draft of the dev-friendly README rewrite: ASCII stack diagram + pillar table of contents, a new Agents API section (Runner, toolkits, policies, state stores — previously undocumented), an OpenCoworker section, and tightened Chat Completions/tools/MCP content.