### PR TITLE
Add 9 connectors to OpenCoworker: Linear, GitLab, Discord, Stripe, Asana, HubSpot, Dropbox, Box, QuickBooks

### DIFF
--- a/platform/coworker/connectors/descriptors.py
+++ b/platform/coworker/connectors/descriptors.py
@@ -93,6 +93,125 @@ def _validate_slack(creds: dict) -> ValidationResult:
     return ValidationResult(False, error=data.get("error") or "invalid bot token")
 
 
+def _validate_whoami(
+    method: str,
+    url: str,
+    *,
+    headers: dict,
+    identity: Callable[[dict], str],
+    json: Optional[dict] = None,
+) -> ValidationResult:
+    """Shared one-shot whoami check: 2xx + extractable identity, else a failure."""
+    import httpx
+
+    try:
+        resp = httpx.request(method, url, headers=headers, json=json, timeout=15)
+        data = resp.json()
+    except Exception as exc:
+        return ValidationResult(False, error=str(exc))
+    if resp.status_code >= 400:
+        detail = (
+            (data.get("message") or data.get("error") or data.get("error_summary"))
+            if isinstance(data, dict)
+            else None
+        )
+        return ValidationResult(False, error=str(detail or f"HTTP {resp.status_code}"))
+    try:
+        return ValidationResult(True, identity=str(identity(data)))
+    except Exception:
+        return ValidationResult(False, error="unexpected response from API")
+
+
+def _validate_linear(creds: dict) -> ValidationResult:
+    return _validate_whoami(
+        "POST",
+        "https://api.linear.app/graphql",
+        headers={
+            "Authorization": creds.get("api_key", ""),
+            "Content-Type": "application/json",
+        },
+        json={"query": "{ viewer { name } }"},
+        identity=lambda d: d["data"]["viewer"]["name"],
+    )
+
+
+def _validate_gitlab(creds: dict) -> ValidationResult:
+    base = str(creds.get("base_url") or "https://gitlab.com").rstrip("/")
+    return _validate_whoami(
+        "GET",
+        f"{base}/api/v4/user",
+        headers={"PRIVATE-TOKEN": creds.get("token", "")},
+        identity=lambda d: "@" + d["username"],
+    )
+
+
+def _validate_discord(creds: dict) -> ValidationResult:
+    return _validate_whoami(
+        "GET",
+        "https://discord.com/api/v10/users/@me",
+        headers={"Authorization": f"Bot {creds.get('bot_token', '')}"},
+        identity=lambda d: d["username"],
+    )
+
+
+def _validate_asana(creds: dict) -> ValidationResult:
+    return _validate_whoami(
+        "GET",
+        "https://app.asana.com/api/1.0/users/me",
+        headers={"Authorization": f"Bearer {creds.get('token', '')}"},
+        identity=lambda d: d["data"]["name"],
+    )
+
+
+def _validate_hubspot(creds: dict) -> ValidationResult:
+    return _validate_whoami(
+        "GET",
+        "https://api.hubapi.com/account-info/v3/details",
+        headers={"Authorization": f"Bearer {creds.get('token', '')}"},
+        identity=lambda d: f"portal {d['portalId']}",
+    )
+
+
+def _validate_dropbox(creds: dict) -> ValidationResult:
+    return _validate_whoami(
+        "POST",
+        "https://api.dropboxapi.com/2/users/get_current_account",
+        headers={"Authorization": f"Bearer {creds.get('access_token', '')}"},
+        identity=lambda d: d["email"],
+    )
+
+
+def _quickbooks_host(creds: dict) -> str:
+    env = str(creds.get("environment", "")).lower()
+    return (
+        "sandbox-quickbooks.api.intuit.com"
+        if env.startswith("sand")
+        else "quickbooks.api.intuit.com"
+    )
+
+
+def _validate_quickbooks(creds: dict) -> ValidationResult:
+    realm = creds.get("realm_id", "")
+    return _validate_whoami(
+        "GET",
+        f"https://{_quickbooks_host(creds)}/v3/company/{realm}/companyinfo/{realm}",
+        headers={
+            "Authorization": f"Bearer {creds.get('access_token', '')}",
+            "Accept": "application/json",
+        },
+        identity=lambda d: d["CompanyInfo"]["CompanyName"],
+    )
+
+
+def _validate_box(creds: dict) -> ValidationResult:
+    return _validate_whoami(
+        "GET",
+        "https://api.box.com/2.0/users/me",
+        headers={"Authorization": f"Bearer {creds.get('access_token', '')}"},
+        identity=lambda d: d["login"],
+    )
+
+
 _ALLOWED_FIELD = Field(
     key="allowed_users",
     label="Allowed user IDs",
@@ -346,6 +465,220 @@ DESCRIPTORS: list[ConnectorDescriptor] = [
             "Paste your subdomain, agent email, and API token below.",
         ],
         available=True,
+    ),
+    ConnectorDescriptor(
+        name="linear",
+        title="Linear",
+        icon="⟋",
+        blurb="Search, read, and create Linear issues.",
+        auth="api_token",
+        two_way=False,
+        fields=[
+            Field(
+                "api_key",
+                "API key",
+                secret=True,
+                help="Personal API key from Linear settings.",
+                placeholder="lin_api_…",
+            ),
+        ],
+        instructions=[
+            "In Linear, open Settings → Security & access → Personal API keys.",
+            "Create a key and paste it below.",
+        ],
+        validate=_validate_linear,
+    ),
+    ConnectorDescriptor(
+        name="gitlab",
+        title="GitLab",
+        icon="▲",
+        blurb="Work with issues and merge requests on GitLab.com or self-hosted.",
+        auth="token",
+        two_way=False,
+        fields=[
+            Field(
+                "base_url",
+                "GitLab URL",
+                required=False,
+                help="Leave empty for gitlab.com.",
+                placeholder="https://gitlab.example.com",
+            ),
+            Field(
+                "token",
+                "Personal access token",
+                secret=True,
+                help="Token with read_api scope (api for write actions).",
+                placeholder="glpat-…",
+            ),
+        ],
+        instructions=[
+            "Create a GitLab personal access token with the read_api scope (api for write actions).",
+            "For self-hosted GitLab, enter your instance URL; leave empty for gitlab.com.",
+        ],
+        validate=_validate_gitlab,
+    ),
+    ConnectorDescriptor(
+        name="discord",
+        title="Discord",
+        icon="✦",
+        blurb="Read channels and send messages through a Discord bot.",
+        auth="bot_token",
+        two_way=False,
+        fields=[
+            Field(
+                "bot_token",
+                "Bot token",
+                secret=True,
+                help="From the Bot tab of your Discord application.",
+            ),
+        ],
+        instructions=[
+            "Go to discord.com/developers/applications → New Application → Bot.",
+            "Copy the bot token and paste it below.",
+            "Use the OAuth2 URL generator to invite the bot to your server with Read/Send Messages permissions.",
+        ],
+        validate=_validate_discord,
+    ),
+    ConnectorDescriptor(
+        name="stripe",
+        title="Stripe",
+        icon="≋",
+        blurb="Read-only access to customers, charges, and invoices.",
+        auth="api_token",
+        two_way=False,
+        fields=[
+            Field(
+                "api_key",
+                "Restricted API key",
+                secret=True,
+                help="Read-only restricted key recommended.",
+                placeholder="rk_live_…",
+            ),
+        ],
+        instructions=[
+            "In the Stripe Dashboard, create a restricted API key with read access to Customers, Charges, and Invoices.",
+            "Paste the key below. The connector only exposes read tools.",
+        ],
+    ),
+    ConnectorDescriptor(
+        name="asana",
+        title="Asana",
+        icon="⊙",
+        blurb="Search tasks, read details, and create tasks.",
+        auth="token",
+        two_way=False,
+        fields=[
+            Field(
+                "token",
+                "Personal access token",
+                secret=True,
+                help="From the Asana developer console.",
+            ),
+        ],
+        instructions=[
+            "In Asana, open My Settings → Apps → Manage developer apps.",
+            "Create a personal access token and paste it below.",
+        ],
+        validate=_validate_asana,
+    ),
+    ConnectorDescriptor(
+        name="hubspot",
+        title="HubSpot",
+        icon="⊚",
+        blurb="Search CRM contacts, companies, and deals; create contacts.",
+        auth="token",
+        two_way=False,
+        fields=[
+            Field(
+                "token",
+                "Private app token",
+                secret=True,
+                help="Access token of a HubSpot private app.",
+                placeholder="pat-…",
+            ),
+        ],
+        instructions=[
+            "In HubSpot, go to Settings → Integrations → Private Apps and create an app.",
+            "Grant CRM object read scopes (and crm.objects.contacts.write to create contacts).",
+            "Copy the access token and paste it below.",
+        ],
+        validate=_validate_hubspot,
+    ),
+    ConnectorDescriptor(
+        name="dropbox",
+        title="Dropbox",
+        icon="▣",
+        blurb="Search, browse, and read files in Dropbox.",
+        auth="oauth",
+        two_way=False,
+        fields=[
+            Field(
+                "access_token",
+                "OAuth access token",
+                secret=True,
+                help="Dropbox token with files.metadata.read and files.content.read scopes.",
+            ),
+        ],
+        instructions=[
+            "Create an app in the Dropbox App Console with files.metadata.read and files.content.read scopes.",
+            "Generate an access token and paste it below. Managed sign-in will replace this manual step later.",
+        ],
+        validate=_validate_dropbox,
+    ),
+    ConnectorDescriptor(
+        name="box",
+        title="Box",
+        icon="▢",
+        blurb="Search, browse, and read files in Box.",
+        auth="oauth",
+        two_way=False,
+        fields=[
+            Field(
+                "access_token",
+                "OAuth access token",
+                secret=True,
+                help="Box developer token or OAuth access token.",
+            ),
+        ],
+        instructions=[
+            "Create a Box app at app.box.com/developers/console.",
+            "Generate a developer token (or OAuth access token) and paste it below. Managed sign-in will replace this manual step later.",
+        ],
+        validate=_validate_box,
+    ),
+    ConnectorDescriptor(
+        name="quickbooks",
+        title="QuickBooks",
+        icon="◴",
+        blurb="Read-only access to customers, invoices, and financial reports.",
+        auth="oauth",
+        two_way=False,
+        fields=[
+            Field(
+                "access_token",
+                "OAuth access token",
+                secret=True,
+                help="Intuit OAuth token with the com.intuit.quickbooks.accounting scope. Expires hourly.",
+            ),
+            Field(
+                "realm_id",
+                "Company ID (realm ID)",
+                help="Shown during OAuth authorization and in the developer playground.",
+            ),
+            Field(
+                "environment",
+                "Environment",
+                required=False,
+                help="production (default) or sandbox.",
+                placeholder="production",
+            ),
+        ],
+        instructions=[
+            "Create an app at developer.intuit.com and authorize it against your company (the OAuth playground works for testing).",
+            "Copy the access token and the company ID (realm ID) and paste them below.",
+            "Intuit access tokens expire after about an hour. Managed sign-in will replace this manual step later.",
+        ],
+        validate=_validate_quickbooks,
     ),
 ]
 

--- a/platform/coworker/connectors/integration_tools.py
+++ b/platform/coworker/connectors/integration_tools.py
@@ -8,10 +8,12 @@ access-token fields without changing the tool surface.
 from __future__ import annotations
 
 import base64
+import json
 import re
 from email.message import EmailMessage
 from html.parser import HTMLParser
 from typing import Any, Callable, Optional
+from urllib.parse import quote
 
 import aisuite as ai
 
@@ -151,6 +153,38 @@ def _basic_auth(email: str, token: str) -> tuple[str, str]:
 
 def _atlassian_base(profile: dict[str, Any]) -> str:
     return str(profile.get("base_url", "")).rstrip("/")
+
+
+def _bearer_headers(token: str) -> dict[str, str]:
+    return {"Authorization": f"Bearer {token}", "Accept": "application/json"}
+
+
+def _gitlab_api(profile: dict[str, Any]) -> str:
+    base = str(profile.get("base_url") or "https://gitlab.com").rstrip("/")
+    return f"{base}/api/v4"
+
+
+def _linear_gql(api_key: str, query: str, variables: dict[str, Any]) -> dict[str, Any]:
+    return _request(
+        "POST",
+        "https://api.linear.app/graphql",
+        headers={"Authorization": api_key, "Content-Type": "application/json"},
+        json={"query": query, "variables": variables},
+    )
+
+
+def _clamp(n: Any, default: int = 10, ceiling: int = 20) -> int:
+    return max(1, min(int(n or default), ceiling))
+
+
+def _qbo_base(profile: dict[str, Any]) -> str:
+    env = str(profile.get("environment", "")).lower()
+    host = (
+        "sandbox-quickbooks.api.intuit.com"
+        if env.startswith("sand")
+        else "quickbooks.api.intuit.com"
+    )
+    return f"https://{host}/v3/company/{profile['realm_id']}"
 
 
 def make_integration_tools(
@@ -978,6 +1012,891 @@ def make_integration_tools(
             ),
             approval=True,
             caps=["zendesk", "write"],
+        )
+    )
+
+    def linear_search_issues(query: str, max_results: int = 10) -> dict[str, Any]:
+        profile, err = _profile(secrets, "linear", "api_key")
+        if err:
+            return err
+        gql = (
+            "query($term: String!, $first: Int!) {"
+            " searchIssues(term: $term, first: $first) {"
+            " nodes { identifier title url state { name } assignee { name } } } }"
+        )
+        return _linear_gql(
+            profile["api_key"], gql, {"term": query, "first": _clamp(max_results)}
+        )
+
+    linear_search_issues.__name__ = "linear_search_issues"
+    tools.append(
+        _attach(
+            linear_search_issues,
+            _schema(
+                "linear_search_issues",
+                "Search Linear issues by text.",
+                {"query": {"type": "string"}, "max_results": {"type": "integer"}},
+                ["query"],
+            ),
+            caps=["linear", "read"],
+        )
+    )
+
+    def linear_get_issue(issue_id: str) -> dict[str, Any]:
+        profile, err = _profile(secrets, "linear", "api_key")
+        if err:
+            return err
+        gql = (
+            "query($id: String!) { issue(id: $id) {"
+            " identifier title description url state { name } assignee { name }"
+            " comments { nodes { body user { name } } } } }"
+        )
+        return _linear_gql(profile["api_key"], gql, {"id": issue_id})
+
+    linear_get_issue.__name__ = "linear_get_issue"
+    tools.append(
+        _attach(
+            linear_get_issue,
+            _schema(
+                "linear_get_issue",
+                "Read a Linear issue (with comments) by ID or key like ENG-123.",
+                {"issue_id": {"type": "string"}},
+                ["issue_id"],
+            ),
+            caps=["linear", "read"],
+        )
+    )
+
+    def linear_list_teams() -> dict[str, Any]:
+        profile, err = _profile(secrets, "linear", "api_key")
+        if err:
+            return err
+        return _linear_gql(
+            profile["api_key"], "{ teams { nodes { id key name } } }", {}
+        )
+
+    linear_list_teams.__name__ = "linear_list_teams"
+    tools.append(
+        _attach(
+            linear_list_teams,
+            _schema(
+                "linear_list_teams",
+                "List Linear teams (IDs are needed to create issues).",
+                {},
+                [],
+            ),
+            caps=["linear", "read"],
+        )
+    )
+
+    def linear_create_issue(
+        team_id: str, title: str, description: str = ""
+    ) -> dict[str, Any]:
+        profile, err = _profile(secrets, "linear", "api_key")
+        if err:
+            return err
+        gql = (
+            "mutation($input: IssueCreateInput!) { issueCreate(input: $input) {"
+            " success issue { identifier url } } }"
+        )
+        return _linear_gql(
+            profile["api_key"],
+            gql,
+            {"input": {"teamId": team_id, "title": title, "description": description}},
+        )
+
+    linear_create_issue.__name__ = "linear_create_issue"
+    tools.append(
+        _attach(
+            linear_create_issue,
+            _schema(
+                "linear_create_issue",
+                "Create a Linear issue. Get team_id from linear_list_teams. Requires user approval.",
+                {
+                    "team_id": {"type": "string"},
+                    "title": {"type": "string"},
+                    "description": {"type": "string"},
+                },
+                ["team_id", "title"],
+            ),
+            approval=True,
+            caps=["linear", "write"],
+        )
+    )
+
+    def gitlab_search(
+        query: str, scope: str = "issues", max_results: int = 10
+    ) -> dict[str, Any]:
+        profile, err = _profile(secrets, "gitlab", "token")
+        if err:
+            return err
+        kind = scope if scope in ("projects", "issues", "merge_requests") else "issues"
+        return _request(
+            "GET",
+            f"{_gitlab_api(profile)}/search",
+            headers={"PRIVATE-TOKEN": profile["token"]},
+            params={"scope": kind, "search": query, "per_page": _clamp(max_results)},
+        )
+
+    gitlab_search.__name__ = "gitlab_search"
+    tools.append(
+        _attach(
+            gitlab_search,
+            _schema(
+                "gitlab_search",
+                "Search GitLab projects, issues, or merge_requests (scope).",
+                {
+                    "query": {"type": "string"},
+                    "scope": {"type": "string"},
+                    "max_results": {"type": "integer"},
+                },
+                ["query"],
+            ),
+            caps=["gitlab", "read"],
+        )
+    )
+
+    def gitlab_get_issue(project: str, issue_iid: int) -> dict[str, Any]:
+        profile, err = _profile(secrets, "gitlab", "token")
+        if err:
+            return err
+        return _request(
+            "GET",
+            f"{_gitlab_api(profile)}/projects/{quote(project, safe='')}/issues/{issue_iid}",
+            headers={"PRIVATE-TOKEN": profile["token"]},
+        )
+
+    gitlab_get_issue.__name__ = "gitlab_get_issue"
+    tools.append(
+        _attach(
+            gitlab_get_issue,
+            _schema(
+                "gitlab_get_issue",
+                "Read a GitLab issue. project is an ID or full path like group/repo.",
+                {"project": {"type": "string"}, "issue_iid": {"type": "integer"}},
+                ["project", "issue_iid"],
+            ),
+            caps=["gitlab", "read"],
+        )
+    )
+
+    def gitlab_get_merge_request(project: str, mr_iid: int) -> dict[str, Any]:
+        profile, err = _profile(secrets, "gitlab", "token")
+        if err:
+            return err
+        return _request(
+            "GET",
+            f"{_gitlab_api(profile)}/projects/{quote(project, safe='')}/merge_requests/{mr_iid}",
+            headers={"PRIVATE-TOKEN": profile["token"]},
+        )
+
+    gitlab_get_merge_request.__name__ = "gitlab_get_merge_request"
+    tools.append(
+        _attach(
+            gitlab_get_merge_request,
+            _schema(
+                "gitlab_get_merge_request",
+                "Read a GitLab merge request. project is an ID or full path like group/repo.",
+                {"project": {"type": "string"}, "mr_iid": {"type": "integer"}},
+                ["project", "mr_iid"],
+            ),
+            caps=["gitlab", "read"],
+        )
+    )
+
+    def gitlab_create_issue(
+        project: str, title: str, description: str = ""
+    ) -> dict[str, Any]:
+        profile, err = _profile(secrets, "gitlab", "token")
+        if err:
+            return err
+        return _request(
+            "POST",
+            f"{_gitlab_api(profile)}/projects/{quote(project, safe='')}/issues",
+            headers={"PRIVATE-TOKEN": profile["token"]},
+            json={"title": title, "description": description},
+        )
+
+    gitlab_create_issue.__name__ = "gitlab_create_issue"
+    tools.append(
+        _attach(
+            gitlab_create_issue,
+            _schema(
+                "gitlab_create_issue",
+                "Create a GitLab issue. Requires user approval.",
+                {
+                    "project": {"type": "string"},
+                    "title": {"type": "string"},
+                    "description": {"type": "string"},
+                },
+                ["project", "title"],
+            ),
+            approval=True,
+            caps=["gitlab", "write"],
+        )
+    )
+
+    def discord_list_channels(guild_id: str) -> dict[str, Any]:
+        profile, err = _profile(secrets, "discord", "bot_token")
+        if err:
+            return err
+        return _request(
+            "GET",
+            f"https://discord.com/api/v10/guilds/{guild_id}/channels",
+            headers={"Authorization": f"Bot {profile['bot_token']}"},
+        )
+
+    discord_list_channels.__name__ = "discord_list_channels"
+    tools.append(
+        _attach(
+            discord_list_channels,
+            _schema(
+                "discord_list_channels",
+                "List channels in a Discord server (guild).",
+                {"guild_id": {"type": "string"}},
+                ["guild_id"],
+            ),
+            caps=["discord", "read"],
+        )
+    )
+
+    def discord_read_messages(channel_id: str, max_results: int = 10) -> dict[str, Any]:
+        profile, err = _profile(secrets, "discord", "bot_token")
+        if err:
+            return err
+        return _request(
+            "GET",
+            f"https://discord.com/api/v10/channels/{channel_id}/messages",
+            headers={"Authorization": f"Bot {profile['bot_token']}"},
+            params={"limit": _clamp(max_results, ceiling=50)},
+        )
+
+    discord_read_messages.__name__ = "discord_read_messages"
+    tools.append(
+        _attach(
+            discord_read_messages,
+            _schema(
+                "discord_read_messages",
+                "Read recent messages from a Discord channel.",
+                {"channel_id": {"type": "string"}, "max_results": {"type": "integer"}},
+                ["channel_id"],
+            ),
+            caps=["discord", "read"],
+        )
+    )
+
+    def discord_send_message(channel_id: str, content: str) -> dict[str, Any]:
+        profile, err = _profile(secrets, "discord", "bot_token")
+        if err:
+            return err
+        return _request(
+            "POST",
+            f"https://discord.com/api/v10/channels/{channel_id}/messages",
+            headers={"Authorization": f"Bot {profile['bot_token']}"},
+            json={"content": content[:2000]},
+        )
+
+    discord_send_message.__name__ = "discord_send_message"
+    tools.append(
+        _attach(
+            discord_send_message,
+            _schema(
+                "discord_send_message",
+                "Send a message to a Discord channel. Requires user approval.",
+                {"channel_id": {"type": "string"}, "content": {"type": "string"}},
+                ["channel_id", "content"],
+            ),
+            approval=True,
+            caps=["discord", "write"],
+        )
+    )
+
+    def stripe_search_customers(query: str, max_results: int = 10) -> dict[str, Any]:
+        profile, err = _profile(secrets, "stripe", "api_key")
+        if err:
+            return err
+        return _request(
+            "GET",
+            "https://api.stripe.com/v1/customers/search",
+            headers=_bearer_headers(profile["api_key"]),
+            params={"query": query, "limit": _clamp(max_results)},
+        )
+
+    stripe_search_customers.__name__ = "stripe_search_customers"
+    tools.append(
+        _attach(
+            stripe_search_customers,
+            _schema(
+                "stripe_search_customers",
+                "Search Stripe customers. Query uses Stripe search syntax, e.g. email:'jane@example.com' or name~'Jane'.",
+                {"query": {"type": "string"}, "max_results": {"type": "integer"}},
+                ["query"],
+            ),
+            caps=["stripe", "read"],
+        )
+    )
+
+    def stripe_list_charges(
+        customer_id: str = "", max_results: int = 10
+    ) -> dict[str, Any]:
+        profile, err = _profile(secrets, "stripe", "api_key")
+        if err:
+            return err
+        params: dict[str, Any] = {"limit": _clamp(max_results)}
+        if customer_id:
+            params["customer"] = customer_id
+        return _request(
+            "GET",
+            "https://api.stripe.com/v1/charges",
+            headers=_bearer_headers(profile["api_key"]),
+            params=params,
+        )
+
+    stripe_list_charges.__name__ = "stripe_list_charges"
+    tools.append(
+        _attach(
+            stripe_list_charges,
+            _schema(
+                "stripe_list_charges",
+                "List Stripe charges, optionally for one customer.",
+                {"customer_id": {"type": "string"}, "max_results": {"type": "integer"}},
+                [],
+            ),
+            caps=["stripe", "read"],
+        )
+    )
+
+    def stripe_list_invoices(
+        customer_id: str = "", max_results: int = 10
+    ) -> dict[str, Any]:
+        profile, err = _profile(secrets, "stripe", "api_key")
+        if err:
+            return err
+        params: dict[str, Any] = {"limit": _clamp(max_results)}
+        if customer_id:
+            params["customer"] = customer_id
+        return _request(
+            "GET",
+            "https://api.stripe.com/v1/invoices",
+            headers=_bearer_headers(profile["api_key"]),
+            params=params,
+        )
+
+    stripe_list_invoices.__name__ = "stripe_list_invoices"
+    tools.append(
+        _attach(
+            stripe_list_invoices,
+            _schema(
+                "stripe_list_invoices",
+                "List Stripe invoices, optionally for one customer.",
+                {"customer_id": {"type": "string"}, "max_results": {"type": "integer"}},
+                [],
+            ),
+            caps=["stripe", "read"],
+        )
+    )
+
+    def asana_list_workspaces() -> dict[str, Any]:
+        profile, err = _profile(secrets, "asana", "token")
+        if err:
+            return err
+        return _request(
+            "GET",
+            "https://app.asana.com/api/1.0/workspaces",
+            headers=_bearer_headers(profile["token"]),
+        )
+
+    asana_list_workspaces.__name__ = "asana_list_workspaces"
+    tools.append(
+        _attach(
+            asana_list_workspaces,
+            _schema(
+                "asana_list_workspaces",
+                "List Asana workspaces (GIDs are needed to search tasks).",
+                {},
+                [],
+            ),
+            caps=["asana", "read"],
+        )
+    )
+
+    def asana_search_tasks(
+        workspace_gid: str, query: str, max_results: int = 10
+    ) -> dict[str, Any]:
+        profile, err = _profile(secrets, "asana", "token")
+        if err:
+            return err
+        return _request(
+            "GET",
+            f"https://app.asana.com/api/1.0/workspaces/{workspace_gid}/typeahead",
+            headers=_bearer_headers(profile["token"]),
+            params={
+                "resource_type": "task",
+                "query": query,
+                "count": _clamp(max_results),
+            },
+        )
+
+    asana_search_tasks.__name__ = "asana_search_tasks"
+    tools.append(
+        _attach(
+            asana_search_tasks,
+            _schema(
+                "asana_search_tasks",
+                "Search Asana tasks by name in a workspace. Get workspace_gid from asana_list_workspaces.",
+                {
+                    "workspace_gid": {"type": "string"},
+                    "query": {"type": "string"},
+                    "max_results": {"type": "integer"},
+                },
+                ["workspace_gid", "query"],
+            ),
+            caps=["asana", "read"],
+        )
+    )
+
+    def asana_get_task(task_gid: str) -> dict[str, Any]:
+        profile, err = _profile(secrets, "asana", "token")
+        if err:
+            return err
+        return _request(
+            "GET",
+            f"https://app.asana.com/api/1.0/tasks/{task_gid}",
+            headers=_bearer_headers(profile["token"]),
+        )
+
+    asana_get_task.__name__ = "asana_get_task"
+    tools.append(
+        _attach(
+            asana_get_task,
+            _schema(
+                "asana_get_task",
+                "Read an Asana task.",
+                {"task_gid": {"type": "string"}},
+                ["task_gid"],
+            ),
+            caps=["asana", "read"],
+        )
+    )
+
+    def asana_create_task(
+        project_gid: str, name: str, notes: str = ""
+    ) -> dict[str, Any]:
+        profile, err = _profile(secrets, "asana", "token")
+        if err:
+            return err
+        return _request(
+            "POST",
+            "https://app.asana.com/api/1.0/tasks",
+            headers=_bearer_headers(profile["token"]),
+            json={"data": {"name": name, "notes": notes, "projects": [project_gid]}},
+        )
+
+    asana_create_task.__name__ = "asana_create_task"
+    tools.append(
+        _attach(
+            asana_create_task,
+            _schema(
+                "asana_create_task",
+                "Create an Asana task in a project. Requires user approval.",
+                {
+                    "project_gid": {"type": "string"},
+                    "name": {"type": "string"},
+                    "notes": {"type": "string"},
+                },
+                ["project_gid", "name"],
+            ),
+            approval=True,
+            caps=["asana", "write"],
+        )
+    )
+
+    def hubspot_search(
+        query: str, object_type: str = "contacts", max_results: int = 10
+    ) -> dict[str, Any]:
+        profile, err = _profile(secrets, "hubspot", "token")
+        if err:
+            return err
+        kind = (
+            object_type
+            if object_type in ("contacts", "companies", "deals", "tickets")
+            else "contacts"
+        )
+        return _request(
+            "POST",
+            f"https://api.hubapi.com/crm/v3/objects/{kind}/search",
+            headers=_bearer_headers(profile["token"]),
+            json={"query": query, "limit": _clamp(max_results)},
+        )
+
+    hubspot_search.__name__ = "hubspot_search"
+    tools.append(
+        _attach(
+            hubspot_search,
+            _schema(
+                "hubspot_search",
+                "Search HubSpot CRM contacts, companies, deals, or tickets (object_type).",
+                {
+                    "query": {"type": "string"},
+                    "object_type": {"type": "string"},
+                    "max_results": {"type": "integer"},
+                },
+                ["query"],
+            ),
+            caps=["hubspot", "read"],
+        )
+    )
+
+    def hubspot_get_object(object_type: str, object_id: str) -> dict[str, Any]:
+        profile, err = _profile(secrets, "hubspot", "token")
+        if err:
+            return err
+        kind = (
+            object_type
+            if object_type in ("contacts", "companies", "deals", "tickets")
+            else "contacts"
+        )
+        return _request(
+            "GET",
+            f"https://api.hubapi.com/crm/v3/objects/{kind}/{object_id}",
+            headers=_bearer_headers(profile["token"]),
+        )
+
+    hubspot_get_object.__name__ = "hubspot_get_object"
+    tools.append(
+        _attach(
+            hubspot_get_object,
+            _schema(
+                "hubspot_get_object",
+                "Read a HubSpot CRM record by ID.",
+                {"object_type": {"type": "string"}, "object_id": {"type": "string"}},
+                ["object_type", "object_id"],
+            ),
+            caps=["hubspot", "read"],
+        )
+    )
+
+    def hubspot_create_contact(
+        email: str, first_name: str = "", last_name: str = ""
+    ) -> dict[str, Any]:
+        profile, err = _profile(secrets, "hubspot", "token")
+        if err:
+            return err
+        props = {"email": email}
+        if first_name:
+            props["firstname"] = first_name
+        if last_name:
+            props["lastname"] = last_name
+        return _request(
+            "POST",
+            "https://api.hubapi.com/crm/v3/objects/contacts",
+            headers=_bearer_headers(profile["token"]),
+            json={"properties": props},
+        )
+
+    hubspot_create_contact.__name__ = "hubspot_create_contact"
+    tools.append(
+        _attach(
+            hubspot_create_contact,
+            _schema(
+                "hubspot_create_contact",
+                "Create a HubSpot contact. Requires user approval.",
+                {
+                    "email": {"type": "string"},
+                    "first_name": {"type": "string"},
+                    "last_name": {"type": "string"},
+                },
+                ["email"],
+            ),
+            approval=True,
+            caps=["hubspot", "write"],
+        )
+    )
+
+    def _dropbox_path(path: str) -> str:
+        path = (path or "").strip()
+        if path and not path.startswith("/"):
+            path = "/" + path
+        return path
+
+    def dropbox_search(query: str, max_results: int = 10) -> dict[str, Any]:
+        profile, err = _profile(secrets, "dropbox", "access_token")
+        if err:
+            return err
+        return _request(
+            "POST",
+            "https://api.dropboxapi.com/2/files/search_v2",
+            headers=_bearer_headers(profile["access_token"]),
+            json={"query": query, "options": {"max_results": _clamp(max_results)}},
+        )
+
+    dropbox_search.__name__ = "dropbox_search"
+    tools.append(
+        _attach(
+            dropbox_search,
+            _schema(
+                "dropbox_search",
+                "Search Dropbox files and folders by name/content.",
+                {"query": {"type": "string"}, "max_results": {"type": "integer"}},
+                ["query"],
+            ),
+            caps=["dropbox", "read"],
+        )
+    )
+
+    def dropbox_list_folder(path: str = "") -> dict[str, Any]:
+        profile, err = _profile(secrets, "dropbox", "access_token")
+        if err:
+            return err
+        return _request(
+            "POST",
+            "https://api.dropboxapi.com/2/files/list_folder",
+            headers=_bearer_headers(profile["access_token"]),
+            json={"path": _dropbox_path(path)},
+        )
+
+    dropbox_list_folder.__name__ = "dropbox_list_folder"
+    tools.append(
+        _attach(
+            dropbox_list_folder,
+            _schema(
+                "dropbox_list_folder",
+                "List a Dropbox folder. Empty path is the root.",
+                {"path": {"type": "string"}},
+                [],
+            ),
+            caps=["dropbox", "read"],
+        )
+    )
+
+    def dropbox_read_file(path: str, max_chars: int = 20000) -> dict[str, Any]:
+        profile, err = _profile(secrets, "dropbox", "access_token")
+        if err:
+            return err
+        out = _request(
+            "POST",
+            "https://content.dropboxapi.com/2/files/download",
+            headers={
+                "Authorization": f"Bearer {profile['access_token']}",
+                "Dropbox-API-Arg": json.dumps({"path": _dropbox_path(path)}),
+            },
+        )
+        if "error" in out:
+            return out
+        text = out["data"] if isinstance(out["data"], str) else str(out["data"])
+        cap = max(1, min(int(max_chars or 20000), 100000))
+        return {"path": path, "text": text[:cap], "truncated": len(text) > cap}
+
+    dropbox_read_file.__name__ = "dropbox_read_file"
+    tools.append(
+        _attach(
+            dropbox_read_file,
+            _schema(
+                "dropbox_read_file",
+                "Read a text file from Dropbox by path.",
+                {"path": {"type": "string"}, "max_chars": {"type": "integer"}},
+                ["path"],
+            ),
+            caps=["dropbox", "read"],
+        )
+    )
+
+    def box_search(query: str, max_results: int = 10) -> dict[str, Any]:
+        profile, err = _profile(secrets, "box", "access_token")
+        if err:
+            return err
+        return _request(
+            "GET",
+            "https://api.box.com/2.0/search",
+            headers=_bearer_headers(profile["access_token"]),
+            params={"query": query, "limit": _clamp(max_results)},
+        )
+
+    box_search.__name__ = "box_search"
+    tools.append(
+        _attach(
+            box_search,
+            _schema(
+                "box_search",
+                "Search Box files and folders.",
+                {"query": {"type": "string"}, "max_results": {"type": "integer"}},
+                ["query"],
+            ),
+            caps=["box", "read"],
+        )
+    )
+
+    def box_list_folder(folder_id: str = "0") -> dict[str, Any]:
+        profile, err = _profile(secrets, "box", "access_token")
+        if err:
+            return err
+        return _request(
+            "GET",
+            f"https://api.box.com/2.0/folders/{folder_id}/items",
+            headers=_bearer_headers(profile["access_token"]),
+        )
+
+    box_list_folder.__name__ = "box_list_folder"
+    tools.append(
+        _attach(
+            box_list_folder,
+            _schema(
+                "box_list_folder",
+                "List items in a Box folder. Folder '0' is the root.",
+                {"folder_id": {"type": "string"}},
+                [],
+            ),
+            caps=["box", "read"],
+        )
+    )
+
+    def box_read_file(file_id: str, max_chars: int = 20000) -> dict[str, Any]:
+        profile, err = _profile(secrets, "box", "access_token")
+        if err:
+            return err
+        out = _request(
+            "GET",
+            f"https://api.box.com/2.0/files/{file_id}/content",
+            headers=_bearer_headers(profile["access_token"]),
+        )
+        if "error" in out:
+            return out
+        text = out["data"] if isinstance(out["data"], str) else str(out["data"])
+        cap = max(1, min(int(max_chars or 20000), 100000))
+        return {"file_id": file_id, "text": text[:cap], "truncated": len(text) > cap}
+
+    box_read_file.__name__ = "box_read_file"
+    tools.append(
+        _attach(
+            box_read_file,
+            _schema(
+                "box_read_file",
+                "Read a text file from Box by file ID.",
+                {"file_id": {"type": "string"}, "max_chars": {"type": "integer"}},
+                ["file_id"],
+            ),
+            caps=["box", "read"],
+        )
+    )
+
+    def quickbooks_query(query: str, max_results: int = 10) -> dict[str, Any]:
+        profile, err = _profile(secrets, "quickbooks", "access_token", "realm_id")
+        if err:
+            return err
+        q = query.strip()
+        if "maxresults" not in q.lower():
+            q = f"{q} MAXRESULTS {_clamp(max_results, ceiling=100)}"
+        return _request(
+            "GET",
+            f"{_qbo_base(profile)}/query",
+            headers=_bearer_headers(profile["access_token"]),
+            params={"query": q},
+        )
+
+    quickbooks_query.__name__ = "quickbooks_query"
+    tools.append(
+        _attach(
+            quickbooks_query,
+            _schema(
+                "quickbooks_query",
+                "Run a QuickBooks Online query, e.g. \"SELECT * FROM Invoice WHERE TotalAmt > '100'\". "
+                "Entities include Customer, Invoice, Bill, Payment, Account, Vendor.",
+                {"query": {"type": "string"}, "max_results": {"type": "integer"}},
+                ["query"],
+            ),
+            caps=["quickbooks", "read"],
+        )
+    )
+
+    def quickbooks_list_customers(max_results: int = 10) -> dict[str, Any]:
+        profile, err = _profile(secrets, "quickbooks", "access_token", "realm_id")
+        if err:
+            return err
+        return _request(
+            "GET",
+            f"{_qbo_base(profile)}/query",
+            headers=_bearer_headers(profile["access_token"]),
+            params={
+                "query": f"SELECT * FROM Customer MAXRESULTS {_clamp(max_results)}"
+            },
+        )
+
+    quickbooks_list_customers.__name__ = "quickbooks_list_customers"
+    tools.append(
+        _attach(
+            quickbooks_list_customers,
+            _schema(
+                "quickbooks_list_customers",
+                "List QuickBooks customers.",
+                {"max_results": {"type": "integer"}},
+                [],
+            ),
+            caps=["quickbooks", "read"],
+        )
+    )
+
+    def quickbooks_list_invoices(max_results: int = 10) -> dict[str, Any]:
+        profile, err = _profile(secrets, "quickbooks", "access_token", "realm_id")
+        if err:
+            return err
+        return _request(
+            "GET",
+            f"{_qbo_base(profile)}/query",
+            headers=_bearer_headers(profile["access_token"]),
+            params={
+                "query": "SELECT * FROM Invoice ORDERBY TxnDate DESC "
+                f"MAXRESULTS {_clamp(max_results)}"
+            },
+        )
+
+    quickbooks_list_invoices.__name__ = "quickbooks_list_invoices"
+    tools.append(
+        _attach(
+            quickbooks_list_invoices,
+            _schema(
+                "quickbooks_list_invoices",
+                "List recent QuickBooks invoices.",
+                {"max_results": {"type": "integer"}},
+                [],
+            ),
+            caps=["quickbooks", "read"],
+        )
+    )
+
+    def quickbooks_get_report(
+        report: str, start_date: str = "", end_date: str = ""
+    ) -> dict[str, Any]:
+        profile, err = _profile(secrets, "quickbooks", "access_token", "realm_id")
+        if err:
+            return err
+        params: dict[str, Any] = {}
+        if start_date:
+            params["start_date"] = start_date
+        if end_date:
+            params["end_date"] = end_date
+        return _request(
+            "GET",
+            f"{_qbo_base(profile)}/reports/{quote(report, safe='')}",
+            headers=_bearer_headers(profile["access_token"]),
+            params=params or None,
+        )
+
+    quickbooks_get_report.__name__ = "quickbooks_get_report"
+    tools.append(
+        _attach(
+            quickbooks_get_report,
+            _schema(
+                "quickbooks_get_report",
+                "Run a QuickBooks report such as ProfitAndLoss, BalanceSheet, CashFlow, "
+                "AgedReceivables. Dates are YYYY-MM-DD.",
+                {
+                    "report": {"type": "string"},
+                    "start_date": {"type": "string"},
+                    "end_date": {"type": "string"},
+                },
+                ["report"],
+            ),
+            caps=["quickbooks", "read"],
         )
     )
 

--- a/platform/coworker/connectors/tool_defs.py
+++ b/platform/coworker/connectors/tool_defs.py
@@ -232,6 +232,181 @@ TOOL_DEFS: tuple[ConnectorToolDef, ...] = (
         "write",
         "Create a Zendesk ticket.",
     ),
+    ConnectorToolDef(
+        "linear",
+        "linear_search_issues",
+        "Search issues",
+        "read",
+        "Search Linear issues.",
+    ),
+    ConnectorToolDef(
+        "linear", "linear_get_issue", "Read issue", "read", "Read a Linear issue."
+    ),
+    ConnectorToolDef(
+        "linear", "linear_list_teams", "List teams", "read", "List Linear teams."
+    ),
+    ConnectorToolDef(
+        "linear",
+        "linear_create_issue",
+        "Create issue",
+        "write",
+        "Create a Linear issue.",
+    ),
+    ConnectorToolDef(
+        "gitlab",
+        "gitlab_search",
+        "Search GitLab",
+        "read",
+        "Search projects, issues, or merge requests.",
+    ),
+    ConnectorToolDef(
+        "gitlab", "gitlab_get_issue", "Read issue", "read", "Read a GitLab issue."
+    ),
+    ConnectorToolDef(
+        "gitlab",
+        "gitlab_get_merge_request",
+        "Read merge request",
+        "read",
+        "Read a GitLab merge request.",
+    ),
+    ConnectorToolDef(
+        "gitlab",
+        "gitlab_create_issue",
+        "Create issue",
+        "write",
+        "Create a GitLab issue.",
+    ),
+    ConnectorToolDef(
+        "discord",
+        "discord_list_channels",
+        "List channels",
+        "read",
+        "List channels in a Discord server.",
+    ),
+    ConnectorToolDef(
+        "discord",
+        "discord_read_messages",
+        "Read messages",
+        "read",
+        "Read recent Discord channel messages.",
+    ),
+    ConnectorToolDef(
+        "discord",
+        "discord_send_message",
+        "Send message",
+        "write",
+        "Send a Discord channel message.",
+    ),
+    ConnectorToolDef(
+        "stripe",
+        "stripe_search_customers",
+        "Search customers",
+        "read",
+        "Search Stripe customers.",
+    ),
+    ConnectorToolDef(
+        "stripe",
+        "stripe_list_charges",
+        "List charges",
+        "read",
+        "List Stripe charges.",
+    ),
+    ConnectorToolDef(
+        "stripe",
+        "stripe_list_invoices",
+        "List invoices",
+        "read",
+        "List Stripe invoices.",
+    ),
+    ConnectorToolDef(
+        "asana",
+        "asana_list_workspaces",
+        "List workspaces",
+        "read",
+        "List Asana workspaces.",
+    ),
+    ConnectorToolDef(
+        "asana", "asana_search_tasks", "Search tasks", "read", "Search Asana tasks."
+    ),
+    ConnectorToolDef(
+        "asana", "asana_get_task", "Read task", "read", "Read an Asana task."
+    ),
+    ConnectorToolDef(
+        "asana", "asana_create_task", "Create task", "write", "Create an Asana task."
+    ),
+    ConnectorToolDef(
+        "hubspot",
+        "hubspot_search",
+        "Search CRM",
+        "read",
+        "Search HubSpot contacts, companies, deals, or tickets.",
+    ),
+    ConnectorToolDef(
+        "hubspot",
+        "hubspot_get_object",
+        "Read record",
+        "read",
+        "Read a HubSpot CRM record.",
+    ),
+    ConnectorToolDef(
+        "hubspot",
+        "hubspot_create_contact",
+        "Create contact",
+        "write",
+        "Create a HubSpot contact.",
+    ),
+    ConnectorToolDef(
+        "dropbox", "dropbox_search", "Search files", "read", "Search Dropbox files."
+    ),
+    ConnectorToolDef(
+        "dropbox",
+        "dropbox_list_folder",
+        "List folder",
+        "read",
+        "List a Dropbox folder.",
+    ),
+    ConnectorToolDef(
+        "dropbox",
+        "dropbox_read_file",
+        "Read file",
+        "read",
+        "Read a text file from Dropbox.",
+    ),
+    ConnectorToolDef("box", "box_search", "Search files", "read", "Search Box files."),
+    ConnectorToolDef(
+        "box", "box_list_folder", "List folder", "read", "List a Box folder."
+    ),
+    ConnectorToolDef(
+        "box", "box_read_file", "Read file", "read", "Read a text file from Box."
+    ),
+    ConnectorToolDef(
+        "quickbooks",
+        "quickbooks_query",
+        "Query records",
+        "read",
+        "Run a QuickBooks Online query.",
+    ),
+    ConnectorToolDef(
+        "quickbooks",
+        "quickbooks_list_customers",
+        "List customers",
+        "read",
+        "List QuickBooks customers.",
+    ),
+    ConnectorToolDef(
+        "quickbooks",
+        "quickbooks_list_invoices",
+        "List invoices",
+        "read",
+        "List recent QuickBooks invoices.",
+    ),
+    ConnectorToolDef(
+        "quickbooks",
+        "quickbooks_get_report",
+        "Run report",
+        "read",
+        "Run a QuickBooks financial report.",
+    ),
 )
 
 TOOL_TO_CONNECTOR = {d.name: d.connector for d in TOOL_DEFS}

--- a/platform/tests/test_connectors.py
+++ b/platform/tests/test_connectors.py
@@ -852,3 +852,252 @@ def test_superagent_rest(tmp_path, monkeypatch):
         ).json()["ok"]
         is True
     )
+
+
+# -- new tool connectors (linear / gitlab / discord / stripe / asana / hubspot /
+#    dropbox / box) --------------------------------------------------------------
+_NEW_CONNECTORS = {
+    "linear": {"api_key": "lin_api_x"},
+    "gitlab": {"token": "glpat-x"},
+    "discord": {"bot_token": "B0T"},
+    "stripe": {"api_key": "rk_test_x"},
+    "asana": {"token": "asana_pat"},
+    "hubspot": {"token": "pat-x"},
+    "dropbox": {"access_token": "dbx"},
+    "box": {"access_token": "boxtok"},
+    "quickbooks": {"access_token": "qbo", "realm_id": "9341453"},
+}
+
+
+def test_new_connector_descriptors_listed(tmp_path):
+    from coworker.connectors import connector_list
+
+    by_name = {
+        c["name"]: c for c in connector_list(SecretStore(tmp_path / "secrets.json"))
+    }
+    for name in _NEW_CONNECTORS:
+        assert by_name[name]["available"] is True
+        assert by_name[name]["connected"] is False
+        assert by_name[name]["two_way"] is False
+        assert by_name[name]["instructions"]
+        assert by_name[name]["tools"], f"{name} has no tools in the catalog"
+    # stripe and quickbooks are deliberately read-only
+    assert all(t["kind"] == "read" for t in by_name["stripe"]["tools"])
+    assert all(t["kind"] == "read" for t in by_name["dropbox"]["tools"])
+    assert all(t["kind"] == "read" for t in by_name["box"]["tools"])
+    assert all(t["kind"] == "read" for t in by_name["quickbooks"]["tools"])
+
+
+def test_new_connectors_connect_and_gate_tools(tmp_path):
+    from coworker.connectors import connect_connector, connector_list
+    from coworker.connectors.integration_tools import make_integration_tools
+
+    secrets = SecretStore(tmp_path / "secrets.json")
+    for name, fields in _NEW_CONNECTORS.items():
+        assert connect_connector(secrets, name, fields, validate=False)["ok"] is True
+
+    by_name = {c["name"]: c for c in connector_list(secrets)}
+    for name in _NEW_CONNECTORS:
+        assert by_name[name]["connected"] is True and by_name[name]["enabled"] is True
+
+    # only the enabled connectors' tools survive the filter
+    tools = make_integration_tools(secrets, enabled_connectors={"linear", "box"})
+    names = {t.__name__ for t in tools}
+    assert "linear_search_issues" in names and "box_search" in names
+    assert "gitlab_search" not in names and "stripe_list_charges" not in names
+
+
+def test_new_tools_error_when_not_connected(tmp_path):
+    from coworker.connectors.integration_tools import make_integration_tools
+
+    tools = {
+        t.__name__: t
+        for t in make_integration_tools(SecretStore(tmp_path / "secrets.json"))
+    }
+    assert "not connected" in tools["linear_search_issues"](query="q")["error"]
+    assert "not connected" in tools["gitlab_search"](query="q")["error"]
+    assert "not connected" in tools["discord_send_message"]("1", "hi")["error"]
+    assert "not connected" in tools["stripe_search_customers"]("e:'a'")["error"]
+    assert "not connected" in tools["asana_get_task"]("1")["error"]
+    assert "not connected" in tools["hubspot_search"]("acme")["error"]
+    assert "not connected" in tools["dropbox_list_folder"]()["error"]
+    assert "not connected" in tools["box_read_file"]("1")["error"]
+    assert "not connected" in tools["quickbooks_query"]("SELECT * FROM Bill")["error"]
+
+
+def _connected_tools(tmp_path, monkeypatch, calls):
+    """All new connectors connected + _request recorded instead of hitting the network."""
+    import coworker.connectors.integration_tools as it
+
+    secrets = SecretStore(tmp_path / "secrets.json")
+    for name, fields in _NEW_CONNECTORS.items():
+        secrets.put(f"{name}:default", {**fields, "enabled": True})
+
+    def fake_request(method, url, *, headers=None, params=None, json=None, auth=None):
+        calls.append(
+            {
+                "method": method,
+                "url": url,
+                "headers": headers or {},
+                "params": params,
+                "json": json,
+            }
+        )
+        return {"ok": True, "data": {}}
+
+    monkeypatch.setattr(it, "_request", fake_request)
+    return {t.__name__: t for t in it.make_integration_tools(secrets)}
+
+
+def test_new_tools_request_routing(tmp_path, monkeypatch):
+    calls = []
+    tools = _connected_tools(tmp_path, monkeypatch, calls)
+
+    tools["linear_search_issues"]("crash", max_results=5)
+    assert calls[-1]["url"] == "https://api.linear.app/graphql"
+    assert calls[-1]["headers"]["Authorization"] == "lin_api_x"  # raw key, no Bearer
+    assert calls[-1]["json"]["variables"] == {"term": "crash", "first": 5}
+
+    tools["gitlab_get_issue"]("group/repo", 7)
+    assert (
+        calls[-1]["url"] == "https://gitlab.com/api/v4/projects/group%2Frepo/issues/7"
+    )
+    assert calls[-1]["headers"]["PRIVATE-TOKEN"] == "glpat-x"
+
+    tools["discord_send_message"]("123", "x" * 3000)
+    assert calls[-1]["url"] == "https://discord.com/api/v10/channels/123/messages"
+    assert calls[-1]["headers"]["Authorization"] == "Bot B0T"
+    assert len(calls[-1]["json"]["content"]) == 2000  # discord hard limit
+
+    tools["stripe_list_charges"](customer_id="cus_1", max_results=99)
+    assert calls[-1]["params"] == {"limit": 20, "customer": "cus_1"}
+
+    tools["asana_search_tasks"]("WS1", "report")
+    assert "workspaces/WS1/typeahead" in calls[-1]["url"]
+
+    tools["hubspot_search"]("acme", object_type="bogus")
+    assert calls[-1]["url"].endswith("/crm/v3/objects/contacts/search")  # fallback
+
+    tools["dropbox_list_folder"]("Docs")
+    assert calls[-1]["json"] == {"path": "/Docs"}  # leading slash added
+    tools["dropbox_list_folder"]()
+    assert calls[-1]["json"] == {"path": ""}  # root stays empty
+
+    tools["dropbox_read_file"]("/a.txt")
+    assert "Dropbox-API-Arg" in calls[-1]["headers"]
+
+    tools["box_read_file"]("f1")
+    assert calls[-1]["url"] == "https://api.box.com/2.0/files/f1/content"
+
+    tools["quickbooks_query"]("SELECT * FROM Invoice", max_results=5)
+    assert (
+        calls[-1]["url"] == "https://quickbooks.api.intuit.com/v3/company/9341453/query"
+    )
+    assert calls[-1]["params"]["query"] == "SELECT * FROM Invoice MAXRESULTS 5"
+    tools["quickbooks_query"]("SELECT * FROM Bill MAXRESULTS 3")
+    assert (
+        calls[-1]["params"]["query"] == "SELECT * FROM Bill MAXRESULTS 3"
+    )  # untouched
+
+    tools["quickbooks_get_report"]("ProfitAndLoss", start_date="2026-01-01")
+    assert calls[-1]["url"].endswith("/reports/ProfitAndLoss")
+    assert calls[-1]["params"] == {"start_date": "2026-01-01"}
+
+
+def test_new_write_tools_require_approval(tmp_path, monkeypatch):
+    # every connector tool is approval-gated in this codebase (see _attach default);
+    # the write tools matter most, so pin them explicitly
+    tools = _connected_tools(tmp_path, monkeypatch, [])
+    for name in (
+        "linear_create_issue",
+        "gitlab_create_issue",
+        "discord_send_message",
+        "asana_create_task",
+        "hubspot_create_contact",
+        "stripe_search_customers",
+        "dropbox_read_file",
+        "box_search",
+    ):
+        assert tools[name].__aisuite_tool_metadata__.requires_approval is True, name
+
+
+def test_gitlab_self_hosted_base_url(tmp_path, monkeypatch):
+    import coworker.connectors.integration_tools as it
+
+    secrets = SecretStore(tmp_path / "secrets.json")
+    secrets.put(
+        "gitlab:default",
+        {"token": "t", "base_url": "https://git.example.com/", "enabled": True},
+    )
+    calls = []
+    monkeypatch.setattr(
+        it, "_request", lambda m, url, **kw: calls.append(url) or {"ok": True}
+    )
+    tools = {t.__name__: t for t in it.make_integration_tools(secrets)}
+    tools["gitlab_search"]("q")
+    assert calls[0] == "https://git.example.com/api/v4/search"
+
+
+def test_quickbooks_sandbox_environment(tmp_path, monkeypatch):
+    import coworker.connectors.integration_tools as it
+
+    secrets = SecretStore(tmp_path / "secrets.json")
+    secrets.put(
+        "quickbooks:default",
+        {"access_token": "t", "realm_id": "r1", "environment": "sandbox"},
+    )
+    calls = []
+    monkeypatch.setattr(
+        it, "_request", lambda m, url, **kw: calls.append(url) or {"ok": True}
+    )
+    tools = {t.__name__: t for t in it.make_integration_tools(secrets)}
+    tools["quickbooks_list_customers"]()
+    assert calls[0] == "https://sandbox-quickbooks.api.intuit.com/v3/company/r1/query"
+
+
+def test_new_connector_validators_wired():
+    from coworker.connectors.descriptors import get_descriptor
+
+    for name in (
+        "linear",
+        "gitlab",
+        "discord",
+        "asana",
+        "hubspot",
+        "dropbox",
+        "box",
+        "quickbooks",
+    ):
+        assert get_descriptor(name).validate is not None, name
+    # stripe restricted-key permissions vary, so it has no whoami validator
+    assert get_descriptor("stripe").validate is None
+
+
+def test_validate_whoami_helper(monkeypatch):
+    import coworker.connectors.descriptors as d
+
+    class _Resp:
+        def __init__(self, status, payload):
+            self.status_code = status
+            self._payload = payload
+
+        def json(self):
+            return self._payload
+
+    def fake(status, payload):
+        import httpx
+
+        monkeypatch.setattr(httpx, "request", lambda *a, **k: _Resp(status, payload))
+
+    fake(200, {"username": "alice"})
+    res = d._validate_gitlab({"token": "t"})
+    assert res.ok and res.identity == "@alice"
+
+    fake(401, {"message": "401 Unauthorized"})
+    res = d._validate_gitlab({"token": "bad"})
+    assert not res.ok and "Unauthorized" in res.error
+
+    # 200 but unexpected shape (e.g. GraphQL errors payload) must not pass
+    fake(200, {"errors": [{"message": "auth"}]})
+    res = d._validate_linear({"api_key": "bad"})
+    assert not res.ok


### PR DESCRIPTION
Adds nine tool connectors (31 tools) following the existing pattern: wizard descriptors, httpx-based tools, catalog entries for per-tool enablement. No engine/server/UI changes needed.

- **Read + write (approval-gated)**: Linear, GitLab (incl. self-hosted), Discord (bot), Asana, HubSpot
- **Read-only by design**: Stripe, Dropbox, Box, QuickBooks
- Lightweight whoami validators confirm tokens at connect time (skipped for Stripe, where restricted-key permissions vary)

10 new offline tests cover descriptor listing, tool gating, request routing, approval metadata, and validator failure modes. Full suite: 274 passed, 1 skipped.