### PR TITLE
Fix shared provider config state across Client instances

### DIFF
--- a/aisuite/client.py
+++ b/aisuite/client.py
@@ -23,7 +23,7 @@ except ImportError:
 class Client:
     def __init__(
         self,
-        provider_configs: dict = {},
+        provider_configs: Optional[dict] = None,
         extra_param_mode: Literal["strict", "warn", "permissive"] = "warn",
     ):
         """
@@ -49,18 +49,28 @@ class Client:
                 - "permissive": Allow all params without validation (testing)
         """
         self.providers = {}
-        self.provider_configs = provider_configs
+        self.provider_configs = self._copy_provider_configs(provider_configs)
         self.extra_param_mode = extra_param_mode
         self.param_validator = ParamValidator(extra_param_mode)
         self._chat = None
         self._audio = None
+
+    @staticmethod
+    def _copy_provider_configs(provider_configs: Optional[dict]) -> dict:
+        if provider_configs is None:
+            return {}
+
+        return {
+            provider_key: dict(config)
+            for provider_key, config in provider_configs.items()
+        }
 
     def _initialize_providers(self):
         """Helper method to initialize or update providers."""
         for provider_key, config in self.provider_configs.items():
             provider_key = self._validate_provider_key(provider_key)
             self.providers[provider_key] = ProviderFactory.create_provider(
-                provider_key, config
+                provider_key, dict(config)
             )
 
     def _validate_provider_key(self, provider_key):
@@ -84,7 +94,7 @@ class Client:
         if provider_configs is None:
             return
 
-        self.provider_configs.update(provider_configs)
+        self.provider_configs.update(self._copy_provider_configs(provider_configs))
         # Providers will be lazily initialized when needed
 
     @property
@@ -382,7 +392,7 @@ class Completions:
         if provider_key not in self.client.providers:
             config = self.client.provider_configs.get(provider_key, {})
             self.client.providers[provider_key] = ProviderFactory.create_provider(
-                provider_key, config
+                provider_key, dict(config)
             )
 
         provider = self.client.providers.get(provider_key)
@@ -534,7 +544,7 @@ class Transcriptions:
             config = self.client.provider_configs.get(provider_key, {})
             try:
                 self.client.providers[provider_key] = ProviderFactory.create_provider(
-                    provider_key, config
+                    provider_key, dict(config)
                 )
             except ImportError as e:
                 raise ValueError(f"Provider '{provider_key}' is not available: {e}")

--- a/tests/client/test_client.py
+++ b/tests/client/test_client.py
@@ -50,6 +50,66 @@ def provider_configs():
     }
 
 
+def test_default_provider_configs_are_not_shared_between_clients():
+    client_a = Client()
+    client_b = Client()
+
+    client_a.configure({"openai": {"api_key": "client-a-key"}})
+
+    assert client_a.provider_configs == {"openai": {"api_key": "client-a-key"}}
+    assert client_b.provider_configs == {}
+
+
+def test_provider_configs_are_copied_on_init():
+    provider_configs = {"openai": {"api_key": "original"}}
+    openai_config = provider_configs["openai"]
+
+    client = Client(provider_configs)
+
+    assert client.provider_configs["openai"] is not openai_config
+
+    provider_configs["openai"]["api_key"] = "mutated"
+    provider_configs["anthropic"] = {"api_key": "new"}
+
+    assert client.provider_configs == {"openai": {"api_key": "original"}}
+
+
+def test_provider_configs_are_copied_on_configure():
+    provider_configs = {"openai": {"api_key": "original"}}
+    openai_config = provider_configs["openai"]
+    client = Client()
+
+    client.configure(provider_configs)
+
+    assert client.provider_configs["openai"] is not openai_config
+
+    provider_configs["openai"]["api_key"] = "mutated"
+    provider_configs["anthropic"] = {"api_key": "new"}
+
+    assert client.provider_configs == {"openai": {"api_key": "original"}}
+
+
+@patch("aisuite.provider.ProviderFactory.create_provider")
+def test_provider_initialization_uses_config_copy(mock_create_provider):
+    provider = Mock()
+    provider.chat_completions_create.return_value = "response"
+
+    def create_provider(provider_key, config):
+        config["api_key"] = "mutated-by-factory"
+        return provider
+
+    mock_create_provider.side_effect = create_provider
+    client = Client({"openai": {"api_key": "original"}})
+
+    response = client.chat.completions.create(
+        model="openai:gpt-4o",
+        messages=[{"role": "user", "content": "Hello"}],
+    )
+
+    assert response == "response"
+    assert client.provider_configs == {"openai": {"api_key": "original"}}
+
+
 @pytest.mark.parametrize(
     argnames=("provider", "model"),
     argvalues=[


### PR DESCRIPTION
## Summary

This fixes a shared mutable default in `Client.__init__` where multiple `Client()` instances could share the same `provider_configs` dict.

## Problem

`provider_configs` previously defaulted to `{}` and `configure()` mutates that dict in place. As a result, configuring one default client could leak provider settings into another default client.

## Changes

- Default `provider_configs` to `None`
- Create a fresh provider config dict per `Client`
- Copy provider config dictionaries on init and `configure()`
- Pass copied configs into lazy provider initialization
- Add regression tests for client config isolation

## Test Plan

```bash
uv run --with pytest --with pydantic --with docstring-parser --with openai pytest tests/client/test_client.py
```

Result: `38 passed`
