### PR TITLE
Add WhatsApp connector (official Cloud API) and experimental-connector gating

### DIFF
--- a/platform/coworker/connectors/__init__.py
+++ b/platform/coworker/connectors/__init__.py
@@ -27,6 +27,8 @@ from .setup import (
     connect_connector,
     connector_list,
     disconnect_connector,
+    experimental_enabled,
+    set_experimental_enabled,
     update_connector_tools,
 )
 from .superagent import SUPERAGENT_MESSAGING_NOTE, SuperAgent
@@ -54,6 +56,8 @@ __all__ = [
     "connect_connector",
     "connector_list",
     "disconnect_connector",
+    "experimental_enabled",
+    "set_experimental_enabled",
     "update_connector_tools",
     "make_integration_tools",
     "make_send_message_tool",

--- a/platform/coworker/connectors/descriptors.py
+++ b/platform/coworker/connectors/descriptors.py
@@ -54,6 +54,11 @@ class ConnectorDescriptor:
     instructions: list[str]
     available: bool = True  # False → shown as "soon"
     validate: Optional[Callable[[dict], ValidationResult]] = None
+    # Experimental connectors are hidden unless the user enables them in settings, require an
+    # explicit risk acknowledgment to connect, and ship in a separate package
+    # (connectors/experimental/) that release builds exclude entirely.
+    experimental: bool = False
+    risk_notice: str = ""
 
 
 # -- validators (sync httpx, one-shot) -----------------------------------------
@@ -209,6 +214,15 @@ def _validate_box(creds: dict) -> ValidationResult:
         "https://api.box.com/2.0/users/me",
         headers={"Authorization": f"Bearer {creds.get('access_token', '')}"},
         identity=lambda d: d["login"],
+    )
+
+
+def _validate_whatsapp(creds: dict) -> ValidationResult:
+    return _validate_whoami(
+        "GET",
+        f"https://graph.facebook.com/v21.0/{creds.get('phone_number_id', '')}",
+        headers={"Authorization": f"Bearer {creds.get('access_token', '')}"},
+        identity=lambda d: d["display_phone_number"],
     )
 
 
@@ -647,6 +661,34 @@ DESCRIPTORS: list[ConnectorDescriptor] = [
         validate=_validate_box,
     ),
     ConnectorDescriptor(
+        name="whatsapp",
+        title="WhatsApp",
+        icon="◌",
+        blurb="Send WhatsApp messages through Meta's official Cloud API (outbound only).",
+        auth="token",
+        two_way=False,
+        fields=[
+            Field(
+                "access_token",
+                "Access token",
+                secret=True,
+                help="From your Meta app's WhatsApp setup page (a system-user token for long-lived access).",
+            ),
+            Field(
+                "phone_number_id",
+                "Phone number ID",
+                help="The Cloud API phone number ID (not the phone number itself).",
+            ),
+        ],
+        instructions=[
+            "Create a Meta app at developers.facebook.com and add the WhatsApp product.",
+            "Copy the access token and the phone number ID from the API setup page.",
+            "The free test number can message up to 5 verified recipients without business verification.",
+            "Free-form messages only reach people who messaged your number in the last 24 hours; outside that window only approved templates are delivered.",
+        ],
+        validate=_validate_whatsapp,
+    ),
+    ConnectorDescriptor(
         name="quickbooks",
         title="QuickBooks",
         icon="◴",
@@ -683,6 +725,23 @@ DESCRIPTORS: list[ConnectorDescriptor] = [
 ]
 
 _BY_NAME = {d.name: d for d in DESCRIPTORS}
+
+
+def register_descriptor(descriptor: ConnectorDescriptor) -> None:
+    """Register an extra connector (used by the experimental package and tests)."""
+    DESCRIPTORS.append(descriptor)
+    _BY_NAME[descriptor.name] = descriptor
+
+
+# Experimental connectors live in a separate package so release builds can exclude the code
+# entirely (see packaging/coworker-server.spec). When the package is absent this is a no-op.
+try:
+    from .experimental import EXPERIMENTAL_DESCRIPTORS as _EXPERIMENTAL
+except ImportError:
+    _EXPERIMENTAL = []
+for _exp in _EXPERIMENTAL:
+    _exp.experimental = True  # enforced here, not trusted from the author
+    register_descriptor(_exp)
 
 
 def list_descriptors() -> list[ConnectorDescriptor]:

--- a/platform/coworker/connectors/experimental/__init__.py
+++ b/platform/coworker/connectors/experimental/__init__.py
@@ -1,0 +1,18 @@
+"""Experimental connectors — use-at-your-own-risk integrations, excluded from release builds.
+
+Connectors in this package are hidden behind the experimental-connectors setting, require an
+explicit per-connector risk acknowledgment to connect, and are stripped from official desktop
+builds by packaging/coworker-server.spec (set COWORKER_EXPERIMENTAL=1 at build time to include
+them in a self-built binary).
+
+To add one: define a `ConnectorDescriptor` with a `risk_notice` that states the concrete
+downside in plain language, append it to `EXPERIMENTAL_DESCRIPTORS`, and register its tools or
+adapter the same way first-party connectors do. The `experimental` flag is forced on by the
+loader in descriptors.py regardless of what the descriptor sets.
+"""
+
+from __future__ import annotations
+
+from ..descriptors import ConnectorDescriptor
+
+EXPERIMENTAL_DESCRIPTORS: list[ConnectorDescriptor] = []

--- a/platform/coworker/connectors/integration_tools.py
+++ b/platform/coworker/connectors/integration_tools.py
@@ -1900,6 +1900,80 @@ def make_integration_tools(
         )
     )
 
+    def whatsapp_send_message(to: str, text: str) -> dict[str, Any]:
+        profile, err = _profile(secrets, "whatsapp", "access_token", "phone_number_id")
+        if err:
+            return err
+        return _request(
+            "POST",
+            f"https://graph.facebook.com/v21.0/{profile['phone_number_id']}/messages",
+            headers=_bearer_headers(profile["access_token"]),
+            json={
+                "messaging_product": "whatsapp",
+                "to": to,
+                "type": "text",
+                "text": {"body": text[:4096]},
+            },
+        )
+
+    whatsapp_send_message.__name__ = "whatsapp_send_message"
+    tools.append(
+        _attach(
+            whatsapp_send_message,
+            _schema(
+                "whatsapp_send_message",
+                "Send a WhatsApp text message. Only delivered if the recipient messaged "
+                "this number within the last 24 hours; otherwise use "
+                "whatsapp_send_template. Requires user approval.",
+                {"to": {"type": "string"}, "text": {"type": "string"}},
+                ["to", "text"],
+            ),
+            approval=True,
+            caps=["whatsapp", "write"],
+        )
+    )
+
+    def whatsapp_send_template(
+        to: str, template_name: str, language_code: str = "en_US"
+    ) -> dict[str, Any]:
+        profile, err = _profile(secrets, "whatsapp", "access_token", "phone_number_id")
+        if err:
+            return err
+        return _request(
+            "POST",
+            f"https://graph.facebook.com/v21.0/{profile['phone_number_id']}/messages",
+            headers=_bearer_headers(profile["access_token"]),
+            json={
+                "messaging_product": "whatsapp",
+                "to": to,
+                "type": "template",
+                "template": {
+                    "name": template_name,
+                    "language": {"code": language_code},
+                },
+            },
+        )
+
+    whatsapp_send_template.__name__ = "whatsapp_send_template"
+    tools.append(
+        _attach(
+            whatsapp_send_template,
+            _schema(
+                "whatsapp_send_template",
+                "Send a pre-approved WhatsApp template message (works outside the "
+                "24-hour service window). Requires user approval.",
+                {
+                    "to": {"type": "string"},
+                    "template_name": {"type": "string"},
+                    "language_code": {"type": "string"},
+                },
+                ["to", "template_name"],
+            ),
+            approval=True,
+            caps=["whatsapp", "write"],
+        )
+    )
+
     if enabled_connectors is not None:
         tools = [
             t for t in tools if connector_for_tool(t.__name__) in enabled_connectors

--- a/platform/coworker/connectors/setup.py
+++ b/platform/coworker/connectors/setup.py
@@ -13,6 +13,18 @@ from ..secrets import SecretStore
 from .descriptors import get_descriptor, list_descriptors
 from .tool_defs import patch_tool_settings, tool_dicts
 
+_EXPERIMENTAL_KEY = "experimental:settings"
+
+
+def experimental_enabled(secrets: SecretStore) -> bool:
+    """Whether the user has opted in to experimental (use-at-your-own-risk) connectors."""
+    return bool((secrets.get(_EXPERIMENTAL_KEY) or {}).get("enabled"))
+
+
+def set_experimental_enabled(secrets: SecretStore, value: bool) -> dict[str, Any]:
+    secrets.put(_EXPERIMENTAL_KEY, {"enabled": bool(value)})
+    return {"ok": True, "enabled": bool(value)}
+
 
 def _profile_connected(descriptor, profile: dict[str, Any]) -> bool:
     if not descriptor.available:
@@ -26,8 +38,14 @@ def _profile_connected(descriptor, profile: dict[str, Any]) -> bool:
 
 
 def connector_list(secrets: SecretStore) -> list[dict[str, Any]]:
+    show_experimental = experimental_enabled(secrets)
     out: list[dict[str, Any]] = []
     for d in list_descriptors():
+        # Experimental connectors are invisible (not just disabled) until the user opts in;
+        # hiding them here also drops their tools from engine builds via
+        # _enabled_connector_tools, so flipping the setting off cuts access immediately.
+        if d.experimental and not show_experimental:
+            continue
         profile = secrets.get(f"{d.name}:default") or {}
         connected = _profile_connected(d, profile)
         out.append(
@@ -46,6 +64,8 @@ def connector_list(secrets: SecretStore) -> list[dict[str, Any]]:
                 "enabled": bool(profile.get("enabled", True)) and connected,
                 "allowed_users": len(profile.get("allowed_users") or []),
                 "tools": tool_dicts(secrets, d.name),
+                "experimental": d.experimental,
+                "risk_notice": d.risk_notice,
             }
         )
     return out
@@ -60,11 +80,25 @@ def update_connector_tools(
 
 
 def connect_connector(
-    secrets: SecretStore, name: str, fields: dict[str, Any], *, validate: bool = True
+    secrets: SecretStore,
+    name: str,
+    fields: dict[str, Any],
+    *,
+    validate: bool = True,
+    acknowledged: bool = False,
 ) -> dict[str, Any]:
     d = get_descriptor(name)
     if d is None or not d.available:
         return {"ok": False, "error": "unknown or unavailable connector"}
+    if d.experimental:
+        if not experimental_enabled(secrets):
+            return {"ok": False, "error": "experimental connectors are disabled"}
+        if not acknowledged:
+            return {
+                "ok": False,
+                "error": "risk acknowledgment required",
+                "risk_notice": d.risk_notice,
+            }
 
     raw = {f.key: str(fields.get(f.key) or "").strip() for f in d.fields}
     missing = [f.label for f in d.fields if f.required and not raw.get(f.key)]

--- a/platform/coworker/connectors/tool_defs.py
+++ b/platform/coworker/connectors/tool_defs.py
@@ -407,6 +407,20 @@ TOOL_DEFS: tuple[ConnectorToolDef, ...] = (
         "read",
         "Run a QuickBooks financial report.",
     ),
+    ConnectorToolDef(
+        "whatsapp",
+        "whatsapp_send_message",
+        "Send message",
+        "write",
+        "Send a WhatsApp text message.",
+    ),
+    ConnectorToolDef(
+        "whatsapp",
+        "whatsapp_send_template",
+        "Send template",
+        "write",
+        "Send an approved WhatsApp template message.",
+    ),
 )
 
 TOOL_TO_CONNECTOR = {d.name: d.connector for d in TOOL_DEFS}

--- a/platform/coworker/server/app.py
+++ b/platform/coworker/server/app.py
@@ -183,8 +183,14 @@ def create_app(manager: SessionManager) -> FastAPI:
     @app.post("/v1/connectors/{name}/connect")
     async def connector_connect(name: str, body: dict) -> dict[str, Any]:
         fields = body.get("fields") if isinstance(body, dict) else None
+        # experimental connectors require the caller to explicitly acknowledge the risk notice
+        acknowledged = bool(isinstance(body, dict) and body.get("acknowledge_risk"))
         # token validation does a blocking HTTP call → keep it off the event loop
-        return await asyncio.to_thread(manager.connect_connector, name, fields or {})
+        return await asyncio.to_thread(
+            lambda: manager.connect_connector(
+                name, fields or {}, acknowledged=acknowledged
+            )
+        )
 
     @app.post("/v1/connectors/{name}/disconnect")
     def connector_disconnect(name: str) -> dict[str, Any]:
@@ -279,6 +285,10 @@ def create_app(manager: SessionManager) -> FastAPI:
     @app.post("/v1/settings/onboarded")
     def settings_set_onboarded(body: dict) -> dict[str, Any]:
         return manager.set_onboarded(bool((body or {}).get("value", True)))
+
+    @app.post("/v1/settings/experimental-connectors")
+    def settings_set_experimental(body: dict) -> dict[str, Any]:
+        return manager.set_experimental_connectors(bool((body or {}).get("value")))
 
     @app.post("/v1/settings/surfaces")
     def settings_set_surfaces(body: dict) -> dict[str, Any]:

--- a/platform/coworker/server/manager.py
+++ b/platform/coworker/server/manager.py
@@ -29,8 +29,10 @@ from ..connectors import (
     connect_connector,
     connector_list,
     disconnect_connector,
+    experimental_enabled,
     load_settings,
     make_adapter,
+    set_experimental_enabled,
     update_connector_tools,
 )
 from ..connectors.browser_automation import (
@@ -353,9 +355,14 @@ class SessionManager:
     def list_connectors(self) -> list[dict[str, Any]]:
         return connector_list(self.secrets)
 
-    def connect_connector(self, name: str, fields: dict[str, Any]) -> dict[str, Any]:
+    def connect_connector(
+        self, name: str, fields: dict[str, Any], *, acknowledged: bool = False
+    ) -> dict[str, Any]:
         # validates the token by a live API call (sync httpx) — run off the event loop
-        return connect_connector(self.secrets, name, fields)
+        return connect_connector(self.secrets, name, fields, acknowledged=acknowledged)
+
+    def set_experimental_connectors(self, value: bool) -> dict[str, Any]:
+        return set_experimental_enabled(self.secrets, value)
 
     def disconnect_connector(self, name: str) -> dict[str, Any]:
         return disconnect_connector(self.secrets, name)
@@ -770,6 +777,7 @@ class SessionManager:
             "has_key": env_key or stored,
             "source": "env" if env_key else ("store" if stored else None),
             "onboarded": bool(self._prefs.get("onboarded")),
+            "experimental_connectors": experimental_enabled(self.secrets),
             "surfaces": self._surfaces(),
             "scratch_base": self._prefs.get("scratch_base")
             or self.DEFAULT_SCRATCH_BASE,

--- a/platform/packaging/build_dmg.sh
+++ b/platform/packaging/build_dmg.sh
@@ -9,6 +9,10 @@
 #
 # The result is UNSIGNED — first launch needs right-click → Open (Gatekeeper). Real
 # code-signing + notarization is a later step.
+#
+# Experimental (use-at-your-own-risk) connectors are EXCLUDED from this build by default —
+# the spec strips coworker.connectors.experimental. Self-builders can opt in with:
+#   COWORKER_EXPERIMENTAL=1 ./build_dmg.sh
 set -euo pipefail
 
 HERE="$(cd "$(dirname "$0")" && pwd)"

--- a/platform/packaging/build_windows.ps1
+++ b/platform/packaging/build_windows.ps1
@@ -19,6 +19,10 @@
 
   The result is UNSIGNED — first launch shows a SmartScreen warning ("More info" -> "Run anyway").
   Authenticode signing is a later step.
+
+  Experimental (use-at-your-own-risk) connectors are EXCLUDED from this build by default —
+  the spec strips coworker.connectors.experimental. Self-builders can opt in with:
+    $env:COWORKER_EXPERIMENTAL = "1"; .\build_windows.ps1
 #>
 [CmdletBinding()]
 param(

--- a/platform/packaging/coworker-server.spec
+++ b/platform/packaging/coworker-server.spec
@@ -30,12 +30,22 @@ ROOT = os.path.dirname(PLATFORM)
 
 IS_WINDOWS = sys.platform == "win32"
 
+# Experimental (use-at-your-own-risk) connectors are excluded from official builds: the code
+# is stripped, not just disabled. Self-builders opt in with COWORKER_EXPERIMENTAL=1; the
+# loader in coworker/connectors/descriptors.py treats the missing package as a no-op.
+INCLUDE_EXPERIMENTAL = os.environ.get("COWORKER_EXPERIMENTAL") == "1"
+
 hiddenimports = []
 datas = []
 binaries = []
 
 for pkg in ("coworker", "aisuite", "mcp", "ddgs", "croniter", "docstring_parser"):
     hiddenimports += collect_submodules(pkg)
+
+if not INCLUDE_EXPERIMENTAL:
+    hiddenimports = [
+        m for m in hiddenimports if not m.startswith("coworker.connectors.experimental")
+    ]
 
 for pkg in ("uvicorn", "certifi", "anyio"):
     d, b, h = collect_all(pkg)
@@ -67,7 +77,8 @@ a = Analysis(
     hiddenimports=hiddenimports,
     hookspath=[],
     runtime_hooks=[],
-    excludes=["tkinter", "matplotlib", "PIL", "PyQt5", "PySide6"],
+    excludes=["tkinter", "matplotlib", "PIL", "PyQt5", "PySide6"]
+    + ([] if INCLUDE_EXPERIMENTAL else ["coworker.connectors.experimental"]),
     noarchive=False,
 )
 pyz = PYZ(a.pure)

--- a/platform/tests/test_connectors.py
+++ b/platform/tests/test_connectors.py
@@ -866,6 +866,7 @@ _NEW_CONNECTORS = {
     "dropbox": {"access_token": "dbx"},
     "box": {"access_token": "boxtok"},
     "quickbooks": {"access_token": "qbo", "realm_id": "9341453"},
+    "whatsapp": {"access_token": "wa_tok", "phone_number_id": "555111"},
 }
 
 
@@ -1003,6 +1004,17 @@ def test_new_tools_request_routing(tmp_path, monkeypatch):
     assert calls[-1]["url"].endswith("/reports/ProfitAndLoss")
     assert calls[-1]["params"] == {"start_date": "2026-01-01"}
 
+    tools["whatsapp_send_message"]("15551234567", "x" * 5000)
+    assert calls[-1]["url"] == "https://graph.facebook.com/v21.0/555111/messages"
+    assert calls[-1]["json"]["messaging_product"] == "whatsapp"
+    assert len(calls[-1]["json"]["text"]["body"]) == 4096  # whatsapp hard limit
+
+    tools["whatsapp_send_template"]("15551234567", "order_update")
+    assert calls[-1]["json"]["template"] == {
+        "name": "order_update",
+        "language": {"code": "en_US"},
+    }
+
 
 def test_new_write_tools_require_approval(tmp_path, monkeypatch):
     # every connector tool is approval-gated in this codebase (see _attach default);
@@ -1017,6 +1029,8 @@ def test_new_write_tools_require_approval(tmp_path, monkeypatch):
         "stripe_search_customers",
         "dropbox_read_file",
         "box_search",
+        "whatsapp_send_message",
+        "whatsapp_send_template",
     ):
         assert tools[name].__aisuite_tool_metadata__.requires_approval is True, name
 
@@ -1067,6 +1081,7 @@ def test_new_connector_validators_wired():
         "dropbox",
         "box",
         "quickbooks",
+        "whatsapp",
     ):
         assert get_descriptor(name).validate is not None, name
     # stripe restricted-key permissions vary, so it has no whoami validator
@@ -1101,3 +1116,125 @@ def test_validate_whoami_helper(monkeypatch):
     fake(200, {"errors": [{"message": "auth"}]})
     res = d._validate_linear({"api_key": "bad"})
     assert not res.ok
+
+
+# -- experimental connector gating ----------------------------------------------
+@pytest.fixture
+def experimental_descriptor():
+    """Register a synthetic experimental connector through the same hook the
+    experimental package uses, and clean it up afterwards."""
+    import coworker.connectors.descriptors as d
+
+    desc = d.ConnectorDescriptor(
+        name="dangerzone",
+        title="Danger Zone",
+        icon="!",
+        blurb="Test-only experimental connector.",
+        auth="token",
+        two_way=False,
+        fields=[d.Field("token", "Token", secret=True)],
+        instructions=["test only"],
+        experimental=True,
+        risk_notice="This may eat your laundry.",
+    )
+    d.register_descriptor(desc)
+    yield desc
+    d.DESCRIPTORS.remove(desc)
+    d._BY_NAME.pop(desc.name, None)
+
+
+def test_experimental_hidden_until_enabled(tmp_path, experimental_descriptor):
+    from coworker.connectors import connector_list, set_experimental_enabled
+
+    secrets = SecretStore(tmp_path / "secrets.json")
+    assert "dangerzone" not in {c["name"] for c in connector_list(secrets)}
+
+    assert set_experimental_enabled(secrets, True)["enabled"] is True
+    listed = {c["name"]: c for c in connector_list(secrets)}
+    assert listed["dangerzone"]["experimental"] is True
+    assert "laundry" in listed["dangerzone"]["risk_notice"]
+    # first-party connectors are never flagged
+    assert listed["github"]["experimental"] is False
+    assert listed["whatsapp"]["experimental"] is False
+
+    set_experimental_enabled(secrets, False)
+    assert "dangerzone" not in {c["name"] for c in connector_list(secrets)}
+
+
+def test_experimental_connect_requires_optin_and_ack(tmp_path, experimental_descriptor):
+    from coworker.connectors import (
+        connect_connector,
+        connector_list,
+        set_experimental_enabled,
+    )
+
+    secrets = SecretStore(tmp_path / "secrets.json")
+    res = connect_connector(secrets, "dangerzone", {"token": "t"}, validate=False)
+    assert res["ok"] is False and "disabled" in res["error"]
+
+    set_experimental_enabled(secrets, True)
+    res = connect_connector(secrets, "dangerzone", {"token": "t"}, validate=False)
+    assert res["ok"] is False and "acknowledgment" in res["error"]
+    assert "laundry" in res["risk_notice"]  # surfaced so the UI can show it
+
+    res = connect_connector(
+        secrets, "dangerzone", {"token": "t"}, validate=False, acknowledged=True
+    )
+    assert res["ok"] is True
+
+    # turning the setting off hides it (and gates its tools) even though connected
+    set_experimental_enabled(secrets, False)
+    assert "dangerzone" not in {c["name"] for c in connector_list(secrets)}
+
+
+def test_experimental_does_not_gate_regular_connectors(tmp_path):
+    from coworker.connectors import connect_connector
+
+    secrets = SecretStore(tmp_path / "secrets.json")
+    res = connect_connector(
+        secrets, "github", {"token": "ghp_x"}, validate=False
+    )  # no acknowledged flag
+    assert res["ok"] is True
+
+
+def test_experimental_rest_roundtrip(tmp_path, monkeypatch, experimental_descriptor):
+    from fastapi.testclient import TestClient
+
+    from coworker.server.app import create_app
+    from coworker.server.manager import SessionManager
+
+    monkeypatch.setenv("COWORKER_STATE_DIR", str(tmp_path / "state"))
+    client = TestClient(create_app(SessionManager(data_dir=tmp_path / "data")))
+
+    assert client.get("/v1/settings").json()["experimental_connectors"] is False
+    names = {c["name"] for c in client.get("/v1/connectors").json()["connectors"]}
+    assert "dangerzone" not in names
+
+    assert (
+        client.post(
+            "/v1/settings/experimental-connectors", json={"value": True}
+        ).json()["enabled"]
+        is True
+    )
+    assert client.get("/v1/settings").json()["experimental_connectors"] is True
+    names = {c["name"] for c in client.get("/v1/connectors").json()["connectors"]}
+    assert "dangerzone" in names
+
+    r = client.post(
+        "/v1/connectors/dangerzone/connect", json={"fields": {"token": "T"}}
+    ).json()
+    assert r["ok"] is False and "acknowledgment" in r["error"]
+    r = client.post(
+        "/v1/connectors/dangerzone/connect",
+        json={"fields": {"token": "T"}, "acknowledge_risk": True},
+    ).json()
+    assert r["ok"] is True
+
+
+def test_experimental_package_loads_cleanly():
+    """The experimental package import hook is a no-op when the package is empty or absent."""
+    from coworker.connectors.descriptors import DESCRIPTORS
+    from coworker.connectors.experimental import EXPERIMENTAL_DESCRIPTORS
+
+    assert EXPERIMENTAL_DESCRIPTORS == []
+    assert all(d.experimental is False for d in DESCRIPTORS if d.name != "dangerzone")


### PR DESCRIPTION
Stacked on #311. Two pieces:

- **WhatsApp (official, outbound-only)**: `whatsapp_send_message` / `whatsapp_send_template`, both approval-gated, validator echoes the display number back. Wizard explains the 24-hour service window and the free test-number tier.
- **Experimental-connector gating** (groundwork for the Baileys-based two-way WhatsApp): `experimental` flag + `risk_notice` on descriptors; connectors stay hidden until the user opts in via settings; connecting one requires an explicit `acknowledge_risk`; the code lives in `connectors/experimental/` which release builds strip via the PyInstaller spec (`COWORKER_EXPERIMENTAL=1` to self-build with it included).

6 new tests (gating visibility, opt-in + acknowledgment, REST roundtrip, stripped-build no-op) plus WhatsApp coverage in the shared connector fixtures. Full suite: 279 passed, 1 skipped.