### PR TITLE
Validate missing chat completion model

### DIFF
--- a/aisuite/client.py
+++ b/aisuite/client.py
@@ -360,7 +360,7 @@ class Completions:
         Supports automatic tool execution when max_turns is specified.
         """
         # Check that correct format is used
-        if ":" not in model:
+        if not isinstance(model, str) or ":" not in model:
             raise ValueError(
                 f"Invalid model format. Expected 'provider:model', got '{model}'"
             )

--- a/tests/client/test_client.py
+++ b/tests/client/test_client.py
@@ -135,6 +135,18 @@ def test_invalid_model_format_in_create():
         client.chat.completions.create(invalid_model, messages=messages)
 
 
+def test_none_model_format_in_create_raises_value_error():
+    client = Client()
+    messages = [
+        {"role": "user", "content": "Hello"},
+    ]
+
+    with pytest.raises(
+        ValueError, match=r"Invalid model format. Expected 'provider:model'"
+    ):
+        client.chat.completions.create(None, messages=messages)
+
+
 def _chat_response(content=None, tool_calls=None):
     message = Message(role="assistant", content=content, tool_calls=tool_calls)
     return SimpleNamespace(choices=[SimpleNamespace(message=message)])


### PR DESCRIPTION
## Summary
- validate chat completion model input before checking for the provider separator
- raise the existing invalid model format ValueError for `model=None`
- add a regression test for the None model case

Fixes #254

## Validation
- `uv run pytest tests/client/test_client.py tests/client/test_manual_tool_calling.py`
- `uv run pre-commit run --files aisuite/client.py tests/client/test_client.py`