### PR TITLE
Code agent: tool ergonomics, parallel execution, plan/discuss modes, explorer subagent

### DIFF
--- a/platform/coworker/agent.py
+++ b/platform/coworker/agent.py
@@ -19,6 +19,7 @@ from .connectors import (
     make_send_message_tool,
 )
 from .engine import Approver, TurnEngine
+from .environment import environment_context
 from .memory import MemoryStore, Scope, format_memories, memory_tools
 from .permissions import Mode, PermissionEngine
 from .project import load_agents_md
@@ -146,6 +147,7 @@ def build_engine(
 
     instructions = agent.system_prompt
     if ws is not None:
+        instructions = f"{instructions}\n\n{environment_context(ws)}"
         conventions = load_agents_md(ws)
         if conventions:
             instructions = f"{instructions}\n\n{conventions}"

--- a/platform/coworker/agent.py
+++ b/platform/coworker/agent.py
@@ -35,6 +35,13 @@ from .web import make_web_fetch_tool, make_web_search_tool
 from .tools.shell import LocalExecutor
 from .tools.todo import TodoList
 
+# Appended each turn while discuss mode is active: enforcement-only read-only, with no
+# pressure toward a plan proposal (that's what distinguishes it from plan mode).
+_DISCUSS_MODE_CONTEXT = """\
+Discuss mode is active: write and shell tools are disabled. Explore and answer freely; if
+the user asks for a change, describe it in chat instead of attempting it (they can switch
+to plan or approval mode to have you make it)."""
+
 # Appended to the latest user message every turn while plan mode is active. The mode can
 # flip mid-session (plan approval), so this can't live in the static instructions.
 _PLAN_MODE_CONTEXT = """\
@@ -219,10 +226,10 @@ def build_engine(
         auto_allow_tools=set(config.auto_allow),
         roots=root_list or None,
     )
-    # Sessions that START in plan mode get the exit door: propose_plan, whose approval
-    # flips `permissions.mode` live (the engine handles the round-trip).
-    if mode is Mode.PLAN:
-        registry.register(propose_plan_tool())
+    # The plan-mode exit door. Always registered (surfaces can flip a live session into
+    # plan mode via set_mode, and the registry is fixed at build); the engine rejects the
+    # call whenever the session isn't actually in plan mode.
+    registry.register(propose_plan_tool())
 
     # Per-turn ephemeral context, appended to the latest user message since mid-thread system
     # messages aren't reliable across providers. Two producers: the plan-mode reminder (mode can
@@ -238,6 +245,8 @@ def build_engine(
         parts = []
         if permissions.mode is Mode.PLAN:
             parts.append(_PLAN_MODE_CONTEXT)
+        elif permissions.mode is Mode.DISCUSS:
+            parts.append(_DISCUSS_MODE_CONTEXT)
         if roots_context is not None:
             ctx = roots_context()
             if ctx:

--- a/platform/coworker/agent.py
+++ b/platform/coworker/agent.py
@@ -29,9 +29,35 @@ from .secrets import SecretStore, state_dir
 from .skills import SkillLoader, skill_catalog_text, skill_tools
 from .tools import ToolRegistry
 from .tools.directories import request_directory_tool
+from .tools.plan import propose_plan_tool
+from .tools.subagent import explorer_tools
 from .web import make_web_fetch_tool, make_web_search_tool
 from .tools.shell import LocalExecutor
 from .tools.todo import TodoList
+
+# Appended to the latest user message every turn while plan mode is active. The mode can
+# flip mid-session (plan approval), so this can't live in the static instructions.
+_PLAN_MODE_CONTEXT = """\
+Plan mode is active: write and shell tools are blocked. Explore read-only and design an
+approach. When you've committed to one, present it with `propose_plan` (what you'll change,
+in which files, how you'll verify) — don't describe edits as if you were making them. If
+the plan is approved, this same session switches to execution and you implement it; if
+rejected, revise the plan using the feedback."""
+
+# When-to-remember rules, injected only when a memory store is wired. Without these,
+# models either never call `remember` or save noise the repo already records.
+_MEMORY_GUIDANCE = """\
+Memory:
+- You have persistent memory across sessions. Use `remember` for durable facts: the user's \
+corrections and stated preferences (include the why), and project context you couldn't \
+rederive from the code. Don't save what the repo already records (code structure, git \
+history, AGENTS.md) or details that only matter to the current task. Use absolute dates, \
+never "yesterday".
+- Before saving, check the known-memories list: if an entry already covers it, revise that \
+entry with `memory_update` instead of adding a near-duplicate; retire wrong or obsolete \
+entries with `memory_forget`.
+- Memories reflect when they were written. If one names a file, flag, or URL, verify it \
+still exists before relying on it."""
 
 
 def _enabled_connector_tools(secrets: SecretStore) -> tuple[set[str], set[str]]:
@@ -78,6 +104,7 @@ def build_engine(
     audit_sink: Optional[Any] = None,
     roots: Optional[list] = None,
     directory_requester: Optional[Any] = None,
+    plan_approver: Optional[Any] = None,
 ) -> TurnEngine:
     ws = Path(workspace).expanduser().resolve() if workspace else None
     if agent.needs_workspace and ws is None:
@@ -129,6 +156,21 @@ def build_engine(
     # Web search + fetch: research tools for every agent (keyless DuckDuckGo default).
     registry.register(make_web_search_tool(secrets))
     registry.register(make_web_fetch_tool())
+    # Route by the model's `provider:` prefix (OpenAI default, Ollama, …). The manager normally
+    # passes its shared router; this fallback covers the TUI / direct build_engine() callers.
+    # Resolved here (not at engine construction) because the explorer subagent captures it.
+    provider = provider or ProviderRouter(secrets, default_provider="openai")
+    # The Code agent can fan broad research out to read-only explorer subagents, keeping its
+    # own context for the actual change.
+    if agent.name == "code" and ws is not None:
+        registry.register_all(
+            explorer_tools(
+                workspace=ws,
+                provider=provider,
+                model=model,
+                model_settings=model_settings,
+            )
+        )
     # Scheduling: Cowork + MyHelper can set up scheduled tasks (origin = this session).
     if (
         task_store is not None
@@ -156,6 +198,7 @@ def build_engine(
         registry.register_all(
             memory_tools(memory_store, workspace=str(ws) if ws else None)
         )
+        instructions = f"{instructions}\n\n{_MEMORY_GUIDANCE}"
         remembered = memory_store.list(scope=Scope.GLOBAL)
         if ws is not None:
             remembered += memory_store.list(scope=Scope.WORKSPACE, workspace=str(ws))
@@ -176,17 +219,30 @@ def build_engine(
         auto_allow_tools=set(config.auto_allow),
         roots=root_list or None,
     )
-    # Tell the agent, each turn, which directories it has and their access (orphan Cowork can gain
-    # folders mid-session) — appended to the latest user message since mid-thread system messages
-    # aren't reliable across providers. Multi-dir surfaces (Cowork/MyHelper) only.
-    context_provider = (
+    # Sessions that START in plan mode get the exit door: propose_plan, whose approval
+    # flips `permissions.mode` live (the engine handles the round-trip).
+    if mode is Mode.PLAN:
+        registry.register(propose_plan_tool())
+
+    # Per-turn ephemeral context, appended to the latest user message since mid-thread system
+    # messages aren't reliable across providers. Two producers: the plan-mode reminder (mode can
+    # flip mid-session, so it's checked each turn, not baked into the instructions) and the live
+    # directory list (orphan Cowork can gain folders mid-session; Cowork/MyHelper only).
+    roots_context = (
         (lambda: render_context(root_list))
         if root_list and agent.name in ("cowork", "myhelper")
         else None
     )
-    # Route by the model's `provider:` prefix (OpenAI default, Ollama, …). The manager normally
-    # passes its shared router; this fallback covers the TUI / direct build_engine() callers.
-    provider = provider or ProviderRouter(secrets, default_provider="openai")
+
+    def context_provider() -> str:
+        parts = []
+        if permissions.mode is Mode.PLAN:
+            parts.append(_PLAN_MODE_CONTEXT)
+        if roots_context is not None:
+            ctx = roots_context()
+            if ctx:
+                parts.append(ctx)
+        return "\n\n".join(parts)
 
     engine = TurnEngine(
         provider=provider,
@@ -203,6 +259,7 @@ def build_engine(
         audit_sink=audit_sink,
         context_provider=context_provider,
         directory_requester=directory_requester,
+        plan_approver=plan_approver,
     )
     engine.executor = executor  # type: ignore[attr-defined]
     engine.todo = todo  # type: ignore[attr-defined]

--- a/platform/coworker/agents/code.py
+++ b/platform/coworker/agents/code.py
@@ -20,6 +20,10 @@ before editing. Don't guess at APIs, signatures, or layout — read them. `git_l
 file evolved. Read meaningful chunks, not a line at a time.
 - Independent lookups run in parallel: when you need several reads/greps and none depends on \
 another's result, request them together in one batch instead of one per turn.
+- For broad questions spanning many files ("where is X handled?", "how does the Y flow \
+work?"), delegate to `explore` — a read-only subagent that searches in its own context and \
+returns only a report, keeping your context for the actual change. Independent explores can \
+run in parallel. For a single known file, just read it yourself.
 
 Match the codebase:
 - Write code that reads like the surrounding code: match its style, naming, structure, and \

--- a/platform/coworker/agents/code.py
+++ b/platform/coworker/agents/code.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import aisuite as ai
 
+from ..tools.files import file_tools
 from ..tools.git import git_tools
 from ..tools.search import search_tools
 from ..tools.shell import shell_tools
@@ -17,6 +18,8 @@ Understand before you change:
 - Explore first. Use `grep` and `read_file` to find the relevant code and learn how it works \
 before editing. Don't guess at APIs, signatures, or layout — read them. `git_log` shows how a \
 file evolved. Read meaningful chunks, not a line at a time.
+- Independent lookups run in parallel: when you need several reads/greps and none depends on \
+another's result, request them together in one batch instead of one per turn.
 
 Match the codebase:
 - Write code that reads like the surrounding code: match its style, naming, structure, and \
@@ -35,10 +38,13 @@ Patch / *** Update File / @@ / +/- lines / *** End Patch) for targeted multi-lin
 `apply_unified_diff` for standard unified diffs; `write_file` for new files or full rewrites.
 
 Verify:
-- `run_shell` is a persistent bash (cd and env persist). After changes, run the narrowest \
+- `run_shell` is a persistent shell (cd and env persist). After changes, run the narrowest \
 relevant test/build/lint to confirm your work. Don't report something done without verifying \
 it; if you can't verify, say so plainly. Don't repeat a failing command — if stuck after 2–3 \
 attempts, step back, reconsider, and surface the blocker.
+- Pass a short `description` with each command (shown in approval prompts), and raise \
+`timeout_seconds` for slow builds/tests. For long-running processes (dev servers, watchers), \
+set `run_in_background` and poll `shell_task_output`; stop them with `shell_task_kill`.
 
 Plan multi-step work:
 - For anything beyond a few steps, maintain a task list with `todo_write`: keep exactly one \
@@ -59,14 +65,17 @@ the request is ambiguous rather than guessing."""
 def code_agent() -> Agent:
     def factory(context: AgentContext) -> list:
         ws = str(context.workspace)
-        # Our `grep` (ripgrep, .gitignore-aware) replaces the toolkit's slower search_files.
+        # Our `grep` (ripgrep, .gitignore-aware) replaces the toolkit's slower search_files;
+        # our line-numbered, windowing `read_file` replaces its read_file/read_file_lines.
+        replaced = {"search_files", "read_file", "read_file_lines"}
         files = [
             t
             for t in ai.toolkits.files(root=ws, allow_write=True)
-            if getattr(t, "__name__", "") != "search_files"
+            if getattr(t, "__name__", "") not in replaced
         ]
         tools = [
             *files,
+            *file_tools(ws),  # read_file (numbered lines, windowed)
             *ai.toolkits.git(root=ws),  # git_status, git_diff
             *git_tools(ws),  # git_log
             *search_tools(ws),  # grep

--- a/platform/coworker/engine.py
+++ b/platform/coworker/engine.py
@@ -19,7 +19,7 @@ from enum import Enum
 from typing import Any, AsyncIterator, Awaitable, Callable, Optional
 
 from .events import Event, EventType
-from .permissions import PermissionEngine
+from .permissions import Mode, PermissionEngine
 from .providers import AssistantTurn, ProviderClient, ToolCall
 from .tools import ToolRegistry
 
@@ -64,6 +64,9 @@ class TurnEngine:
         directory_requester: Optional[
             Callable[[dict[str, Any]], "Awaitable[dict[str, Any]]"]
         ] = None,
+        plan_approver: Optional[
+            Callable[[dict[str, Any]], "Awaitable[dict[str, Any]]"]
+        ] = None,
     ) -> None:
         self.provider = provider
         self.registry = registry
@@ -83,6 +86,10 @@ class TurnEngine:
         # user to grant/decline a folder out-of-band, applies the grant to this live session, and
         # returns the outcome. None on surfaces that can't prompt (the tool then no-ops).
         self.directory_requester = directory_requester
+        # Handles the `propose_plan` tool: emits PLAN_PROPOSED, waits for the user's decision.
+        # An approving result flips the live PermissionEngine out of plan mode (same session,
+        # context kept). None on surfaces that can't prompt (the tool then no-ops).
+        self.plan_approver = plan_approver
         self.audit_context: dict[str, Any] = {}
         if instructions and not (
             self.messages and self.messages[0].get("role") == "system"
@@ -203,11 +210,20 @@ class TurnEngine:
         run concurrently; everything else runs one at a time in call order."""
         cleared: list[ToolCall] = []
         for tool_call in tool_calls:
-            # `request_directory` is interactive: the user grants a folder out-of-band and
-            # the live session gains it. The grant IS the consent, so it skips the
+            yield Event(
+                EventType.TOOL_PROPOSED,
+                {"name": tool_call.name, "arguments": tool_call.arguments},
+            )
+            self._audit(tool_call, stage="proposed")
+            # `request_directory` and `propose_plan` are interactive: the user decides
+            # out-of-band and that decision IS the consent, so they skip the
             # permission/registry path.
             if tool_call.name == "request_directory":
                 async for event in self._handle_directory_request(tool_call):
+                    yield event
+                continue
+            if tool_call.name == "propose_plan":
+                async for event in self._handle_plan_proposal(tool_call):
                     yield event
                 continue
             allowed = False
@@ -252,16 +268,11 @@ class TurnEngine:
         )
 
     async def _authorize(self, tool_call: ToolCall) -> "AsyncIterator[Event | bool]":
-        """Permission flow for one call. Yields its events, then True/False (allowed) last.
-        Denied/unknown calls get their tool-error message appended here."""
+        """Permission flow for one call (TOOL_PROPOSED is emitted by the caller). Yields
+        its events, then True/False (allowed) last. Denied/unknown calls get their
+        tool-error message appended here."""
         spec = self.registry.get(tool_call.name)
         metadata = spec.metadata if spec else None
-
-        yield Event(
-            EventType.TOOL_PROPOSED,
-            {"name": tool_call.name, "arguments": tool_call.arguments},
-        )
-        self._audit(tool_call, stage="proposed")
 
         decision = self.permissions.evaluate(
             tool_call.name, tool_call.arguments, metadata
@@ -376,6 +387,57 @@ class TurnEngine:
             self.audit_sink(payload)
         except Exception:
             pass
+
+    async def _handle_plan_proposal(self, tool_call: ToolCall) -> AsyncIterator[Event]:
+        """Emit the plan for review, await the user's out-of-band decision, and apply it:
+        approval flips the live PermissionEngine out of plan mode (the same session keeps
+        going, with all its exploration context); rejection keeps plan mode and returns
+        the user's feedback so the agent can revise."""
+        args = tool_call.arguments or {}
+        plan = str(args.get("plan", ""))
+        if self.plan_approver is None:
+            result: dict[str, Any] = {
+                "approved": False,
+                "error": "plan approval isn't available here",
+            }
+        else:
+            yield Event(EventType.PLAN_PROPOSED, {"plan": plan})
+            self._audit(tool_call, stage="plan_proposed")
+            result = await self.plan_approver(dict(args)) or {
+                "approved": False,
+                "error": "no response",
+            }
+
+        if result.get("approved"):
+            # The approver may pick the post-plan mode ("interactive" asks per write,
+            # "auto" executes the approved plan without further prompts).
+            try:
+                self.permissions.mode = Mode(str(result.get("mode", "interactive")))
+            except ValueError:
+                self.permissions.mode = Mode.INTERACTIVE
+            result = {
+                **result,
+                "mode": self.permissions.mode.value,
+                "note": "plan approved — implement it now",
+            }
+
+        status = "ok" if result.get("approved") else "denied"
+        self.messages.append(_tool_result_message(tool_call, result))
+        self._audit(
+            tool_call,
+            stage="finished",
+            status=status,
+            result=result,
+            result_preview=_preview(result),
+        )
+        yield Event(
+            EventType.TOOL_FINISHED,
+            {
+                "name": tool_call.name,
+                "status": status,
+                "result_preview": _preview(result),
+            },
+        )
 
     async def _handle_directory_request(
         self, tool_call: ToolCall

--- a/platform/coworker/engine.py
+++ b/platform/coworker/engine.py
@@ -395,8 +395,21 @@ class TurnEngine:
         the user's feedback so the agent can revise."""
         args = tool_call.arguments or {}
         plan = str(args.get("plan", ""))
-        if self.plan_approver is None:
-            result: dict[str, Any] = {
+        if self.permissions.mode is not Mode.PLAN:
+            # The tool is always registered (mode can flip mid-session), but proposing a
+            # plan only means something while the session is actually in plan mode. The
+            # right next step differs by mode: discuss stays read-only, so the agent
+            # should talk through the change; write-capable modes should just do it.
+            if self.permissions.mode is Mode.DISCUSS:
+                error = (
+                    "not in plan mode — this is discuss mode (read-only), so describe "
+                    "the proposed changes in chat instead"
+                )
+            else:
+                error = "not in plan mode — proceed with the work directly"
+            result: dict[str, Any] = {"approved": False, "error": error}
+        elif self.plan_approver is None:
+            result = {
                 "approved": False,
                 "error": "plan approval isn't available here",
             }

--- a/platform/coworker/engine.py
+++ b/platform/coworker/engine.py
@@ -3,6 +3,8 @@
 Async, but with blocking provider/tool calls wrapped in `asyncio.to_thread` so the loop
 (and any UI consuming its events) stays responsive. One user turn spans many model↔tool
 iterations until the model stops requesting tools, a rail trips, or it's interrupted.
+When the model requests several tool calls in one turn, low-risk ones (reads, searches)
+execute concurrently; writes/shell stay strictly ordered.
 
 Approvals are handled out-of-band via an injected async `approver`: when the permission
 engine says `needs_user`, the engine emits `PERMISSION_REQUIRED` and awaits the approver.
@@ -147,9 +149,8 @@ class TurnEngine:
                 )
                 return
 
-            for tool_call in turn.tool_calls:
-                async for event in self._handle_tool_call(tool_call):
-                    yield event
+            async for event in self._handle_tool_calls(turn.tool_calls):
+                yield event
 
             yield Event(EventType.ITERATION_END, {"iteration": iterations})
 
@@ -194,7 +195,65 @@ class TurnEngine:
             else:
                 return
 
-    async def _handle_tool_call(self, tool_call: ToolCall) -> AsyncIterator[Event]:
+    async def _handle_tool_calls(
+        self, tool_calls: list[ToolCall]
+    ) -> AsyncIterator[Event]:
+        """Run one assistant turn's tool calls: authorize all of them first (sequentially —
+        approval prompts are interactive), then execute. Low-risk calls (reads, searches)
+        run concurrently; everything else runs one at a time in call order."""
+        cleared: list[ToolCall] = []
+        for tool_call in tool_calls:
+            # `request_directory` is interactive: the user grants a folder out-of-band and
+            # the live session gains it. The grant IS the consent, so it skips the
+            # permission/registry path.
+            if tool_call.name == "request_directory":
+                async for event in self._handle_directory_request(tool_call):
+                    yield event
+                continue
+            allowed = False
+            async for item in self._authorize(tool_call):
+                if isinstance(item, Event):
+                    yield item
+                else:
+                    allowed = item
+            if allowed:
+                cleared.append(tool_call)
+
+        concurrent = (
+            [tc for tc in cleared if self._parallel_safe(tc)]
+            if len(cleared) > 1
+            else []
+        )
+        serial = [tc for tc in cleared if tc not in concurrent]
+
+        if concurrent:
+            for tool_call in concurrent:
+                yield Event(EventType.TOOL_STARTED, {"name": tool_call.name})
+                self._audit(tool_call, stage="started")
+            outcomes = await asyncio.gather(
+                *[asyncio.to_thread(self._execute_sync, tc) for tc in concurrent]
+            )
+            for tool_call, (result, status) in zip(concurrent, outcomes):
+                yield self._record_result(tool_call, result, status)
+
+        for tool_call in serial:
+            yield Event(EventType.TOOL_STARTED, {"name": tool_call.name})
+            self._audit(tool_call, stage="started")
+            result, status = await asyncio.to_thread(self._execute_sync, tool_call)
+            yield self._record_result(tool_call, result, status)
+
+    def _parallel_safe(self, tool_call: ToolCall) -> bool:
+        # Only metadata-declared low-risk tools (reads, searches, git queries) run
+        # concurrently; writes, shell, and anything unannotated stay strictly ordered.
+        spec = self.registry.get(tool_call.name)
+        metadata = spec.metadata if spec else None
+        return getattr(metadata, "risk_level", "") == "low" and not getattr(
+            metadata, "requires_approval", False
+        )
+
+    async def _authorize(self, tool_call: ToolCall) -> "AsyncIterator[Event | bool]":
+        """Permission flow for one call. Yields its events, then True/False (allowed) last.
+        Denied/unknown calls get their tool-error message appended here."""
         spec = self.registry.get(tool_call.name)
         metadata = spec.metadata if spec else None
 
@@ -203,13 +262,6 @@ class TurnEngine:
             {"name": tool_call.name, "arguments": tool_call.arguments},
         )
         self._audit(tool_call, stage="proposed")
-
-        # `request_directory` is interactive: the user grants a folder out-of-band and the live
-        # session gains it. The grant IS the consent, so it skips the permission/registry path.
-        if tool_call.name == "request_directory":
-            async for event in self._handle_directory_request(tool_call):
-                yield event
-            return
 
         decision = self.permissions.evaluate(
             tool_call.name, tool_call.arguments, metadata
@@ -270,6 +322,7 @@ class TurnEngine:
                 {"name": tool_call.name, "status": "denied", "reason": reason},
             )
             self._audit(tool_call, stage="finished", status="denied", reason=reason)
+            yield False
             return
 
         if spec is None:
@@ -280,19 +333,19 @@ class TurnEngine:
                 EventType.TOOL_FINISHED,
                 {"name": tool_call.name, "status": "error", "reason": "unknown tool"},
             )
+            yield False
             return
 
-        yield Event(EventType.TOOL_STARTED, {"name": tool_call.name})
-        self._audit(tool_call, stage="started")
-        try:
-            result = await asyncio.to_thread(
-                self.registry.execute, tool_call.name, tool_call.arguments
-            )
-            status = "ok"
-        except Exception as exc:
-            result = {"error": str(exc), "error_type": type(exc).__name__}
-            status = "error"
+        yield True
 
+    def _execute_sync(self, tool_call: ToolCall) -> tuple[Any, str]:
+        """Execute one authorized call (runs in a worker thread)."""
+        try:
+            return self.registry.execute(tool_call.name, tool_call.arguments), "ok"
+        except Exception as exc:
+            return {"error": str(exc), "error_type": type(exc).__name__}, "error"
+
+    def _record_result(self, tool_call: ToolCall, result: Any, status: str) -> Event:
         self.messages.append(_tool_result_message(tool_call, result))
         self._audit(
             tool_call,
@@ -301,7 +354,7 @@ class TurnEngine:
             result=result,
             result_preview=_preview(result),
         )
-        yield Event(
+        return Event(
             EventType.TOOL_FINISHED,
             {
                 "name": tool_call.name,

--- a/platform/coworker/environment.py
+++ b/platform/coworker/environment.py
@@ -1,0 +1,72 @@
+"""Session environment context — injected into the system prompt at engine build.
+
+Saves the agent 3-4 discovery tool calls every session (pwd, uname, git status, git log)
+by telling it up front where it is and what state the workspace is in. The git snapshot is
+point-in-time; the prompt labels it as such so the agent re-checks before relying on it.
+"""
+
+from __future__ import annotations
+
+import platform as _platform
+import subprocess
+import sys
+from datetime import date
+from pathlib import Path
+from typing import Optional
+
+
+def _git(workspace: Path, *args: str) -> Optional[str]:
+    try:
+        out = subprocess.run(
+            ["git", "-C", str(workspace), *args],
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+    if out.returncode != 0:
+        return None
+    return out.stdout.strip()
+
+
+def _git_snapshot(workspace: Path) -> list[str]:
+    if _git(workspace, "rev-parse", "--is-inside-work-tree") != "true":
+        return ["Git: not a git repository"]
+
+    lines = []
+    branch = _git(workspace, "rev-parse", "--abbrev-ref", "HEAD") or "(unknown)"
+    lines.append(f"Git branch: {branch}")
+
+    status = _git(workspace, "status", "--porcelain")
+    if status is not None:
+        changed = status.splitlines()
+        if not changed:
+            lines.append("Git status: clean")
+        else:
+            shown = "\n".join(changed[:20])
+            more = f"\n… and {len(changed) - 20} more" if len(changed) > 20 else ""
+            lines.append(f"Git status ({len(changed)} changed):\n{shown}{more}")
+
+    log = _git(workspace, "log", "-n5", "--pretty=format:%h %s")
+    if log:
+        lines.append(f"Recent commits:\n{log}")
+    return lines
+
+
+def environment_context(workspace: str | Path) -> str:
+    """A system-prompt block describing the session's environment and git state."""
+    ws = Path(workspace).expanduser().resolve()
+    mac = _platform.mac_ver()[0]
+    os_name = f"macOS {mac}" if mac else f"{_platform.system()} {_platform.release()}"
+    lines = [
+        f"Workspace: {ws}",
+        f"Platform: {sys.platform} ({os_name})",
+        f"Today's date: {date.today().isoformat()}",
+        *_git_snapshot(ws),
+    ]
+    body = "\n".join(lines)
+    return (
+        "Environment (snapshot from session start — verify before relying on git "
+        f"state):\n<environment>\n{body}\n</environment>"
+    )

--- a/platform/coworker/events.py
+++ b/platform/coworker/events.py
@@ -18,6 +18,9 @@ class EventType(str, Enum):
     TOOL_PROPOSED = "tool_proposed"
     PERMISSION_REQUIRED = "permission_required"
     DIRECTORY_REQUESTED = "directory_requested"  # agent asks the user to grant a folder
+    PLAN_PROPOSED = (
+        "plan_proposed"  # agent presents a plan for approval (plan mode exit)
+    )
     TOOL_STARTED = "tool_started"
     TOOL_FINISHED = "tool_finished"
     ITERATION_END = "iteration_end"

--- a/platform/coworker/memory/base.py
+++ b/platform/coworker/memory/base.py
@@ -62,8 +62,9 @@ class MemoryStore(ABC):
 
 
 def format_memories(items: list[MemoryItem]) -> str:
-    """Render memories for injection into the system prompt."""
+    """Render memories for injection into the system prompt. Ids are shown so the agent
+    can revise a memory (`memory_update`) or retire it (`memory_forget`)."""
     if not items:
         return ""
-    lines = [f"- {item.content}" for item in items]
+    lines = [f"- [#{item.id}] {item.content}" for item in items]
     return "Known memories (from earlier sessions):\n" + "\n".join(lines)

--- a/platform/coworker/memory/tools.py
+++ b/platform/coworker/memory/tools.py
@@ -1,4 +1,9 @@
-"""The `remember` tool — the agent's explicit write path into memory."""
+"""Memory tools — the agent's explicit write paths into memory.
+
+`remember` saves a new fact; `memory_update` / `memory_forget` revise or retire one by
+the [#id] shown in the known-memories block, so corrections replace stale facts instead
+of piling up next to them.
+"""
 
 from __future__ import annotations
 
@@ -10,10 +15,14 @@ from .base import MemoryStore, Scope
 
 _SCOPES = {s.value for s in Scope}
 
+_META = dict(category="memory", risk_level="low", capabilities=["remember"])
+
 
 def memory_tools(store: MemoryStore, *, workspace: Optional[str]) -> list:
     def remember(content: str, scope: str = "workspace") -> dict:
         """Save a durable memory (a fact or preference) to recall in future sessions.
+        Check the known-memories list first: if one already covers this, use
+        memory_update instead of saving a near-duplicate.
 
         Args:
             content (str): The thing to remember.
@@ -27,13 +36,29 @@ def memory_tools(store: MemoryStore, *, workspace: Optional[str]) -> list:
         )
         return {"id": item.id, "scope": item.scope.value, "saved": True}
 
+    def memory_update(memory_id: int, content: str) -> dict:
+        """Rewrite an existing memory with corrected or refined content.
+
+        Args:
+            memory_id (int): The memory's id, from the [#id] in the known-memories list.
+            content (str): The full corrected memory text (replaces the old text).
+        """
+        item = store.update(memory_id, content)
+        if item is None:
+            return {"updated": False, "error": f"no memory with id {memory_id}"}
+        return {"updated": True, "id": item.id}
+
+    def memory_forget(memory_id: int) -> dict:
+        """Delete a memory that turned out to be wrong or is no longer true.
+
+        Args:
+            memory_id (int): The memory's id, from the [#id] in the known-memories list.
+        """
+        if store.delete(memory_id):
+            return {"deleted": True, "id": memory_id}
+        return {"deleted": False, "error": f"no memory with id {memory_id}"}
+
     return [
-        ai.tool(
-            remember,
-            metadata=ai.ToolMetadata(
-                category="memory",
-                risk_level="low",
-                capabilities=["remember"],
-            ),
-        )
+        ai.tool(fn, metadata=ai.ToolMetadata(**_META))
+        for fn in (remember, memory_update, memory_forget)
     ]

--- a/platform/coworker/permissions.py
+++ b/platform/coworker/permissions.py
@@ -15,10 +15,18 @@ from typing import Any, Optional
 
 
 class Mode(str, Enum):
-    PLAN = "plan"  # read-only
+    DISCUSS = "discuss"  # read-only conversation: no edits, no planning workflow
+    PLAN = (
+        "plan"  # read-only + the planning contract (explore → propose_plan → execute)
+    )
     INTERACTIVE = "interactive"  # ask for approval (default)
     AUTO = "auto"  # full access
     CUSTOM = "custom"  # interactive + auto-allow the config's `auto_allow` tools
+
+
+# Modes whose enforcement is read-only. DISCUSS and PLAN share the same gate; they differ
+# only in intent — PLAN additionally drives the agent toward a propose_plan approval.
+READ_ONLY_MODES = frozenset({Mode.DISCUSS, Mode.PLAN})
 
 
 @dataclass
@@ -74,9 +82,11 @@ class PermissionEngine:
         is_shell = tool_name == SHELL_TOOL
         consequential = is_write or is_shell or requires_approval
 
-        # Plan mode: read-only.
-        if self.mode is Mode.PLAN and consequential:
-            return Decision(False, "plan mode is read-only", needs_user=False)
+        # Discuss / plan modes: read-only.
+        if self.mode in READ_ONLY_MODES and consequential:
+            return Decision(
+                False, f"{self.mode.value} mode is read-only", needs_user=False
+            )
 
         # Path scoping for writes that name a path (all modes): must land in a writable root.
         if is_write:

--- a/platform/coworker/server/app.py
+++ b/platform/coworker/server/app.py
@@ -370,6 +370,7 @@ def create_app(manager: SessionManager) -> FastAPI:
         await ws.accept()
         approval_queue: asyncio.Queue[str] = asyncio.Queue()
         directory_queue: asyncio.Queue[dict] = asyncio.Queue()
+        plan_queue: asyncio.Queue[dict] = asyncio.Queue()
 
         async def approver(_request) -> ApprovalOutcome:
             decision = await approval_queue.get()
@@ -377,6 +378,18 @@ def create_app(manager: SessionManager) -> FastAPI:
                 return ApprovalOutcome(decision)
             except ValueError:
                 return ApprovalOutcome.DENY
+
+        async def plan_approver(_args: dict) -> dict:
+            # The engine has already emitted PLAN_PROPOSED; wait for the user's verdict.
+            # Approval carries the post-plan mode ("interactive" or "auto"); rejection
+            # carries feedback the agent uses to revise the plan.
+            resp = await plan_queue.get()
+            if not resp.get("approved"):
+                return {
+                    "approved": False,
+                    "feedback": resp.get("feedback") or "the user rejected the plan",
+                }
+            return {"approved": True, "mode": resp.get("mode") or "interactive"}
 
         async def directory_requester(args: dict) -> dict:
             # The engine has already emitted DIRECTORY_REQUESTED; wait for the user's reply, then
@@ -422,6 +435,7 @@ def create_app(manager: SessionManager) -> FastAPI:
             approver=approver,
             extra_tools=mcp_tools,
             directory_requester=directory_requester,
+            plan_approver=plan_approver,
         )
         if engine is None:
             await ws.send_json(
@@ -460,6 +474,7 @@ def create_app(manager: SessionManager) -> FastAPI:
             "turn_start",
             "permission_required",
             "directory_requested",
+            "plan_proposed",
             "iteration_end",
         }
 
@@ -481,6 +496,8 @@ def create_app(manager: SessionManager) -> FastAPI:
                     approval_queue.put_nowait(message.get("decision", "deny"))
                 elif kind == "directory_response":
                     directory_queue.put_nowait(message)
+                elif kind == "plan_response":
+                    plan_queue.put_nowait(message)
                 elif kind == "interrupt":
                     engine.request_interrupt()
                 elif kind == "set_mode":

--- a/platform/coworker/server/manager.py
+++ b/platform/coworker/server/manager.py
@@ -184,6 +184,7 @@ class SessionManager:
         approver: Optional[Approver] = None,
         extra_tools: Optional[list[Any]] = None,
         directory_requester: Optional[Any] = None,
+        plan_approver: Optional[Any] = None,
     ) -> Optional[TurnEngine]:
         engine = self._engines.get(session_id)
         if engine is not None:
@@ -191,6 +192,8 @@ class SessionManager:
                 engine.approver = approver
             if directory_requester is not None:
                 engine.directory_requester = directory_requester
+            if plan_approver is not None:
+                engine.plan_approver = plan_approver
             return engine
 
         record = self.session_store.load(session_id)
@@ -241,6 +244,7 @@ class SessionManager:
             audit_sink=self.audit_store.append,
             roots=roots,
             directory_requester=directory_requester,
+            plan_approver=plan_approver,
         )
         self._engines[session_id] = engine
         return engine

--- a/platform/coworker/server/run.py
+++ b/platform/coworker/server/run.py
@@ -114,7 +114,9 @@ def main(argv=None) -> None:
     parser.add_argument("--cwd", default=None, help="optional seed/default workspace")
     parser.add_argument("--model", default=cfg.model)
     parser.add_argument(
-        "--mode", default=cfg.mode, choices=["plan", "interactive", "auto"]
+        "--mode",
+        default=cfg.mode,
+        choices=["discuss", "plan", "interactive", "auto"],
     )
     parser.add_argument("--host", default=cfg.host)
     parser.add_argument("--port", type=int, default=cfg.port)

--- a/platform/coworker/tools/files.py
+++ b/platform/coworker/tools/files.py
@@ -1,0 +1,113 @@
+"""Line-numbered file reading (`read_file`) — replaces the aisuite toolkit's reader.
+
+The toolkit's `read_file` returns raw text (the agent can't cite path:line without
+counting) and raises outright on large files (the agent errors and guesses). This one
+returns `cat -n`-style numbered lines, windows big files instead of failing, and tells
+the agent how to continue reading. Read-only, workspace-scoped.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import aisuite as ai
+
+_DEFAULT_MAX_LINES = 2000
+_MAX_LINE_CHARS = 500
+
+_SCHEMA = {
+    "type": "function",
+    "function": {
+        "name": "read_file",
+        "description": (
+            "Read a text file, returning numbered lines ('   12\\ttext') so code can be "
+            "referenced as path:line. Large files are windowed: pass start_line to continue "
+            "where the previous read stopped. Read-only."
+        ),
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "path": {
+                    "type": "string",
+                    "description": "File path, relative to the workspace.",
+                },
+                "start_line": {
+                    "type": "integer",
+                    "description": "First line to read, 1-based (default 1).",
+                },
+                "max_lines": {
+                    "type": "integer",
+                    "description": f"How many lines (default {_DEFAULT_MAX_LINES}).",
+                },
+            },
+            "required": ["path"],
+        },
+    },
+}
+
+
+def file_tools(workspace: str) -> list:
+    root = Path(workspace).resolve()
+
+    def read_file(
+        path: str,
+        start_line: int = 1,
+        max_lines: int = _DEFAULT_MAX_LINES,
+    ) -> dict[str, Any]:
+        start = start_line if isinstance(start_line, int) and start_line > 0 else 1
+        n = (
+            max_lines
+            if isinstance(max_lines, int) and max_lines > 0
+            else _DEFAULT_MAX_LINES
+        )
+        n = min(n, _DEFAULT_MAX_LINES)
+        target = (root / path).resolve()
+        try:
+            target.relative_to(root)  # keep reads inside the workspace
+        except ValueError:
+            return {"error": "path escapes the workspace"}
+        if not target.is_file():
+            return {"error": f"not a file: {path}"}
+
+        selected: list[str] = []
+        total = 0
+        try:
+            with open(target, "r", encoding="utf-8", errors="replace") as fh:
+                for i, line in enumerate(fh, 1):
+                    total = i
+                    if i < start or len(selected) >= n:
+                        continue
+                    text = line.rstrip("\n")
+                    if len(text) > _MAX_LINE_CHARS:
+                        text = text[:_MAX_LINE_CHARS] + "… (line truncated)"
+                    selected.append(f"{i:>6}\t{text}")
+        except OSError as exc:
+            return {"error": f"read failed: {exc}"}
+
+        end = start + len(selected) - 1 if selected else start - 1
+        result: dict[str, Any] = {
+            "path": str(target.relative_to(root)),
+            "start_line": start,
+            "end_line": end,
+            "total_lines": total,
+            "content": "\n".join(selected),
+        }
+        if end < total:
+            result["note"] = (
+                f"showing lines {start}-{end} of {total}; "
+                f"call again with start_line={end + 1} to continue"
+            )
+        return result
+
+    read_file.__name__ = "read_file"
+    read_file.__doc__ = _SCHEMA["function"]["description"]
+    read_file.__aisuite_tool_metadata__ = ai.ToolMetadata(
+        name="read_file",
+        category="filesystem",
+        risk_level="low",
+        capabilities=["read"],
+        requires_approval=False,
+    )
+    read_file.__coworker_schema__ = _SCHEMA
+    return [read_file]

--- a/platform/coworker/tools/plan.py
+++ b/platform/coworker/tools/plan.py
@@ -1,0 +1,43 @@
+"""The `propose_plan` tool — the agent presents its plan and asks to start executing.
+
+Registered only when the session starts in plan mode. Like `request_directory`, it is
+intercepted by the TurnEngine: it emits a PLAN_PROPOSED event and waits for the user's
+out-of-band decision. Approval flips the live PermissionEngine out of plan mode (same
+session, full exploration context kept); rejection returns the user's feedback so the
+agent can revise the plan. The callable here is only a schema carrier + a safe fallback
+for surfaces without an approver.
+"""
+
+from __future__ import annotations
+
+from aisuite.agents import ToolMetadata, tool
+
+
+def propose_plan_tool() -> object:
+    def propose_plan(plan: str) -> dict:
+        """Present your implementation plan to the user for approval. Use this once you
+        have explored enough to commit to an approach: summarize what you'll change, in
+        which files, and how you'll verify it. If approved, the session switches out of
+        read-only plan mode and you implement the plan; if rejected, revise it using the
+        feedback in the result. Don't start describing implementation steps as if you
+        were doing them — propose first.
+        """
+        # Real handling lives in the engine (it needs the out-of-band approval round-trip).
+        # This body only runs if no approver is wired (e.g. a headless surface).
+        return {
+            "approved": False,
+            "error": "plan approval isn't available in this surface",
+        }
+
+    return tool(
+        propose_plan,
+        metadata=ToolMetadata(
+            category="planning",
+            risk_level="low",
+            capabilities=["plan"],
+            description=(
+                "Present the implementation plan for user approval; approval exits "
+                "read-only plan mode and starts execution."
+            ),
+        ),
+    )

--- a/platform/coworker/tools/shell.py
+++ b/platform/coworker/tools/shell.py
@@ -13,6 +13,11 @@ Safety here is permission-gating (high-risk tool → approval) + per-command tim
 best-effort non-interactive enforcement. A timed-out command is interrupted (SIGINT to the
 foreground child on POSIX, Ctrl-Break to the child group on Windows); the shell survives so
 session state is preserved.
+
+Background tasks (`run_shell` with `run_in_background`) get their own detached process —
+NOT the persistent shell — so a dev server can run while the session keeps working. They
+are deliberately not killed by `close()` (which the timeout-recovery path calls); they end
+when they exit or via `shell_task_kill`.
 """
 
 from __future__ import annotations
@@ -33,6 +38,11 @@ import aisuite as ai
 
 _IS_WINDOWS = sys.platform == "win32"
 
+# Foreground timeout bounds: long enough for installs/builds/test runs by default, capped so
+# a model-requested timeout can't wedge the turn for more than ten minutes.
+_DEFAULT_TIMEOUT = 120.0
+_MAX_TIMEOUT = 600.0
+
 # Env defaults that discourage commands from blocking on a prompt.
 _NONINTERACTIVE_ENV = {
     "GIT_TERMINAL_PROMPT": "0",
@@ -46,11 +56,82 @@ class Executor(ABC):
     @abstractmethod
     def run(self, command: str, timeout: Optional[float] = None) -> dict[str, Any]: ...
 
+    def run_background(self, command: str) -> dict[str, Any]:
+        return {"error": "background execution is not supported by this executor"}
+
+    def background_output(self, task_id: str) -> dict[str, Any]:
+        return {"error": "background execution is not supported by this executor"}
+
+    def background_kill(self, task_id: str) -> dict[str, Any]:
+        return {"error": "background execution is not supported by this executor"}
+
     def interrupt(self) -> None:  # pragma: no cover - default no-op
         pass
 
     def close(self) -> None:  # pragma: no cover - default no-op
         pass
+
+
+class _BackgroundTask:
+    """One detached background command: its own process (not the persistent shell), a
+    reader thread draining output into a buffer, and an incremental-read cursor."""
+
+    def __init__(self, task_id: str, command: str, cwd: str, env: dict[str, str]):
+        self.id = task_id
+        self.command = command
+        if _IS_WINDOWS:
+            argv = ["powershell.exe", "-NoProfile", "-Command", command]
+            spawn_kwargs: dict[str, Any] = {
+                "creationflags": subprocess.CREATE_NEW_PROCESS_GROUP
+            }
+        else:
+            argv = ["/bin/bash", "-c", command]
+            spawn_kwargs = {"start_new_session": True}
+        self.proc = subprocess.Popen(
+            argv,
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            cwd=cwd,
+            text=True,
+            bufsize=1,
+            env=env,
+            **spawn_kwargs,
+        )
+        self._lock = threading.Lock()
+        self._lines: list[str] = []
+        self._cursor = 0
+        self._reader = threading.Thread(target=self._read_loop, daemon=True)
+        self._reader.start()
+
+    def _read_loop(self) -> None:
+        assert self.proc.stdout is not None
+        for line in self.proc.stdout:
+            with self._lock:
+                self._lines.append(line)
+
+    def read_new(self) -> str:
+        with self._lock:
+            new = "".join(self._lines[self._cursor :])
+            self._cursor = len(self._lines)
+        return new
+
+    def kill(self) -> None:
+        if self.proc.poll() is not None:
+            return
+        if _IS_WINDOWS:
+            try:
+                subprocess.run(
+                    ["taskkill", "/F", "/T", "/PID", str(self.proc.pid)],
+                    capture_output=True,
+                )
+            except (OSError, subprocess.SubprocessError):
+                pass
+            return
+        try:
+            os.killpg(os.getpgid(self.proc.pid), signal.SIGTERM)
+        except (ProcessLookupError, PermissionError, OSError):
+            pass
 
 
 class LocalExecutor(Executor):
@@ -60,7 +141,7 @@ class LocalExecutor(Executor):
         cwd: str | Path,
         env: Optional[dict[str, str]] = None,
         shell_path: Optional[str] = None,
-        default_timeout: float = 30.0,
+        default_timeout: float = _DEFAULT_TIMEOUT,
         max_output_chars: int = 20_000,
     ) -> None:
         self.cwd = str(Path(cwd).expanduser().resolve())
@@ -68,6 +149,8 @@ class LocalExecutor(Executor):
         self.max_output_chars = max_output_chars
         self._marker = f"__COWORKER_DONE_{uuid.uuid4().hex}__"
         self._is_windows = _IS_WINDOWS
+        self._bg_tasks: dict[str, _BackgroundTask] = {}
+        self._bg_counter = 0
 
         # Pick a native shell per-OS. POSIX drives bash line-by-line; Windows drives
         # PowerShell in `-Command -` mode, which is a true stdin REPL (executes
@@ -193,10 +276,59 @@ class LocalExecutor(Executor):
         output = "".join(lines)
         truncated = len(output) > self.max_output_chars
         if truncated:
-            output = output[: self.max_output_chars]
+            # Keep the TAIL: builds and test runners put the verdict at the end.
+            output = output[-self.max_output_chars :]
         return self._result(
             command, exit_code, output, timed_out=timed_out, truncated=truncated
         )
+
+    # -- background tasks ---------------------------------------------------------
+    def run_background(self, command: str) -> dict[str, Any]:
+        self._bg_counter += 1
+        task_id = f"bg-{self._bg_counter}"
+        try:
+            task = _BackgroundTask(task_id, command, self.cwd, self._env)
+        except OSError as exc:
+            return {"error": f"failed to start background task: {exc}"}
+        self._bg_tasks[task_id] = task
+        return {
+            "task_id": task_id,
+            "command": command,
+            "status": "running",
+            "note": "use shell_task_output to read its output, shell_task_kill to stop it",
+        }
+
+    def background_output(self, task_id: str) -> dict[str, Any]:
+        task = self._bg_tasks.get(task_id)
+        if task is None:
+            return {"error": f"unknown task: {task_id}"}
+        output = task.read_new()
+        truncated = len(output) > self.max_output_chars
+        if truncated:
+            output = output[-self.max_output_chars :]
+        exit_code = task.proc.poll()
+        return {
+            "task_id": task_id,
+            "status": "running" if exit_code is None else "exited",
+            "exit_code": exit_code,
+            "output": output,
+            "truncated": truncated,
+        }
+
+    def background_kill(self, task_id: str) -> dict[str, Any]:
+        task = self._bg_tasks.get(task_id)
+        if task is None:
+            return {"error": f"unknown task: {task_id}"}
+        task.kill()
+        try:
+            task.proc.wait(timeout=5)
+        except (subprocess.TimeoutExpired, OSError):
+            pass
+        return {
+            "task_id": task_id,
+            "status": "running" if task.proc.poll() is None else "killed",
+            "exit_code": task.proc.poll(),
+        }
 
     def _trailer(self) -> str:
         """Command appended after each user command. Emits one line `<marker> <exit> <cwd>`
@@ -294,21 +426,143 @@ def _parse_cwd(line: str, marker: str) -> Optional[str]:
         return None
 
 
+_RUN_SHELL_SCHEMA = {
+    "type": "function",
+    "function": {
+        "name": "run_shell",
+        "description": (
+            "Run a shell command in the persistent session (cwd and env persist across "
+            "calls). Output longer than the limit keeps the END (where test/build verdicts "
+            "are). Set run_in_background for long-running processes like dev servers, then "
+            "poll with shell_task_output."
+        ),
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "command": {
+                    "type": "string",
+                    "description": "The command to run.",
+                },
+                "description": {
+                    "type": "string",
+                    "description": (
+                        "Short human-readable summary of what the command does (e.g. "
+                        "'Install dependencies'), shown in approval prompts and logs."
+                    ),
+                },
+                "timeout_seconds": {
+                    "type": "integer",
+                    "description": (
+                        f"Max seconds to wait (default {int(_DEFAULT_TIMEOUT)}, "
+                        f"max {int(_MAX_TIMEOUT)}). Ignored for background tasks."
+                    ),
+                },
+                "run_in_background": {
+                    "type": "boolean",
+                    "description": (
+                        "Run detached and return a task_id immediately instead of waiting. "
+                        "Use for servers, watchers, and very long builds."
+                    ),
+                },
+            },
+            "required": ["command"],
+        },
+    },
+}
+
+_TASK_OUTPUT_SCHEMA = {
+    "type": "function",
+    "function": {
+        "name": "shell_task_output",
+        "description": (
+            "Read NEW output (since the last read) from a background task started with "
+            "run_shell run_in_background=true, plus its status and exit code."
+        ),
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "task_id": {
+                    "type": "string",
+                    "description": "The task_id returned by run_shell.",
+                }
+            },
+            "required": ["task_id"],
+        },
+    },
+}
+
+_TASK_KILL_SCHEMA = {
+    "type": "function",
+    "function": {
+        "name": "shell_task_kill",
+        "description": "Stop a background task started with run_shell run_in_background=true.",
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "task_id": {
+                    "type": "string",
+                    "description": "The task_id returned by run_shell.",
+                }
+            },
+            "required": ["task_id"],
+        },
+    },
+}
+
+
 def shell_tools(executor: Executor) -> list:
-    """Return the `run_shell` tool bound to a persistent executor."""
+    """Return the shell tools (`run_shell` + background-task helpers) bound to a
+    persistent executor."""
 
-    def run_shell(command: str, timeout_seconds: Optional[int] = None) -> dict:
-        """Run a shell command in the persistent session (cwd and env persist)."""
-        return executor.run(command, timeout=timeout_seconds)
+    def run_shell(
+        command: str,
+        description: Optional[str] = None,
+        timeout_seconds: Optional[int] = None,
+        run_in_background: bool = False,
+    ) -> dict:
+        # `description` is not used here on purpose: it rides along in the call arguments
+        # so approval prompts and the audit log can show intent, not just the raw command.
+        if run_in_background:
+            return executor.run_background(command)
+        timeout = None
+        if isinstance(timeout_seconds, (int, float)) and timeout_seconds > 0:
+            timeout = min(float(timeout_seconds), _MAX_TIMEOUT)
+        return executor.run(command, timeout=timeout)
 
-    return [
-        ai.tool(
-            run_shell,
-            metadata=ai.ToolMetadata(
-                category="shell",
-                risk_level="high",
-                capabilities=["run_command"],
-                requires_approval=True,
-            ),
-        )
-    ]
+    def shell_task_output(task_id: str) -> dict:
+        return executor.background_output(task_id)
+
+    def shell_task_kill(task_id: str) -> dict:
+        return executor.background_kill(task_id)
+
+    wrapped_run = ai.tool(
+        run_shell,
+        metadata=ai.ToolMetadata(
+            category="shell",
+            risk_level="high",
+            capabilities=["run_command"],
+            requires_approval=True,
+        ),
+    )
+    wrapped_run.__coworker_schema__ = _RUN_SHELL_SCHEMA
+    wrapped_output = ai.tool(
+        shell_task_output,
+        metadata=ai.ToolMetadata(
+            category="shell",
+            risk_level="low",
+            capabilities=["run_command"],
+            requires_approval=False,
+        ),
+    )
+    wrapped_output.__coworker_schema__ = _TASK_OUTPUT_SCHEMA
+    wrapped_kill = ai.tool(
+        shell_task_kill,
+        metadata=ai.ToolMetadata(
+            category="shell",
+            risk_level="low",
+            capabilities=["run_command"],
+            requires_approval=False,
+        ),
+    )
+    wrapped_kill.__coworker_schema__ = _TASK_KILL_SCHEMA
+    return [wrapped_run, wrapped_output, wrapped_kill]

--- a/platform/coworker/tools/subagent.py
+++ b/platform/coworker/tools/subagent.py
@@ -1,0 +1,138 @@
+"""The `explore` tool — a read-only research subagent with its own context window.
+
+Broad questions ("where is retry logic handled?") burn the main session's context on
+dozens of file reads. `explore` spawns a child TurnEngine over the same workspace with
+read-only tools and a fresh context; only its final report returns to the caller.
+
+The child runs in plan mode — the PermissionEngine hard-blocks writes/shell no matter
+what the child decides — with no approver, so it never needs an approval round-trip.
+That's what lets `explore` carry low-risk metadata, which in turn makes several explores
+in one assistant turn eligible for the engine's parallel execution. No recursion: the
+child registry has no `explore` tool.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from typing import Any, Optional
+
+import aisuite as ai
+
+from ..engine import TurnEngine
+from ..events import EventType
+from ..permissions import Mode, PermissionEngine
+from ..tools import ToolRegistry
+from .files import file_tools
+from .git import git_tools
+from .search import search_tools
+
+EXPLORER_INSTRUCTIONS = """You are a read-only code explorer working inside the user's workspace. \
+Answer the research task you're given by searching and reading the code (`grep`, `read_file`, \
+`list_files`, `git_log`, `git_status`, `git_diff`). You cannot write files or run commands.
+
+Your final message is your report — it goes back to the agent that spawned you, not to the \
+user. Make it self-contained: answer the task directly, reference code as path:line, quote the \
+key snippets, and note anything surprising you found along the way. If you couldn't find \
+something, say what you searched so the caller doesn't repeat the same searches."""
+
+_CHILD_MAX_ITERATIONS = 10
+
+
+def build_explorer_engine(
+    *,
+    workspace: str | Path,
+    provider: Any,
+    model: str,
+    model_settings: Optional[dict[str, Any]] = None,
+    max_iterations: int = _CHILD_MAX_ITERATIONS,
+) -> TurnEngine:
+    """A child engine with the Code agent's read-only tools and a fresh context."""
+    ws = str(Path(workspace).resolve())
+    registry = ToolRegistry()
+    # Read-only slice of the Code agent's toolset, with the same toolkit replacements
+    # (our grep for search_files, our windowed read_file for read_file/read_file_lines).
+    replaced = {"search_files", "read_file", "read_file_lines"}
+    registry.register_all(
+        [
+            t
+            for t in ai.toolkits.files(root=ws)  # no allow_write → list/read only
+            if getattr(t, "__name__", "") not in replaced
+        ]
+    )
+    registry.register_all(file_tools(ws))
+    registry.register_all(ai.toolkits.git(root=ws))  # git_status, git_diff
+    registry.register_all(git_tools(ws))  # git_log
+    registry.register_all(search_tools(ws))  # grep
+    permissions = PermissionEngine(workspace_root=Path(ws), mode=Mode.PLAN)
+    return TurnEngine(
+        provider=provider,
+        registry=registry,
+        permissions=permissions,
+        model=model,
+        instructions=EXPLORER_INSTRUCTIONS,
+        max_iterations=max_iterations,
+        model_settings=model_settings,
+    )
+
+
+def explorer_tools(
+    *,
+    workspace: str | Path,
+    provider: Any,
+    model: str,
+    model_settings: Optional[dict[str, Any]] = None,
+) -> list:
+    def explore(task: str) -> dict:
+        """Delegate a broad, read-only research task to a subagent with its own fresh
+        context window. It searches and reads the workspace, then returns only its final
+        report — the intermediate file reads never touch your context. Use it for
+        multi-file questions ("where is X handled?", "how does the Y flow work?"); for a
+        single known file, just read it yourself. Independent explore calls run in
+        parallel when requested together. State the task precisely and say what the
+        report should include.
+
+        Args:
+            task (str): The research question, with any constraints and the expected
+                shape of the report.
+        """
+        engine = build_explorer_engine(
+            workspace=workspace,
+            provider=provider,
+            model=model,
+            model_settings=model_settings,
+        )
+
+        async def _run() -> tuple[str, str]:
+            report, status = "", "unknown"
+            async for event in engine.run(task):
+                if event.type == EventType.ASSISTANT_MESSAGE and event.data.get("text"):
+                    report = event.data["text"]
+                elif event.type == EventType.TURN_END:
+                    status = event.data.get("status", "unknown")
+                elif event.type == EventType.ERROR:
+                    return report, f"error: {event.data.get('error', '')}"
+            return report, status
+
+        # Tools execute in a worker thread (no running loop), so asyncio.run is safe.
+        report, status = asyncio.run(_run())
+        if not report:
+            return {"error": f"explorer produced no report (status: {status})"}
+        result: dict[str, Any] = {"report": report}
+        if status != "completed":
+            result["note"] = (
+                f"explorer stopped early ({status}); the report may be partial"
+            )
+        return result
+
+    return [
+        ai.tool(
+            explore,
+            metadata=ai.ToolMetadata(
+                category="search",
+                risk_level="low",
+                capabilities=["search"],
+                requires_approval=False,
+            ),
+        )
+    ]

--- a/platform/surfaces/gui/src/App.tsx
+++ b/platform/surfaces/gui/src/App.tsx
@@ -34,6 +34,7 @@ import { IntegrationsView } from "./components/IntegrationsView";
 import { AuditView } from "./components/AuditView";
 import { ApprovalCard } from "./components/ApprovalCard";
 import { DirectoryRequestCard } from "./components/DirectoryRequestCard";
+import { PlanCard } from "./components/PlanCard";
 
 const newId = () =>
   (crypto as any).randomUUID ? crypto.randomUUID().slice(0, 12) : Math.random().toString(36).slice(2, 14);
@@ -369,6 +370,9 @@ export function App() {
             { kind: "dirreq", reason: d.reason || "", path: d.path || "", writable: !!d.writable },
           ]);
           break;
+        case "plan_proposed":
+          setItems((p) => [...p, { kind: "planreq", plan: d.plan || "" }]);
+          break;
         case "tool_finished":
           setItems((p) => updateLastTool(p, d.name, d.status, d.result_preview || d.reason));
           // Refresh the right rail when something it shows may have changed: browser state, or a
@@ -434,6 +438,11 @@ export function App() {
   const approve = (decision: ApprovalDecision) => {
     setItems((p) => resolveLastApproval(p, decision));
     sessionRef.current?.approve(decision);
+  };
+  const respondPlan = (approved: boolean, mode?: string, feedback?: string) => {
+    setItems((p) => resolveLastPlan(p, approved ? "approved" : "rejected"));
+    sessionRef.current?.respondPlan(approved, mode, feedback);
+    if (approved && mode) setMode(mode); // the server flips the live engine to this mode
   };
   const respondDirectory = (granted: boolean, path?: string, writable?: boolean) => {
     setItems((p) => resolveLastDirReq(p, granted ? "granted" : "denied"));
@@ -599,6 +608,7 @@ export function App() {
   const idle = items.length === 0 && !streaming;
   const pendingApproval = [...items].reverse().find((i) => i.kind === "approval" && !i.resolved);
   const pendingDirReq = [...items].reverse().find((i) => i.kind === "dirreq" && !i.resolved);
+  const pendingPlan = [...items].reverse().find((i) => i.kind === "planreq" && !i.resolved);
   const activeInfo = sessions.find((s) => s.session_id === sessionId);
   const activeTitle = activeInfo?.title || "New chat";
   const commitTitleRename = () => {
@@ -826,7 +836,9 @@ export function App() {
                     : "Ask the coworker…  (drop or paste images)"
               }
               approvalSlot={
-                pendingDirReq?.kind === "dirreq" ? (
+                pendingPlan?.kind === "planreq" ? (
+                  <PlanCard item={pendingPlan} onRespond={respondPlan} />
+                ) : pendingDirReq?.kind === "dirreq" ? (
                   <DirectoryRequestCard item={pendingDirReq} onRespond={respondDirectory} />
                 ) : pendingApproval?.kind === "approval" ? (
                   <ApprovalCard item={pendingApproval} onApprove={approve} compact />
@@ -978,6 +990,18 @@ function resolveLastDirReq(items: Item[], resolved: "granted" | "denied"): Item[
   for (let i = copy.length - 1; i >= 0; i--) {
     const it = copy[i];
     if (it.kind === "dirreq" && !it.resolved) {
+      copy[i] = { ...it, resolved };
+      break;
+    }
+  }
+  return copy;
+}
+
+function resolveLastPlan(items: Item[], resolved: "approved" | "rejected"): Item[] {
+  const copy = [...items];
+  for (let i = copy.length - 1; i >= 0; i--) {
+    const it = copy[i];
+    if (it.kind === "planreq" && !it.resolved) {
       copy[i] = { ...it, resolved };
       break;
     }

--- a/platform/surfaces/gui/src/api.ts
+++ b/platform/surfaces/gui/src/api.ts
@@ -660,6 +660,16 @@ export class Session {
     this.send({ type: "directory_response", granted, ...(path ? { path } : {}), writable: !!writable });
   }
 
+  // Reply to a `propose_plan` prompt: approve (choosing the execution mode) or reject with feedback.
+  respondPlan(approved: boolean, mode?: string, feedback?: string) {
+    this.send({
+      type: "plan_response",
+      approved,
+      ...(mode ? { mode } : {}),
+      ...(feedback ? { feedback } : {}),
+    });
+  }
+
   interrupt() {
     this.send({ type: "interrupt" });
   }

--- a/platform/surfaces/gui/src/components/Composer.tsx
+++ b/platform/surfaces/gui/src/components/Composer.tsx
@@ -5,7 +5,8 @@ import { Dropdown, type Option } from "./Dropdown";
 import { Icon } from "./Icon";
 
 const PERMISSION_OPTIONS: Option[] = [
-  { value: "plan", label: "Read-only", description: "Suggest changes — don't edit files or run commands" },
+  { value: "discuss", label: "Discuss", description: "Chat and explore — no edits or commands" },
+  { value: "plan", label: "Plan", description: "Explore read-only, propose a plan for approval, then build" },
   { value: "interactive", label: "Ask for approval", description: "Ask before edits and commands" },
   { value: "auto", label: "Full access", description: "Run everything without asking" },
   { value: "custom", label: "Custom", description: "Use auto-allow rules from config.toml" },

--- a/platform/surfaces/gui/src/components/PlanCard.tsx
+++ b/platform/surfaces/gui/src/components/PlanCard.tsx
@@ -1,0 +1,69 @@
+import { useState } from "react";
+import type { Item } from "../types";
+import { Icon } from "./Icon";
+import { Markdown } from "./Markdown";
+
+type PlanItem = Extract<Item, { kind: "planreq" }>;
+
+// The agent (in read-only plan mode) proposed a plan via propose_plan. The user approves it —
+// choosing whether execution should keep asking per action or run with full access — or sends
+// it back with feedback. Mirrors the directory-request card, shown in the composer head.
+export function PlanCard({
+  item,
+  onRespond,
+}: {
+  item: PlanItem;
+  onRespond: (approved: boolean, mode?: string, feedback?: string) => void;
+}) {
+  const [rejecting, setRejecting] = useState(false);
+  const [feedback, setFeedback] = useState("");
+
+  return (
+    <div className="dirreq-card plan-card">
+      <div className="dirreq-head">
+        <Icon name="sparkle" size={16} className="ico" />
+        <span>The agent proposed a plan</span>
+      </div>
+      <div className="plan-body">
+        <Markdown text={item.plan} />
+      </div>
+      {rejecting ? (
+        <div className="dirreq-actions">
+          <input
+            className="dirreq-path"
+            placeholder="What should change about the plan?"
+            value={feedback}
+            autoFocus
+            onChange={(e) => setFeedback(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === "Enter" && feedback.trim()) onRespond(false, undefined, feedback.trim());
+            }}
+          />
+          <button className="btn" onClick={() => setRejecting(false)}>
+            Back
+          </button>
+          <button
+            className="btn primary"
+            disabled={!feedback.trim()}
+            onClick={() => onRespond(false, undefined, feedback.trim())}
+          >
+            Send feedback
+          </button>
+        </div>
+      ) : (
+        <div className="dirreq-actions">
+          <button className="btn" onClick={() => setRejecting(true)}>
+            Request changes
+          </button>
+          <span className="spacer" />
+          <button className="btn" onClick={() => onRespond(true, "interactive")}>
+            Approve — ask per step
+          </button>
+          <button className="btn primary" onClick={() => onRespond(true, "auto")}>
+            Approve & run
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/platform/surfaces/gui/src/components/Transcript.tsx
+++ b/platform/surfaces/gui/src/components/Transcript.tsx
@@ -129,6 +129,20 @@ export function Transcript({ items }: Props) {
                 {item.path && <span className="dim">{item.path}</span>}
               </div>
             );
+          case "planreq":
+            if (!item.resolved) return null; // pending plan renders in the composer head
+            return (
+              <div className="bubble-assistant" key={bi}>
+                <div className="who">proposed plan</div>
+                <Markdown text={item.plan} />
+                <div className="approval-inline">
+                  <span className={"status " + (item.resolved === "approved" ? "ok" : "denied")}>
+                    {item.resolved === "approved" ? "✓" : "✕"}
+                  </span>
+                  <span>{item.resolved === "approved" ? "Plan approved" : "Sent back with feedback"}</span>
+                </div>
+              </div>
+            );
           case "notice":
             return (
               <div className={"notice " + (item.tone === "warn" ? "warn" : "")} key={bi}>

--- a/platform/surfaces/gui/src/styles.css
+++ b/platform/surfaces/gui/src/styles.css
@@ -687,6 +687,13 @@ button.btn.danger { color: var(--accent); }
 .dirreq-access { display: inline-flex; align-items: center; gap: 6px; font-size: 12.5px; color: var(--muted); cursor: pointer; }
 .dirreq-actions .spacer { flex: 1; }
 
+/* propose_plan prompt (plan-mode exit) */
+.plan-card .plan-body {
+  max-height: 320px; overflow-y: auto; font-size: 13.5px;
+  margin: 8px 0 2px; padding: 8px 10px;
+  background: var(--paper); border: 1px solid var(--line); border-radius: 8px;
+}
+
 /* folder gate */
 .gate-overlay { position: fixed; inset: 0; background: var(--scrim); display: grid; place-items: center; z-index: 50; }
 .gate { width: 480px; max-width: 92vw; background: var(--paper); border: 1px solid var(--line-strong); border-radius: 16px; padding: 26px 26px 22px; box-shadow: 0 20px 60px rgba(0,0,0,0.18); }

--- a/platform/surfaces/gui/src/types.ts
+++ b/platform/surfaces/gui/src/types.ts
@@ -7,6 +7,7 @@ export type EventType =
   | "tool_proposed"
   | "permission_required"
   | "directory_requested"
+  | "plan_proposed"
   | "tool_started"
   | "tool_finished"
   | "iteration_end"
@@ -68,5 +69,10 @@ export type Item =
       path?: string;
       writable?: boolean;
       resolved?: "granted" | "denied";
+    }
+  | {
+      kind: "planreq";
+      plan: string;
+      resolved?: "approved" | "rejected";
     }
   | { kind: "notice"; tone: "info" | "warn"; text: string };

--- a/platform/tests/test_code_tools.py
+++ b/platform/tests/test_code_tools.py
@@ -10,6 +10,7 @@ import subprocess
 
 import pytest
 
+from coworker.tools.files import file_tools
 from coworker.tools.git import git_tools
 from coworker.tools.search import _py_grep, search_tools
 from coworker.web.fetch import _html_to_text, make_web_fetch_tool
@@ -79,6 +80,43 @@ def test_git_log_errors_outside_repo(tmp_path):
     assert "error" in git_log()
 
 
+# -- read_file -----------------------------------------------------------------
+def test_read_file_numbers_lines(tmp_path):
+    (tmp_path / "a.py").write_text("one\ntwo\nthree\n", encoding="utf-8")
+    read_file = file_tools(str(tmp_path))[0]
+    out = read_file(path="a.py")
+    assert out["total_lines"] == 3
+    assert out["start_line"] == 1 and out["end_line"] == 3
+    assert out["content"].splitlines()[0].endswith("1\tone")
+    assert "note" not in out  # nothing left to read
+
+
+def test_read_file_windows_and_tells_how_to_continue(tmp_path):
+    (tmp_path / "big.txt").write_text(
+        "\n".join(f"line{i}" for i in range(1, 51)) + "\n", encoding="utf-8"
+    )
+    read_file = file_tools(str(tmp_path))[0]
+    out = read_file(path="big.txt", start_line=5, max_lines=10)
+    assert out["start_line"] == 5 and out["end_line"] == 14
+    assert out["total_lines"] == 50
+    assert "line5" in out["content"] and "line15" not in out["content"]
+    assert "start_line=15" in out["note"]
+
+
+def test_read_file_truncates_long_lines(tmp_path):
+    (tmp_path / "wide.txt").write_text("x" * 2000 + "\n", encoding="utf-8")
+    read_file = file_tools(str(tmp_path))[0]
+    out = read_file(path="wide.txt")
+    assert "(line truncated)" in out["content"]
+    assert len(out["content"]) < 1000
+
+
+def test_read_file_rejects_escape_and_non_files(tmp_path):
+    read_file = file_tools(str(tmp_path))[0]
+    assert "escapes" in read_file(path="../secret.txt")["error"]
+    assert "not a file" in read_file(path="missing.txt")["error"]
+
+
 # -- web_fetch -----------------------------------------------------------------
 def test_web_fetch_rejects_non_http():
     web_fetch = make_web_fetch_tool()
@@ -102,6 +140,7 @@ def test_code_agent_has_grep_and_git_log_not_search_files(tmp_path):
     names = {getattr(t, "__name__", "") for t in code_agent().build_tools(ctx)}
     assert "grep" in names and "git_log" in names
     assert "search_files" not in names  # replaced by grep
+    assert "read_file_lines" not in names  # folded into our windowed read_file
     assert {"read_file", "write_file", "git_status", "git_diff"} <= names
 
 

--- a/platform/tests/test_engine.py
+++ b/platform/tests/test_engine.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import asyncio
+import threading
+import time
 
 import aisuite as ai
 from coworker.engine import ApprovalOutcome, PermissionRequest, TurnEngine
@@ -194,6 +196,97 @@ def test_steering_injects_next_turn(tmp_path):
         for m in engine.messages
     )
     assert events[-1].data["status"] == "completed"
+
+
+# -- parallel tool execution ------------------------------------------------------
+
+
+def _multi_tool_turn(calls):
+    return AssistantTurn(
+        tool_calls=[
+            ToolCall(id=f"call_{i}", name=name, arguments=args)
+            for i, (name, args) in enumerate(calls)
+        ],
+        finish_reason="tool_calls",
+    )
+
+
+def _bare_engine(tmp_path, turns):
+    provider = ScriptedProvider(turns)
+    registry = ToolRegistry()
+    permissions = PermissionEngine(workspace_root=tmp_path)
+    engine = TurnEngine(
+        provider=provider,
+        registry=registry,
+        permissions=permissions,
+        model="gpt-5.5",
+    )
+    return engine, registry
+
+
+def test_low_risk_tool_calls_run_concurrently(tmp_path):
+    # Both tools block on a 2-party barrier: the turn only completes if the engine
+    # really runs them at the same time (sequential execution would trip the timeout
+    # and surface as an error result).
+    barrier = threading.Barrier(2, timeout=5)
+    low = ai.ToolMetadata(category="search", risk_level="low", requires_approval=False)
+
+    def side_a():
+        """Wait for side_b."""
+        barrier.wait()
+        return {"side": "a"}
+
+    def side_b():
+        """Wait for side_a."""
+        barrier.wait()
+        return {"side": "b"}
+
+    engine, registry = _bare_engine(
+        tmp_path,
+        [_multi_tool_turn([("side_a", {}), ("side_b", {})]), _text_turn("done")],
+    )
+    registry.register(side_a, metadata=low)
+    registry.register(side_b, metadata=low)
+
+    events = _collect(engine, "go")
+    finished = [e for e in events if e.type == EventType.TOOL_FINISHED]
+    assert len(finished) == 2
+    assert all(e.data["status"] == "ok" for e in finished)
+    # a tool result message exists for every call id
+    tool_ids = {
+        m.get("tool_call_id") for m in engine.messages if m.get("role") == "tool"
+    }
+    assert tool_ids == {"call_0", "call_1"}
+
+
+def test_non_low_risk_tool_calls_stay_sequential(tmp_path):
+    order = []
+    medium = ai.ToolMetadata(
+        category="filesystem", risk_level="medium", requires_approval=False
+    )
+
+    def first():
+        """Record start/end with a delay."""
+        order.append("first-start")
+        time.sleep(0.2)
+        order.append("first-end")
+        return "ok"
+
+    def second():
+        """Record start/end."""
+        order.append("second-start")
+        order.append("second-end")
+        return "ok"
+
+    engine, registry = _bare_engine(
+        tmp_path,
+        [_multi_tool_turn([("first", {}), ("second", {})]), _text_turn("done")],
+    )
+    registry.register(first, metadata=medium)
+    registry.register(second, metadata=medium)
+
+    _collect(engine, "go")
+    assert order == ["first-start", "first-end", "second-start", "second-end"]
 
 
 class StreamingProvider(ProviderClient):

--- a/platform/tests/test_environment.py
+++ b/platform/tests/test_environment.py
@@ -1,0 +1,76 @@
+"""Tests for the session environment context block (system-prompt injection)."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+
+from coworker.environment import environment_context
+
+
+def _git_repo(tmp_path):
+    ws = tmp_path / "repo"
+    ws.mkdir()
+    run = lambda *a: subprocess.run(
+        ["git", "-C", str(ws), *a], capture_output=True, check=True
+    )
+    run("init", "-q", "-b", "main")
+    run("config", "user.email", "t@t.io")
+    run("config", "user.name", "T")
+    (ws / "f.txt").write_text("1", encoding="utf-8")
+    run("add", "-A")
+    run("commit", "-qm", "first commit")
+    return ws
+
+
+def test_context_includes_workspace_platform_and_date(tmp_path):
+    block = environment_context(tmp_path)
+    assert str(tmp_path.resolve()) in block
+    assert sys.platform in block
+    assert "Today's date:" in block
+    assert "<environment>" in block and "</environment>" in block
+
+
+def test_context_outside_git_repo(tmp_path):
+    assert "not a git repository" in environment_context(tmp_path)
+
+
+def test_context_with_git_repo(tmp_path):
+    ws = _git_repo(tmp_path)
+    block = environment_context(ws)
+    assert "Git branch: main" in block
+    assert "Git status: clean" in block
+    assert "first commit" in block
+
+
+def test_context_shows_dirty_status(tmp_path):
+    ws = _git_repo(tmp_path)
+    (ws / "f.txt").write_text("2", encoding="utf-8")
+    (ws / "new.txt").write_text("x", encoding="utf-8")
+    block = environment_context(ws)
+    assert "Git status (2 changed):" in block
+    assert "f.txt" in block and "new.txt" in block
+
+
+class _Stub:
+    def complete(self, **kwargs):  # pragma: no cover
+        raise NotImplementedError
+
+    def capabilities(self, model):
+        from coworker.providers import ModelCapabilities
+
+        return ModelCapabilities()
+
+
+def test_build_engine_injects_environment(tmp_path):
+    from coworker.agent import build_engine
+    from coworker.agents import code_agent
+
+    engine = build_engine(agent=code_agent(), workspace=tmp_path, provider=_Stub())
+    try:
+        system = engine.messages[0]
+        assert system["role"] == "system"
+        assert "<environment>" in system["content"]
+        assert str(tmp_path.resolve()) in system["content"]
+    finally:
+        engine.executor.close()

--- a/platform/tests/test_memory.py
+++ b/platform/tests/test_memory.py
@@ -49,11 +49,12 @@ def test_memory_listable_and_editable(tmp_path):
     assert store.get(item.id) is None
 
 
-def test_format_memories(tmp_path):
+def test_format_memories_shows_ids(tmp_path):
     store = _store(tmp_path)
-    store.add("fact one", workspace="/proj")
+    item = store.add("fact one", workspace="/proj")
     rendered = format_memories(store.list(workspace="/proj"))
     assert "fact one" in rendered and "Known memories" in rendered
+    assert f"[#{item.id}]" in rendered  # ids let the agent update/forget
 
 
 # -- remember tool --------------------------------------------------------------
@@ -71,6 +72,35 @@ def test_remember_tool_persists(tmp_path):
         m.content == "deploys on Fridays are banned"
         for m in store.list(workspace="/proj")
     )
+
+
+def test_memory_update_and_forget_tools(tmp_path):
+    store = _store(tmp_path)
+    reg = ToolRegistry()
+    reg.register_all(memory_tools(store, workspace="/proj"))
+    assert {"remember", "memory_update", "memory_forget"} <= set(reg.names())
+
+    saved = reg.execute("remember", {"content": "uses npm"})
+    updated = reg.execute(
+        "memory_update", {"memory_id": saved["id"], "content": "uses pnpm, not npm"}
+    )
+    assert updated["updated"] is True
+    assert store.get(saved["id"]).content == "uses pnpm, not npm"
+
+    gone = reg.execute("memory_forget", {"memory_id": saved["id"]})
+    assert gone["deleted"] is True
+    assert store.get(saved["id"]) is None
+
+
+def test_memory_update_and_forget_unknown_id(tmp_path):
+    store = _store(tmp_path)
+    reg = ToolRegistry()
+    reg.register_all(memory_tools(store, workspace="/proj"))
+    assert (
+        "no memory"
+        in reg.execute("memory_update", {"memory_id": 99, "content": "x"})["error"]
+    )
+    assert "no memory" in reg.execute("memory_forget", {"memory_id": 99})["error"]
 
 
 # -- sessions -------------------------------------------------------------------
@@ -121,9 +151,16 @@ def test_build_code_engine_injects_memory(tmp_path):
         workspace=tmp_path, provider=_StubProvider(), memory_store=store
     )
     try:
-        assert "remember" in engine.registry.names()
+        assert {"remember", "memory_update", "memory_forget"} <= set(
+            engine.registry.names()
+        )
         assert engine.messages[0]["role"] == "system"
         assert "always run black" in engine.messages[0]["content"]
+        # when-to-remember guidance rides along with the tools
+        assert "memory_update" in engine.messages[0]["content"]
+        assert (
+            "Don't save what the repo already records" in engine.messages[0]["content"]
+        )
     finally:
         engine.executor.close()
 

--- a/platform/tests/test_plan_mode.py
+++ b/platform/tests/test_plan_mode.py
@@ -172,13 +172,79 @@ def test_build_engine_plan_mode_wiring(tmp_path):
         engine.executor.close()
 
 
-def test_build_engine_interactive_has_no_propose_plan(tmp_path):
+def test_build_engine_interactive_registers_tool_without_reminder(tmp_path):
     from coworker.agent import build_engine
     from coworker.agents import code_agent
 
+    # The tool is always registered (the GUI can flip a live session into plan mode via
+    # set_mode), but the per-turn reminder only appears while actually planning.
     engine = build_engine(agent=code_agent(), workspace=tmp_path, provider=_Stub())
     try:
-        assert "propose_plan" not in engine.registry.names()
+        assert "propose_plan" in engine.registry.names()
         assert "Plan mode is active" not in engine.context_provider()
     finally:
         engine.executor.close()
+
+
+def test_discuss_mode_blocks_writes_without_plan_pressure(tmp_path):
+    engine, permissions = _plan_engine(
+        tmp_path,
+        [
+            _tool_turn("write_file", {"path": "x.py", "content": "x"}),
+            _text_turn("here's what I'd change instead"),
+        ],
+    )
+    permissions.mode = Mode.DISCUSS
+    events = _collect(engine, "tweak x.py")
+    assert not (tmp_path / "x.py").exists()
+    assert any(
+        m.get("role") == "tool" and "discuss mode is read-only" in m["content"]
+        for m in engine.messages
+    )
+
+
+def test_propose_plan_in_discuss_mode_says_describe_instead(tmp_path):
+    engine, permissions = _plan_engine(
+        tmp_path,
+        [_tool_turn("propose_plan", {"plan": "p"}), _text_turn("ok, describing")],
+    )
+    permissions.mode = Mode.DISCUSS
+    events = _collect(engine, "go")
+    assert EventType.PLAN_PROPOSED not in [e.type for e in events]
+    assert any(
+        m.get("role") == "tool" and "describe the proposed changes" in m["content"]
+        for m in engine.messages
+    )
+
+
+def test_build_engine_discuss_reminder_not_plan_contract(tmp_path):
+    from coworker.agent import build_engine
+    from coworker.agents import code_agent
+
+    engine = build_engine(
+        agent=code_agent(), workspace=tmp_path, provider=_Stub(), mode=Mode.DISCUSS
+    )
+    try:
+        ctx = engine.context_provider()
+        assert "Discuss mode is active" in ctx
+        assert "propose_plan" not in ctx  # no planning pressure in discuss mode
+    finally:
+        engine.executor.close()
+
+
+def test_propose_plan_outside_plan_mode_is_rejected(tmp_path):
+    async def approve(args):  # pragma: no cover - must not be called
+        raise AssertionError("approver should not run outside plan mode")
+
+    engine, permissions = _plan_engine(
+        tmp_path,
+        [_tool_turn("propose_plan", {"plan": "p"}), _text_turn("ok, proceeding")],
+        plan_approver=approve,
+    )
+    permissions.mode = Mode.INTERACTIVE  # session was flipped out of plan mode
+    events = _collect(engine, "go")
+    assert EventType.PLAN_PROPOSED not in [e.type for e in events]
+    assert any(
+        m.get("role") == "tool" and "not in plan mode" in m["content"]
+        for m in engine.messages
+    )

--- a/platform/tests/test_plan_mode.py
+++ b/platform/tests/test_plan_mode.py
@@ -1,0 +1,184 @@
+"""Plan mode tests — read-only enforcement + the propose_plan approval round-trip."""
+
+from __future__ import annotations
+
+import asyncio
+
+import aisuite as ai
+from coworker.engine import TurnEngine
+from coworker.events import EventType
+from coworker.permissions import Mode, PermissionEngine
+from coworker.providers import (
+    AssistantTurn,
+    ModelCapabilities,
+    ProviderClient,
+    ToolCall,
+)
+from coworker.tools import ToolRegistry
+from coworker.tools.plan import propose_plan_tool
+
+
+def _text_turn(text):
+    return AssistantTurn(text=text, finish_reason="stop")
+
+
+def _tool_turn(name, args, call_id="call_1"):
+    return AssistantTurn(
+        tool_calls=[ToolCall(id=call_id, name=name, arguments=args)],
+        finish_reason="tool_calls",
+    )
+
+
+class ScriptedProvider(ProviderClient):
+    def __init__(self, turns):
+        self._turns = list(turns)
+
+    def complete(self, *, model, messages, tools=None, **settings):
+        return self._turns.pop(0)
+
+    def capabilities(self, model):
+        return ModelCapabilities()
+
+
+def _plan_engine(tmp_path, turns, *, plan_approver=None):
+    registry = ToolRegistry()
+    registry.register_all(ai.toolkits.files(root=str(tmp_path), allow_write=True))
+    registry.register(propose_plan_tool())
+    permissions = PermissionEngine(workspace_root=tmp_path, mode=Mode.PLAN)
+    engine = TurnEngine(
+        provider=ScriptedProvider(turns),
+        registry=registry,
+        permissions=permissions,
+        model="gpt-5.5",
+        plan_approver=plan_approver,
+    )
+    return engine, permissions
+
+
+def _collect(engine, user_input):
+    async def _run():
+        return [ev async for ev in engine.run(user_input)]
+
+    return asyncio.run(_run())
+
+
+def test_plan_mode_blocks_writes_without_asking(tmp_path):
+    engine, _ = _plan_engine(
+        tmp_path,
+        [
+            _tool_turn("write_file", {"path": "x.py", "content": "x"}),
+            _text_turn("understood, planning instead"),
+        ],
+    )
+    events = _collect(engine, "fix the bug")
+    types = [e.type for e in events]
+    assert EventType.PERMISSION_REQUIRED not in types  # blocked, not escalated
+    assert not (tmp_path / "x.py").exists()
+    finished = next(e for e in events if e.type == EventType.TOOL_FINISHED)
+    assert finished.data["status"] == "denied"
+    assert any(
+        m.get("role") == "tool" and "plan mode is read-only" in m["content"]
+        for m in engine.messages
+    )
+
+
+def test_plan_approval_flips_mode_and_executes(tmp_path):
+    seen_plans = []
+
+    async def approve(args):
+        seen_plans.append(args.get("plan"))
+        return {"approved": True, "mode": "auto"}
+
+    engine, permissions = _plan_engine(
+        tmp_path,
+        [
+            _tool_turn("propose_plan", {"plan": "1. write x.py  2. verify"}),
+            _tool_turn("write_file", {"path": "x.py", "content": "done\n"}, "call_2"),
+            _text_turn("implemented"),
+        ],
+        plan_approver=approve,
+    )
+    events = _collect(engine, "fix the bug")
+    types = [e.type for e in events]
+    assert EventType.PLAN_PROPOSED in types
+    assert seen_plans == ["1. write x.py  2. verify"]
+    # same session flipped to auto and executed the write with no approval prompt
+    assert permissions.mode is Mode.AUTO
+    assert EventType.PERMISSION_REQUIRED not in types
+    assert (tmp_path / "x.py").read_text() == "done\n"
+
+
+def test_plan_rejection_keeps_plan_mode_and_returns_feedback(tmp_path):
+    async def reject(args):
+        return {"approved": False, "feedback": "don't touch x.py, fix y.py instead"}
+
+    engine, permissions = _plan_engine(
+        tmp_path,
+        [
+            _tool_turn("propose_plan", {"plan": "edit x.py"}),
+            _text_turn("revising the plan"),
+        ],
+        plan_approver=reject,
+    )
+    events = _collect(engine, "fix the bug")
+    assert permissions.mode is Mode.PLAN  # still read-only
+    finished = next(e for e in events if e.type == EventType.TOOL_FINISHED)
+    assert finished.data["status"] == "denied"
+    assert any(
+        m.get("role") == "tool" and "fix y.py instead" in m["content"]
+        for m in engine.messages
+    )
+
+
+def test_propose_plan_without_approver_noops(tmp_path):
+    engine, permissions = _plan_engine(
+        tmp_path,
+        [_tool_turn("propose_plan", {"plan": "p"}), _text_turn("ok")],
+    )
+    events = _collect(engine, "go")
+    assert EventType.PLAN_PROPOSED not in [e.type for e in events]
+    assert permissions.mode is Mode.PLAN
+    assert any(
+        m.get("role") == "tool" and "isn't available" in m["content"]
+        for m in engine.messages
+    )
+
+
+# -- build_engine wiring ----------------------------------------------------------
+
+
+class _Stub:
+    def complete(self, **kwargs):  # pragma: no cover
+        raise NotImplementedError
+
+    def capabilities(self, model):
+        return ModelCapabilities()
+
+
+def test_build_engine_plan_mode_wiring(tmp_path):
+    from coworker.agent import build_engine
+    from coworker.agents import code_agent
+
+    engine = build_engine(
+        agent=code_agent(), workspace=tmp_path, provider=_Stub(), mode=Mode.PLAN
+    )
+    try:
+        assert "propose_plan" in engine.registry.names()
+        # the per-turn reminder is live while planning, gone after the flip
+        assert "Plan mode is active" in engine.context_provider()
+        engine.permissions.mode = Mode.INTERACTIVE
+        assert "Plan mode is active" not in engine.context_provider()
+    finally:
+        engine.executor.close()
+
+
+def test_build_engine_interactive_has_no_propose_plan(tmp_path):
+    from coworker.agent import build_engine
+    from coworker.agents import code_agent
+
+    engine = build_engine(agent=code_agent(), workspace=tmp_path, provider=_Stub())
+    try:
+        assert "propose_plan" not in engine.registry.names()
+        assert "Plan mode is active" not in engine.context_provider()
+    finally:
+        engine.executor.close()

--- a/platform/tests/test_shell.py
+++ b/platform/tests/test_shell.py
@@ -68,12 +68,15 @@ def test_timeout_kills_command(executor):
     assert executor.run("echo alive")["output"].strip().endswith("alive")
 
 
-def test_large_output_truncated(tmp_path):
+def test_large_output_truncated_keeps_tail(tmp_path):
     ex = LocalExecutor(cwd=tmp_path, max_output_chars=200, default_timeout=10)
     try:
         result = ex.run(PRINT_1000)
         assert result["truncated"] is True
         assert len(result["output"]) <= 200
+        # the END survives (where test/build verdicts live), the head is dropped
+        assert "line1000" in result["output"]
+        assert "line1\n" not in result["output"]
     finally:
         ex.close()
 
@@ -81,10 +84,13 @@ def test_large_output_truncated(tmp_path):
 def test_shell_tool_integration(executor, tmp_path):
     reg = ToolRegistry()
     reg.register_all(shell_tools(executor))
-    assert "run_shell" in reg.names()
+    assert {"run_shell", "shell_task_output", "shell_task_kill"} <= set(reg.names())
 
     spec = reg.get("run_shell")
     assert spec.metadata.requires_approval is True
+    # polling/killing the agent's own background tasks doesn't need approval
+    assert reg.get("shell_task_output").metadata.requires_approval is False
+    assert reg.get("shell_task_kill").metadata.requires_approval is False
 
     eng = PermissionEngine(workspace_root=tmp_path)
     decision = eng.evaluate("run_shell", {"command": "echo hi"}, spec.metadata)
@@ -92,3 +98,86 @@ def test_shell_tool_integration(executor, tmp_path):
 
     out = reg.execute("run_shell", {"command": "echo hi"})
     assert "hi" in out["output"]
+
+
+def test_run_shell_accepts_description_and_clamped_timeout(executor):
+    reg = ToolRegistry()
+    reg.register_all(shell_tools(executor))
+    # `description` rides along for approval prompts/audit; it must not break execution.
+    out = reg.execute(
+        "run_shell",
+        {"command": "echo ok", "description": "Say ok", "timeout_seconds": 99999},
+    )
+    assert out["exit_code"] == 0 and "ok" in out["output"]
+
+
+# -- background tasks ------------------------------------------------------------
+
+ECHO_THEN_SLEEP = (
+    "Write-Output started; Start-Sleep -Seconds 30"
+    if _WIN
+    else "echo started; sleep 30"
+)
+QUICK_ECHO = "Write-Output quick_done" if _WIN else "echo quick_done"
+
+
+def _poll_output(reg, task_id, *, until_status=None, deadline=10.0):
+    """Poll shell_task_output, accumulating output until a status is reached."""
+    acc = ""
+    end = time.monotonic() + deadline
+    while time.monotonic() < end:
+        res = reg.execute("shell_task_output", {"task_id": task_id})
+        acc += res["output"]
+        if until_status is None or res["status"] == until_status:
+            if until_status is None and not acc:
+                time.sleep(0.1)
+                continue
+            return acc, res
+        time.sleep(0.1)
+    return acc, res
+
+
+def test_background_task_runs_and_exits(executor):
+    reg = ToolRegistry()
+    reg.register_all(shell_tools(executor))
+    started = reg.execute(
+        "run_shell", {"command": QUICK_ECHO, "run_in_background": True}
+    )
+    assert started["status"] == "running" and started["task_id"]
+
+    acc, res = _poll_output(reg, started["task_id"], until_status="exited")
+    assert res["status"] == "exited"
+    assert res["exit_code"] == 0
+    assert "quick_done" in acc
+
+    # output reads are incremental: a second read returns nothing new
+    again = reg.execute("shell_task_output", {"task_id": started["task_id"]})
+    assert again["output"] == ""
+
+
+def test_background_task_kill(executor):
+    reg = ToolRegistry()
+    reg.register_all(shell_tools(executor))
+    started = reg.execute(
+        "run_shell", {"command": ECHO_THEN_SLEEP, "run_in_background": True}
+    )
+    acc, _ = _poll_output(reg, started["task_id"])
+    assert "started" in acc  # it's alive and producing output
+
+    killed = reg.execute("shell_task_kill", {"task_id": started["task_id"]})
+    assert killed["status"] == "killed"
+
+    res = reg.execute("shell_task_output", {"task_id": started["task_id"]})
+    assert res["status"] == "exited"
+
+
+def test_background_unknown_task_errors(executor):
+    reg = ToolRegistry()
+    reg.register_all(shell_tools(executor))
+    assert (
+        "unknown task"
+        in reg.execute("shell_task_output", {"task_id": "bg-99"})["error"]
+    )
+    assert (
+        "unknown task" in reg.execute("shell_task_kill", {"task_id": "bg-99"})["error"]
+    )

--- a/platform/tests/test_subagent.py
+++ b/platform/tests/test_subagent.py
@@ -1,0 +1,130 @@
+"""Explorer subagent tests — read-only child engine, report return, no recursion."""
+
+from __future__ import annotations
+
+from coworker.permissions import Mode
+from coworker.providers import (
+    AssistantTurn,
+    ModelCapabilities,
+    ProviderClient,
+    ToolCall,
+)
+from coworker.tools import ToolRegistry
+from coworker.tools.subagent import build_explorer_engine, explorer_tools
+
+
+def _text_turn(text):
+    return AssistantTurn(text=text, finish_reason="stop")
+
+
+def _tool_turn(name, args, call_id="call_1"):
+    return AssistantTurn(
+        tool_calls=[ToolCall(id=call_id, name=name, arguments=args)],
+        finish_reason="tool_calls",
+    )
+
+
+class ScriptedProvider(ProviderClient):
+    def __init__(self, turns):
+        self._turns = list(turns)
+
+    def complete(self, *, model, messages, tools=None, **settings):
+        return self._turns.pop(0)
+
+    def capabilities(self, model):
+        return ModelCapabilities()
+
+
+def test_explorer_engine_is_read_only(tmp_path):
+    engine = build_explorer_engine(
+        workspace=tmp_path, provider=ScriptedProvider([]), model="gpt-5.5"
+    )
+    names = set(engine.registry.names())
+    assert {
+        "grep",
+        "read_file",
+        "list_files",
+        "git_log",
+        "git_status",
+        "git_diff",
+    } <= names
+    assert "write_file" not in names and "replace_in_file" not in names
+    assert "run_shell" not in names
+    assert "explore" not in names  # no recursion
+    assert engine.permissions.mode is Mode.PLAN  # writes hard-blocked even if present
+
+
+def test_explore_returns_final_report(tmp_path):
+    (tmp_path / "a.py").write_text("def answer():\n    return 42\n", encoding="utf-8")
+    provider = ScriptedProvider(
+        [
+            _tool_turn("grep", {"pattern": "answer"}),
+            _text_turn("Found it: a.py:1 defines answer() returning 42."),
+        ]
+    )
+    reg = ToolRegistry()
+    reg.register_all(
+        explorer_tools(workspace=tmp_path, provider=provider, model="gpt-5.5")
+    )
+    spec = reg.get("explore")
+    assert spec.metadata.risk_level == "low"  # parallel-safe in the parent engine
+
+    result = reg.execute("explore", {"task": "where is answer defined?"})
+    assert result["report"] == "Found it: a.py:1 defines answer() returning 42."
+    assert "note" not in result  # completed normally
+
+
+def test_explore_child_cannot_write(tmp_path):
+    provider = ScriptedProvider(
+        [
+            _tool_turn("write_file", {"path": "evil.py", "content": "x"}),
+            _text_turn("I was blocked; reporting findings only."),
+        ]
+    )
+    reg = ToolRegistry()
+    reg.register_all(
+        explorer_tools(workspace=tmp_path, provider=provider, model="gpt-5.5")
+    )
+    result = reg.execute("explore", {"task": "look around"})
+    assert not (tmp_path / "evil.py").exists()
+    assert "report" in result
+
+
+def test_explore_flags_partial_report_on_iteration_rail(tmp_path):
+    # A provider that always asks for another grep: the child hits max_iterations.
+    class LoopingProvider(ScriptedProvider):
+        def complete(self, **kwargs):
+            return _tool_turn("grep", {"pattern": "x"})
+
+    reg = ToolRegistry()
+    reg.register_all(
+        explorer_tools(
+            workspace=tmp_path, provider=LoopingProvider([]), model="gpt-5.5"
+        )
+    )
+    result = reg.execute("explore", {"task": "endless"})
+    assert "max_iterations" in result.get(
+        "error", ""
+    ) or "max_iterations" in result.get("note", "")
+
+
+def test_code_engine_registers_explore_chat_does_not(tmp_path):
+    from coworker.agent import build_engine
+    from coworker.agents import code_agent
+    from coworker.agents.chat import chat_agent
+
+    class _Stub:
+        def complete(self, **kwargs):  # pragma: no cover
+            raise NotImplementedError
+
+        def capabilities(self, model):
+            return ModelCapabilities()
+
+    engine = build_engine(agent=code_agent(), workspace=tmp_path, provider=_Stub())
+    try:
+        assert "explore" in engine.registry.names()
+    finally:
+        engine.executor.close()
+
+    chat = build_engine(agent=chat_agent(), provider=_Stub())
+    assert "explore" not in chat.registry.names()


### PR DESCRIPTION
Upgrades the Code agent's harness across four commits:

- Env/git context injected into the system prompt; line-numbered, windowed `read_file`; `run_shell` with sane timeouts, a `description` for approval prompts, tail-keeping truncation, and background tasks; low-risk tool calls in one turn now execute concurrently
- Memory revision tools (`memory_update`/`memory_forget`) with when-to-remember guidance; plan mode with a `propose_plan` approval round-trip that flips the live session to execution; a read-only `explore` subagent that keeps broad research out of the main context
- Plan mode wired through the server WS and GUI (PlanCard with approve/revise actions)
- New Discuss mode: read-only conversation without the planning contract

Tests: 297 passing (60+ new). Plan/discuss flows also verified end-to-end in the browser GUI against a live model.