### PR TITLE
fix: relax docstring-parser constraint to support Python 3.14

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1256,15 +1256,20 @@ files = [
 
 [[package]]
 name = "docstring-parser"
-version = "0.15"
+version = "0.18.0"
 description = "Parse Python docstrings in reST, Google and Numpydoc format"
 optional = false
-python-versions = ">=3.6,<4.0"
+python-versions = ">=3.8"
 groups = ["main", "dev"]
 files = [
-    {file = "docstring_parser-0.15-py3-none-any.whl", hash = "sha256:d1679b86250d269d06a99670924d6bce45adc00b08069dae8c47d98e89b667a9"},
-    {file = "docstring_parser-0.15.tar.gz", hash = "sha256:48ddc093e8b1865899956fcc03b03e66bb7240c310fac5af81814580c55bf682"},
+    {file = "docstring_parser-0.18.0-py3-none-any.whl", hash = "sha256:b3fcbed555c47d8479be0796ef7e19c2670d428d72e96da63f3a40122860374b"},
+    {file = "docstring_parser-0.18.0.tar.gz", hash = "sha256:292510982205c12b1248696f44959db3cdd1740237a968ea1e2e7a900eeb2015"},
 ]
+
+[package.extras]
+dev = ["pre-commit (>=2.16.0) ; python_version >= \"3.9\"", "pydoctor (>=25.4.0)", "pytest"]
+docs = ["pydoctor (>=25.4.0)"]
+test = ["pytest"]
 
 [[package]]
 name = "durationpy"
@@ -7420,4 +7425,4 @@ watsonx = ["ibm-watsonx-ai"]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.10"
-content-hash = "d3cce565f222995dc263bcef89f493282e09293e5c29ed3fb40bb93d647b5a2f"
+content-hash = "943532f2036330be88359ba65c2488c9271fe682bde3221b93347e3748a3edf7"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ numpy = { version = "^1.24.0", optional = true }
 groq = { version = "^0.9.0", optional = true }
 mistralai = { version = "^1.0.3", optional = true }
 ibm-watsonx-ai = { version = "^1.1.16", optional = true }
-docstring-parser = { version = "^0.15.0" }
+docstring-parser = { version = ">=0.16,<1.0" }
 pydantic = { version = "^2.10.0" }
 cerebras_cloud_sdk = { version = "^1.19.0", optional = true }
 openai = { version = "^1.107.0", optional = true }


### PR DESCRIPTION
`aisuite` fails on import on Python 3.14 with:
AttributeError: module 'ast' has no attribute 'NameConstant'

This is caused by the `docstring-parser` dependency. Version 0.15 relies on `ast.NameConstant`, `ast.Str`, and `ast.Num`, which were deprecated since Python 3.8 and removed entirely in Python 3.14.

`pyproject.toml` pinned `docstring-parser` with a caret constraint:

```toml
docstring-parser = { version = "^0.15.0" }
```

Under Poetry's semantics for 0.x versions, `^0.15.0` resolves to `>=0.15.0,<0.16.0`, so the resolver could never pick up a release with the fix (the deprecated `ast` classes were removed in a later 0.x release; current latest is `0.18.0`).

Relax the constraint to `>=0.16,<1.0`, allowing resolution to `0.18.0`, which removes the deprecated `ast` usage. `poetry.lock` regenerated accordingly (`docstring-parser` 0.15 → 0.18.0).

**Verified:**
- `import aisuite as ai` succeeds with no `AttributeError` or `DeprecationWarning`.
- Full test suite: 348 passed, 1 skipped (pre-existing failures from missing optional extras such as `mcp`/`cohere`/`deepgram` are unaffected and identical with/without this change).

Fixes #265