### PR TITLE
fix: Preserve Gemini thought signatures across multi-step tool calls resolves #321

### DIFF
--- a/examples/mcp_config_dict_example.py
+++ b/examples/mcp_config_dict_example.py
@@ -153,7 +153,8 @@ print("\n" + "=" * 70)
 print("Example 5: When to Use Config Dict vs MCPClient")
 print("=" * 70)
 
-print("""
+print(
+    """
 Use Config Dict When:
 ✓ Quick prototypes and simple scripts
 ✓ One-off tool usage
@@ -169,7 +170,8 @@ Use Explicit MCPClient When:
 ✓ Want to manually manage resources
 
 Example of explicit MCPClient:
-""")
+"""
+)
 
 from aisuite.mcp import MCPClient
 

--- a/platform/coworker/audit.py
+++ b/platform/coworker/audit.py
@@ -29,7 +29,8 @@ class AuditStore:
         self._lock = threading.RLock()
         self._conn = sqlite3.connect(self.db_path, check_same_thread=False)
         self._conn.row_factory = sqlite3.Row
-        self._conn.execute("""
+        self._conn.execute(
+            """
             CREATE TABLE IF NOT EXISTS audit_events (
                 id INTEGER PRIMARY KEY AUTOINCREMENT,
                 timestamp TEXT DEFAULT CURRENT_TIMESTAMP,
@@ -46,7 +47,8 @@ class AuditStore:
                 reason TEXT,
                 resource TEXT
             )
-            """)
+            """
+        )
         self._conn.commit()
 
     def append(self, event: dict[str, Any]) -> None:

--- a/platform/coworker/automation/store.py
+++ b/platform/coworker/automation/store.py
@@ -72,7 +72,8 @@ class TaskStore:
 
     def _init(self) -> None:
         with self._lock:
-            self._conn.executescript("""
+            self._conn.executescript(
+                """
                 CREATE TABLE IF NOT EXISTS scheduled_tasks (
                     id TEXT PRIMARY KEY,
                     enabled INTEGER NOT NULL DEFAULT 1,
@@ -86,7 +87,8 @@ class TaskStore:
                     data TEXT NOT NULL
                 );
                 CREATE INDEX IF NOT EXISTS idx_runs_task ON task_runs(task_id, started_at DESC);
-                """)
+                """
+            )
             self._conn.commit()
 
     # -- tasks ------------------------------------------------------------------

--- a/platform/coworker/conversations.py
+++ b/platform/coworker/conversations.py
@@ -52,7 +52,8 @@ class ConversationStore:
         self._lock = threading.RLock()
         self._conn = sqlite3.connect(self.db_path, check_same_thread=False)
         self._conn.row_factory = sqlite3.Row
-        self._conn.executescript("""
+        self._conn.executescript(
+            """
             CREATE TABLE IF NOT EXISTS sessions (
                 session_id TEXT PRIMARY KEY, workspace TEXT, model TEXT, mode TEXT,
                 title TEXT, agent TEXT DEFAULT 'code', n_msgs INTEGER DEFAULT 0, messages TEXT,
@@ -62,7 +63,8 @@ class ConversationStore:
             CREATE TABLE IF NOT EXISTS workspaces (
                 path TEXT PRIMARY KEY, last_used TEXT DEFAULT CURRENT_TIMESTAMP
             );
-            """)
+            """
+        )
         for ddl in (
             "ALTER TABLE sessions ADD COLUMN title TEXT",
             "ALTER TABLE sessions ADD COLUMN n_msgs INTEGER DEFAULT 0",

--- a/platform/coworker/engine.py
+++ b/platform/coworker/engine.py
@@ -21,6 +21,7 @@ from typing import Any, AsyncIterator, Awaitable, Callable, Optional
 from .events import Event, EventType
 from .permissions import Mode, PermissionEngine
 from .providers import AssistantTurn, ProviderClient, ToolCall
+from .providers.base import normalize_thought_signature
 from .tools import ToolRegistry
 
 
@@ -533,17 +534,25 @@ class TurnEngine:
         return out
 
 
+def _tool_call_message_entry(tc: ToolCall) -> dict[str, Any]:
+    """One OpenAI-shaped `tool_calls` entry. A Gemini thought signature (when present) rides as
+    `extra_content.google.thought_signature` so it survives the round-trip and can be replayed
+    on the next request — Gemini 3.x rejects multi-step tool turns without it."""
+    entry: dict[str, Any] = {
+        "id": tc.id,
+        "type": "function",
+        "function": {"name": tc.name, "arguments": json.dumps(tc.arguments)},
+    }
+    signature = normalize_thought_signature(tc.thought_signature)
+    if signature:
+        entry["extra_content"] = {"google": {"thought_signature": signature}}
+    return entry
+
+
 def _assistant_message(turn: AssistantTurn) -> dict[str, Any]:
     message: dict[str, Any] = {"role": "assistant", "content": turn.text or ""}
     if turn.tool_calls:
-        message["tool_calls"] = [
-            {
-                "id": tc.id,
-                "type": "function",
-                "function": {"name": tc.name, "arguments": json.dumps(tc.arguments)},
-            }
-            for tc in turn.tool_calls
-        ]
+        message["tool_calls"] = [_tool_call_message_entry(tc) for tc in turn.tool_calls]
     return message
 
 

--- a/platform/coworker/memory/sqlite_store.py
+++ b/platform/coworker/memory/sqlite_store.py
@@ -20,7 +20,8 @@ class SQLiteMemoryStore(MemoryStore):
         self._lock = threading.RLock()
         self._conn = sqlite3.connect(self.path, check_same_thread=False)
         self._conn.row_factory = sqlite3.Row
-        self._conn.execute("""
+        self._conn.execute(
+            """
             CREATE TABLE IF NOT EXISTS memories (
                 id INTEGER PRIMARY KEY AUTOINCREMENT,
                 scope TEXT NOT NULL,
@@ -30,7 +31,8 @@ class SQLiteMemoryStore(MemoryStore):
                 session_id TEXT,
                 created_at TEXT DEFAULT CURRENT_TIMESTAMP
             )
-            """)
+            """
+        )
         self._conn.commit()
 
     def add(

--- a/platform/coworker/providers/base.py
+++ b/platform/coworker/providers/base.py
@@ -7,9 +7,28 @@ slots in later (P12) without touching the engine, since aisuite is OpenAI-API-sh
 
 from __future__ import annotations
 
+import base64
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
 from typing import Any, Optional
+
+
+def normalize_thought_signature(value: Any) -> Optional[str]:
+    """Gemini's SDK may return `thought_signature` as opaque bytes. Conversation history is
+    JSON-serialized, and the REST API expects a string — normalize at capture/persist time.
+    """
+    if value is None:
+        return None
+    if isinstance(value, str):
+        return value or None
+    if isinstance(value, (bytes, bytearray)):
+        raw = bytes(value)
+        try:
+            return raw.decode("utf-8") or None
+        except UnicodeDecodeError:
+            return base64.b64encode(raw).decode("ascii")
+    text = str(value)
+    return text or None
 
 
 @dataclass
@@ -19,6 +38,7 @@ class ToolCall:
     id: str
     name: str
     arguments: dict[str, Any] = field(default_factory=dict)
+    thought_signature: Optional[str] = None
 
 
 @dataclass

--- a/platform/coworker/providers/gemini_provider.py
+++ b/platform/coworker/providers/gemini_provider.py
@@ -24,6 +24,7 @@ from .base import (
     ProviderClient,
     StreamChunk,
     ToolCall,
+    normalize_thought_signature,
 )
 from .capabilities import capabilities_for
 
@@ -141,6 +142,29 @@ def _result_payload(content: Any) -> dict[str, Any]:
         return {"result": str(content or "")}
 
 
+def _signature_from_stored_call(call: dict[str, Any]) -> Optional[str]:
+    """The thought signature stashed on a stored OpenAI-shaped tool call, if any. We persist it
+    as `extra_content.google.thought_signature` (Google's OpenAI-compat convention)."""
+    extra = call.get("extra_content")
+    if not isinstance(extra, dict):
+        return None
+    google = extra.get("google")
+    if not isinstance(google, dict):
+        return None
+    return normalize_thought_signature(google.get("thought_signature"))
+
+
+def _function_call_part(
+    name: str, args: dict[str, Any], signature: Optional[str] = None
+) -> dict[str, Any]:
+    """A Gemini `function_call` part. The thought signature rides as a sibling of `function_call`
+    (a part-level field), never nested inside it — Gemini validates it there."""
+    part: dict[str, Any] = {"function_call": {"name": name, "args": args}}
+    if signature:
+        part["thought_signature"] = signature
+    return part
+
+
 def convert_messages(
     messages: list[dict[str, Any]],
 ) -> tuple[Optional[str], list[dict[str, Any]]]:
@@ -187,12 +211,11 @@ def convert_messages(
                 name = function.get("name") or ""
                 call_names[call.get("id") or ""] = name
                 parts.append(
-                    {
-                        "function_call": {
-                            "name": name,
-                            "args": _parse_args(function.get("arguments")),
-                        }
-                    }
+                    _function_call_part(
+                        name,
+                        _parse_args(function.get("arguments")),
+                        _signature_from_stored_call(call),
+                    )
                 )
             if parts:
                 converted.append({"role": "model", "parts": parts})
@@ -262,18 +285,33 @@ def convert_tools(tools: Optional[list[dict[str, Any]]]) -> list[dict[str, Any]]
     return [{"function_declarations": declarations}] if declarations else []
 
 
-def _parse_candidate(response: Any) -> tuple[list[str], list[ToolCall], Optional[str]]:
-    """Pull text parts, function calls (with synthesized ids), and the finish reason out of a
-    GenerateContentResponse (or one streamed chunk of it)."""
-    texts: list[str] = []
-    calls: list[ToolCall] = []
-    finish = None
+def _candidate_parts(response: Any) -> list[Any]:
+    """The content parts of the first candidate (empty when the response has none)."""
     candidates = getattr(response, "candidates", None) or []
     if not candidates:
-        return texts, calls, finish
-    candidate = candidates[0]
-    content = getattr(candidate, "content", None)
-    for part in getattr(content, "parts", None) or []:
+        return []
+    content = getattr(candidates[0], "content", None)
+    return list(getattr(content, "parts", None) or [])
+
+
+def _candidate_finish(response: Any) -> Optional[str]:
+    """The first candidate's finish reason as a plain string (the SDK uses a .name enum)."""
+    candidates = getattr(response, "candidates", None) or []
+    if not candidates:
+        return None
+    raw_finish = getattr(candidates[0], "finish_reason", None)
+    if raw_finish is None:
+        return None
+    return getattr(raw_finish, "name", None) or str(raw_finish)
+
+
+def _parse_parts(parts: list[Any]) -> tuple[list[str], list[ToolCall]]:
+    """Split a list of content parts into text and function calls. The thought signature is a
+    part-level field, so it is read off the same part as the function call (synthesized ids are
+    assigned by the caller, which has the running count)."""
+    texts: list[str] = []
+    calls: list[ToolCall] = []
+    for part in parts or []:
         text = getattr(part, "text", None)
         if text:
             texts.append(text)
@@ -281,15 +319,22 @@ def _parse_candidate(response: Any) -> tuple[list[str], list[ToolCall], Optional
         if function_call is not None:
             calls.append(
                 ToolCall(
-                    id="",  # synthesized by the caller (needs the running count)
+                    id="",
                     name=getattr(function_call, "name", "") or "",
                     arguments=dict(getattr(function_call, "args", None) or {}),
+                    thought_signature=normalize_thought_signature(
+                        getattr(part, "thought_signature", None)
+                    ),
                 )
             )
-    raw_finish = getattr(candidate, "finish_reason", None)
-    if raw_finish is not None:
-        finish = getattr(raw_finish, "name", None) or str(raw_finish)
-    return texts, calls, finish
+    return texts, calls
+
+
+def _parse_candidate(response: Any) -> tuple[list[str], list[ToolCall], Optional[str]]:
+    """Pull text parts, function calls (with synthesized ids), and the finish reason out of a
+    GenerateContentResponse (or one streamed chunk of it)."""
+    texts, calls = _parse_parts(_candidate_parts(response))
+    return texts, calls, _candidate_finish(response)
 
 
 def _map_finish(finish: Optional[str], has_calls: bool) -> Optional[str]:
@@ -370,7 +415,12 @@ class GeminiProvider(ProviderClient):
         response = self._ensure_client().models.generate_content(**kwargs)
         texts, calls, finish = _parse_candidate(response)
         tool_calls = [
-            ToolCall(id=f"call_{i}", name=c.name, arguments=c.arguments)
+            ToolCall(
+                id=f"call_{i}",
+                name=c.name,
+                arguments=c.arguments,
+                thought_signature=c.thought_signature,
+            )
             for i, c in enumerate(calls)
         ]
         return AssistantTurn(
@@ -397,22 +447,32 @@ class GeminiProvider(ProviderClient):
         client = self._ensure_client()
 
         text_parts: list[str] = []
-        calls: list[ToolCall] = []
+        raw_parts: list[Any] = []
         finish = None
 
-        # Unlike Anthropic, function_call parts arrive whole (args are a complete dict per
-        # part), so there is no JSON accumulation — just collect parts across chunks.
+        # Function_call parts arrive whole (args are a complete dict per part), but the thought
+        # signature can land on a different chunk than the call itself. So accumulate the raw
+        # parts across all chunks and parse the function calls once at the end — that keeps each
+        # signature attached to its part instead of being lost mid-stream.
         for chunk in client.models.generate_content_stream(**kwargs):
-            texts, chunk_calls, chunk_finish = _parse_candidate(chunk)
-            for text in texts:
+            chunk_parts = _candidate_parts(chunk)
+            chunk_texts, _ = _parse_parts(chunk_parts)
+            for text in chunk_texts:
                 text_parts.append(text)
                 yield StreamChunk(text_delta=text)
-            calls.extend(chunk_calls)
+            raw_parts.extend(chunk_parts)
+            chunk_finish = _candidate_finish(chunk)
             if chunk_finish:
                 finish = chunk_finish
 
+        _, calls = _parse_parts(raw_parts)
         tool_calls = [
-            ToolCall(id=f"call_{i}", name=c.name, arguments=c.arguments)
+            ToolCall(
+                id=f"call_{i}",
+                name=c.name,
+                arguments=c.arguments,
+                thought_signature=c.thought_signature,
+            )
             for i, c in enumerate(calls)
         ]
         yield StreamChunk(

--- a/platform/coworker/providers/openai_provider.py
+++ b/platform/coworker/providers/openai_provider.py
@@ -37,6 +37,34 @@ def resolve_api_key(secrets: Any = None) -> Optional[str]:
     return None
 
 
+def _strip_provider_extras(
+    messages: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    """Drop `extra_content` (Gemini thought signatures) from tool calls before sending to the
+    OpenAI API. A session run on Gemini then switched to OpenAI carries that metadata in its
+    history; the OpenAI SDK rejects unknown fields. Copies lazily — only messages that actually
+    carry the field are rewritten, so the engine's shared history is never mutated."""
+    cleaned: list[dict[str, Any]] = []
+    for message in messages:
+        tool_calls = message.get("tool_calls")
+        if not tool_calls or not any(
+            isinstance(tc, dict) and "extra_content" in tc for tc in tool_calls
+        ):
+            cleaned.append(message)
+            continue
+        new_message = dict(message)
+        new_message["tool_calls"] = [
+            (
+                {k: v for k, v in tc.items() if k != "extra_content"}
+                if isinstance(tc, dict)
+                else tc
+            )
+            for tc in tool_calls
+        ]
+        cleaned.append(new_message)
+    return cleaned
+
+
 class OpenAIProvider(ProviderClient):
     def __init__(
         self,
@@ -87,7 +115,11 @@ class OpenAIProvider(ProviderClient):
         tools: Optional[list[dict[str, Any]]] = None,
         **settings: Any,
     ) -> AssistantTurn:
-        kwargs: dict[str, Any] = {"model": model, "messages": messages, **settings}
+        kwargs: dict[str, Any] = {
+            "model": model,
+            "messages": _strip_provider_extras(messages),
+            **settings,
+        }
         if tools:
             kwargs["tools"] = tools
 
@@ -117,7 +149,7 @@ class OpenAIProvider(ProviderClient):
     ):
         kwargs: dict[str, Any] = {
             "model": model,
-            "messages": messages,
+            "messages": _strip_provider_extras(messages),
             "stream": True,
             **settings,
         }

--- a/platform/coworker/server/app.py
+++ b/platform/coworker/server/app.py
@@ -8,7 +8,6 @@ proxy so any OpenAI-format client can use the runtime as a backend.
 from __future__ import annotations
 
 import asyncio
-import json
 import uuid
 from contextlib import asynccontextmanager
 from pathlib import Path
@@ -18,7 +17,7 @@ from fastapi import FastAPI, WebSocket, WebSocketDisconnect
 from fastapi.middleware.cors import CORSMiddleware
 
 from ..attachments import build_user_content
-from ..engine import ApprovalOutcome
+from ..engine import ApprovalOutcome, _tool_call_message_entry
 from ..permissions import Mode
 from ..providers import AssistantTurn
 from .manager import SessionManager
@@ -534,14 +533,7 @@ def create_app(manager: SessionManager) -> FastAPI:
 def _openai_response(model: str, turn: AssistantTurn) -> dict[str, Any]:
     message: dict[str, Any] = {"role": "assistant", "content": turn.text or ""}
     if turn.tool_calls:
-        message["tool_calls"] = [
-            {
-                "id": tc.id,
-                "type": "function",
-                "function": {"name": tc.name, "arguments": json.dumps(tc.arguments)},
-            }
-            for tc in turn.tool_calls
-        ]
+        message["tool_calls"] = [_tool_call_message_entry(tc) for tc in turn.tool_calls]
     return {
         "id": "chatcmpl-" + uuid.uuid4().hex[:12],
         "object": "chat.completion",

--- a/platform/tests/test_gemini_provider.py
+++ b/platform/tests/test_gemini_provider.py
@@ -54,10 +54,26 @@ def _text_part(text):
     return SimpleNamespace(text=text, function_call=None)
 
 
-def _call_part(name, args):
-    return SimpleNamespace(
+def _call_part(name, args, signature=None):
+    part = SimpleNamespace(
         text=None, function_call=SimpleNamespace(name=name, args=args)
     )
+    if signature is not None:
+        part.thought_signature = signature
+    return part
+
+
+def _stored_call(call_id, name, arguments="{}", signature=None):
+    """An OpenAI-shaped stored tool call, optionally carrying a Gemini thought signature the way
+    the engine persists it (`extra_content.google.thought_signature`)."""
+    entry = {
+        "id": call_id,
+        "type": "function",
+        "function": {"name": name, "arguments": arguments},
+    }
+    if signature is not None:
+        entry["extra_content"] = {"google": {"thought_signature": signature}}
+    return entry
 
 
 # -- message conversion -------------------------------------------------------------
@@ -94,6 +110,98 @@ def test_convert_assistant_tool_turn_maps_role_model():
     )
     assert contents[1]["role"] == "model"
     assert contents[1]["parts"] == [{"function_call": {"name": "f", "args": {"x": 1}}}]
+
+
+def test_convert_replays_thought_signature_on_first_tool_call():
+    # A stored signature must ride back as a part-level sibling of function_call (not nested
+    # inside it) — that is exactly where Gemini validates it.
+    _, contents = convert_messages(
+        [
+            {"role": "user", "content": "do it"},
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [
+                    _stored_call("call_0", "f", '{"x": 1}', signature="SIG")
+                ],
+            },
+        ]
+    )
+    assert contents[1]["parts"] == [
+        {"function_call": {"name": "f", "args": {"x": 1}}, "thought_signature": "SIG"}
+    ]
+
+
+def test_convert_parallel_tool_calls_signature_only_on_first():
+    # Parallel calls: Gemini attaches the signature only to the first function call. The second
+    # part must NOT get one (a stray signature there triggers the same 400 we are fixing).
+    _, contents = convert_messages(
+        [
+            {"role": "user", "content": "go"},
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [
+                    _stored_call("call_0", "a", "{}", signature="SIG-A"),
+                    _stored_call("call_1", "b", "{}"),
+                ],
+            },
+        ]
+    )
+    parts = contents[1]["parts"]
+    assert parts[0]["thought_signature"] == "SIG-A"
+    assert "thought_signature" not in parts[1]
+
+
+def test_convert_multi_step_turn_replays_each_step_signature():
+    # Sequential (multi-step) function calling: every step's first call keeps its own signature.
+    _, contents = convert_messages(
+        [
+            {"role": "user", "content": "go"},
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [
+                    _stored_call("call_0", "first", "{}", signature="SIG-1")
+                ],
+            },
+            {"role": "tool", "tool_call_id": "call_0", "content": "r1"},
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [
+                    _stored_call("call_0", "second", "{}", signature="SIG-2")
+                ],
+            },
+            {"role": "tool", "tool_call_id": "call_0", "content": "r2"},
+        ]
+    )
+    signatures = [
+        p.get("thought_signature")
+        for c in contents
+        for p in c["parts"]
+        if "function_call" in p
+    ]
+    assert signatures == ["SIG-1", "SIG-2"]
+
+
+def test_thought_signature_round_trip_through_history():
+    # End-to-end: a turn the provider parsed → engine history entry → replayed by convert_messages.
+    from coworker.engine import _tool_call_message_entry
+    from coworker.providers import ToolCall
+
+    entry = _tool_call_message_entry(
+        ToolCall(id="call_0", name="f", arguments={"x": 1}, thought_signature="SIG")
+    )
+    assert entry["extra_content"] == {"google": {"thought_signature": "SIG"}}
+
+    _, contents = convert_messages(
+        [
+            {"role": "user", "content": "go"},
+            {"role": "assistant", "content": "", "tool_calls": [entry]},
+        ]
+    )
+    assert contents[1]["parts"][0]["thought_signature"] == "SIG"
 
 
 def test_convert_tool_results_map_id_to_name_and_merge():
@@ -327,6 +435,38 @@ def test_complete_parses_function_calls_with_synthesized_ids():
     assert turn.tool_calls[0].arguments == {"path": "a.txt"}
 
 
+def test_complete_captures_thought_signature():
+    fake = _FakeClient(
+        response=_response(
+            [_call_part("write_file", {"path": "a.txt"}, signature="SIG")]
+        )
+    )
+    provider = GeminiProvider(client=fake)
+    turn = provider.complete(model="m", messages=[{"role": "user", "content": "go"}])
+    assert turn.tool_calls[0].thought_signature == "SIG"
+
+
+def test_complete_normalizes_bytes_thought_signature():
+    # The live google-genai SDK returns thought_signature as bytes; it must become a str before
+    # the engine persists history (json.dumps rejects bytes).
+    import json
+
+    from coworker.engine import _tool_call_message_entry
+    from coworker.providers.base import normalize_thought_signature
+
+    assert normalize_thought_signature(b"SIG") == "SIG"
+
+    fake = _FakeClient(
+        response=_response([_call_part("todo_write", {"items": []}, signature=b"SIG")])
+    )
+    provider = GeminiProvider(client=fake)
+    turn = provider.complete(model="m", messages=[{"role": "user", "content": "go"}])
+    assert turn.tool_calls[0].thought_signature == "SIG"
+
+    entry = _tool_call_message_entry(turn.tool_calls[0])
+    json.dumps(entry)  # must not raise TypeError
+
+
 @pytest.mark.parametrize(
     "finish,expected",
     [
@@ -430,6 +570,20 @@ def test_stream_collects_function_calls_across_chunks():
         ("call_1", "g"),
     ]
     assert final.tool_calls[0].arguments == {"x": 1}
+
+
+def test_stream_preserves_thought_signature_on_tool_call():
+    # The signature rides on the function-call part; the final turn must keep it after the
+    # chunks are merged.
+    chunks = [
+        _response([_text_part("working")], finish_reason=None),
+        _response([_call_part("f", {"x": 1}, signature="SIG")], finish_reason="STOP"),
+    ]
+    provider = GeminiProvider(client=_FakeClient(chunks=chunks))
+    final = list(
+        provider.stream(model="m", messages=[{"role": "user", "content": "x"}])
+    )[-1].turn
+    assert final.tool_calls[0].thought_signature == "SIG"
 
 
 def test_stream_handles_enum_like_finish_reason():

--- a/platform/tests/test_providers.py
+++ b/platform/tests/test_providers.py
@@ -74,6 +74,34 @@ def test_complete_parses_tool_calls():
     assert "tools" in client.chat.completions.calls[0]
 
 
+def test_complete_strips_gemini_extra_content_from_history():
+    # A session run on Gemini then switched to OpenAI carries `extra_content` (thought
+    # signatures) on its tool calls. The OpenAI API rejects unknown fields, so it must be
+    # stripped on the way out — without mutating the engine's shared history.
+    client = _FakeClient(_response(content="ok"))
+    provider = OpenAIProvider(client=client)
+    messages = [
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [
+                {
+                    "id": "call_0",
+                    "type": "function",
+                    "function": {"name": "f", "arguments": "{}"},
+                    "extra_content": {"google": {"thought_signature": "SIG"}},
+                }
+            ],
+        }
+    ]
+    provider.complete(model="gpt-5.5", messages=messages)
+
+    sent = client.chat.completions.calls[0]["messages"]
+    assert "extra_content" not in sent[0]["tool_calls"][0]
+    # original history untouched
+    assert "extra_content" in messages[0]["tool_calls"][0]
+
+
 def test_complete_tolerates_bad_tool_args():
     tc = SimpleNamespace(
         id="call_2", function=SimpleNamespace(name="x", arguments="{not json")

--- a/tests/toolkits/test_files.py
+++ b/tests/toolkits/test_files.py
@@ -115,14 +115,16 @@ def test_files_toolkit_applies_unified_diff_to_existing_file(tmp_path):
         fn.__name__: fn for fn in ai.toolkits.files(root=tmp_path, allow_write=True)
     }
 
-    result = tools["apply_unified_diff"]("""--- a/sample.txt
+    result = tools["apply_unified_diff"](
+        """--- a/sample.txt
 +++ b/sample.txt
 @@ -1,3 +1,3 @@
  one
 -two
 +TWO
  three
-""")
+"""
+    )
 
     assert result == {
         "changed_files": ["sample.txt"],
@@ -142,7 +144,8 @@ def test_files_toolkit_applies_unified_diff_add_and_delete(tmp_path):
         fn.__name__: fn for fn in ai.toolkits.files(root=tmp_path, allow_write=True)
     }
 
-    result = tools["apply_unified_diff"]("""--- /dev/null
+    result = tools["apply_unified_diff"](
+        """--- /dev/null
 +++ b/new.txt
 @@ -0,0 +1,2 @@
 +hello
@@ -152,7 +155,8 @@ def test_files_toolkit_applies_unified_diff_add_and_delete(tmp_path):
 @@ -1,2 +0,0 @@
 -bye
 -now
-""")
+"""
+    )
 
     assert result == {
         "changed_files": ["new.txt"],
@@ -171,7 +175,8 @@ def test_files_toolkit_applies_codex_patch_to_existing_file(tmp_path):
         fn.__name__: fn for fn in ai.toolkits.files(root=tmp_path, allow_write=True)
     }
 
-    result = tools["apply_patch"]("""*** Begin Patch
+    result = tools["apply_patch"](
+        """*** Begin Patch
 *** Update File: sample.txt
 @@
  one
@@ -179,7 +184,8 @@ def test_files_toolkit_applies_codex_patch_to_existing_file(tmp_path):
 +TWO
  three
 *** End Patch
-""")
+"""
+    )
 
     assert result == {
         "changed_files": ["sample.txt"],
@@ -200,7 +206,8 @@ def test_files_toolkit_applies_codex_patch_add_delete_and_move(tmp_path):
         fn.__name__: fn for fn in ai.toolkits.files(root=tmp_path, allow_write=True)
     }
 
-    result = tools["apply_patch"]("""*** Begin Patch
+    result = tools["apply_patch"](
+        """*** Begin Patch
 *** Add File: new.txt
 +hello
 +world
@@ -212,7 +219,8 @@ def test_files_toolkit_applies_codex_patch_add_delete_and_move(tmp_path):
 +new
  name
 *** End Patch
-""")
+"""
+    )
 
     assert result == {
         "changed_files": ["new.txt", "renamed.txt"],
@@ -233,7 +241,8 @@ def test_files_toolkit_applies_codex_patch_multiple_hunks_and_insertions(tmp_pat
         fn.__name__: fn for fn in ai.toolkits.files(root=tmp_path, allow_write=True)
     }
 
-    result = tools["apply_patch"]("""*** Begin Patch
+    result = tools["apply_patch"](
+        """*** Begin Patch
 *** Update File: sample.txt
 @@
 -one
@@ -244,7 +253,8 @@ def test_files_toolkit_applies_codex_patch_multiple_hunks_and_insertions(tmp_pat
 +inserted
  four
 *** End Patch
-""")
+"""
+    )
 
     assert result == {
         "changed_files": ["sample.txt"],
@@ -265,21 +275,25 @@ def test_files_toolkit_rejects_bad_or_escaping_codex_patch(tmp_path):
     }
 
     with pytest.raises(ValueError, match="context does not match"):
-        tools["apply_patch"]("""*** Begin Patch
+        tools["apply_patch"](
+            """*** Begin Patch
 *** Update File: sample.txt
 @@
  wrong
 -two
 +TWO
 *** End Patch
-""")
+"""
+        )
 
     with pytest.raises(PermissionError):
-        tools["apply_patch"]("""*** Begin Patch
+        tools["apply_patch"](
+            """*** Begin Patch
 *** Add File: ../outside.txt
 +outside
 *** End Patch
-""")
+"""
+        )
 
 
 def test_files_toolkit_rejects_ambiguous_or_contextless_codex_patch(tmp_path):
@@ -289,21 +303,25 @@ def test_files_toolkit_rejects_ambiguous_or_contextless_codex_patch(tmp_path):
     }
 
     with pytest.raises(ValueError, match="ambiguous"):
-        tools["apply_patch"]("""*** Begin Patch
+        tools["apply_patch"](
+            """*** Begin Patch
 *** Update File: sample.txt
 @@
 -target
 +TARGET
 *** End Patch
-""")
+"""
+        )
 
     with pytest.raises(ValueError, match="context or removal"):
-        tools["apply_patch"]("""*** Begin Patch
+        tools["apply_patch"](
+            """*** Begin Patch
 *** Update File: sample.txt
 @@
 +inserted
 *** End Patch
-""")
+"""
+        )
 
 
 def test_files_toolkit_rejects_codex_patch_move_over_existing_file(tmp_path):
@@ -314,14 +332,16 @@ def test_files_toolkit_rejects_codex_patch_move_over_existing_file(tmp_path):
     }
 
     with pytest.raises(FileExistsError):
-        tools["apply_patch"]("""*** Begin Patch
+        tools["apply_patch"](
+            """*** Begin Patch
 *** Update File: old.txt
 *** Move to: existing.txt
 @@
 -old
 +new
 *** End Patch
-""")
+"""
+        )
     assert (tmp_path / "existing.txt").read_text(encoding="utf-8") == "existing\n"
     assert (tmp_path / "old.txt").read_text(encoding="utf-8") == "old\n"
 
@@ -333,20 +353,24 @@ def test_files_toolkit_rejects_bad_or_escaping_unified_diff(tmp_path):
     }
 
     with pytest.raises(ValueError, match="context does not match"):
-        tools["apply_unified_diff"]("""--- a/sample.txt
+        tools["apply_unified_diff"](
+            """--- a/sample.txt
 +++ b/sample.txt
 @@ -1,2 +1,2 @@
  wrong
 -two
 +TWO
-""")
+"""
+        )
 
     with pytest.raises(PermissionError):
-        tools["apply_unified_diff"]("""--- a/../outside.txt
+        tools["apply_unified_diff"](
+            """--- a/../outside.txt
 +++ b/../outside.txt
 @@ -0,0 +1,1 @@
 +outside
-""")
+"""
+        )
 
 
 def test_files_toolkit_replaces_exact_text(tmp_path):


### PR DESCRIPTION
## Summary
- Fixes #321 
- Capture `thought_signature` from Gemini function-call parts and attach it to `ToolCall`
- Persist signatures in conversation history as `extra_content.google.thought_signature` so they survive round-trips through the engine and OpenAI-compat API
- Replay signatures when converting stored messages back to Gemini `function_call` parts
- Fix streaming: accumulate raw parts across chunks so signatures are not lost when they arrive separately from the function call
- Strip `extra_content` in the OpenAI provider so sessions that started on Gemini still work after switching to OpenAI
- Add tests for signature capture, persistence, replay, and OpenAI stripping

## Why

Gemini 3.x requires thought signatures on multi-step tool turns. Without preserving them in history, follow-up tool-call rounds fail.

## Test plan

- [x] `poetry run pytest platform/tests/test_gemini_provider.py platform/tests/test_providers.py`
- [x] Manual: run a multi-step tool session on Gemini and confirm follow-up turns succeed
- [x] Manual: switch provider from Gemini to OpenAI mid-session and confirm no API errors from `extra_content`