### PR TITLE
Add Linux build script and docs for OpenCoworker

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,10 @@
 > <sub>&nbsp;&nbsp;macOS 13+ (Apple Silicon)</sub> &nbsp;&nbsp;
 > 
 > [**⬇ Download for Windows**](https://github.com/andrewyng/aisuite/releases/latest/download/OpenCoworker-windows-setup.exe)
-> <sub>&nbsp;&nbsp;Windows 10/11 (x64) &nbsp;·&nbsp; </sub>
+> <sub>&nbsp;&nbsp;Windows 10/11 (x64)</sub> &nbsp;&nbsp;
+>
+> [**⬇ Linux (build from source)**](docs/opencoworker-quickstart.md#linux-build-from-source)
+> <sub>&nbsp;&nbsp;Ubuntu/Debian x64 — ~10 min, produces .deb + .AppImage</sub>
 >
 > [**Quickstart:**](docs/opencoworker-quickstart.md) — install, connect a model, first tasks, automations.
 > 

--- a/docs/opencoworker-quickstart.md
+++ b/docs/opencoworker-quickstart.md
@@ -8,8 +8,44 @@
 |---|---|
 | macOS 13+ (Apple Silicon, M1 or later) | [OpenCoworker-macos-arm64.dmg](https://github.com/andrewyng/aisuite/releases/latest/download/OpenCoworker-macos-arm64.dmg) |
 | Windows 10/11 (x64) | [OpenCoworker-windows-setup.exe](https://github.com/andrewyng/aisuite/releases/latest/download/OpenCoworker-windows-setup.exe) |
+| Linux (x64) | Build from source — see below |
 
 NOTE: On Windows, SmartScreen may warn on first run: choose **More info → Run anyway** (the build isn't Authenticode-signed yet).
+
+### Linux: build from source
+
+No pre-built binary is provided yet. The build takes ~5–10 minutes and produces a `.deb` (Ubuntu/Debian) and `.AppImage`.
+
+**1. System dependencies (Ubuntu/Debian):**
+```bash
+sudo apt install libwebkit2gtk-4.1-dev build-essential curl wget file \
+  libxdo-dev libssl-dev libayatana-appindicator3-dev librsvg2-dev \
+  nodejs npm python3 python3-venv
+```
+
+**2. Rust:**
+```bash
+curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
+source ~/.cargo/env
+```
+
+**3. Python venv + dependencies:**
+```bash
+cd platform/
+python3 -m venv .venv
+.venv/bin/pip install -e . -e ../ pyinstaller 'mcp[cli]'
+```
+
+**4. Run the build script:**
+```bash
+cd platform/packaging/
+./build_linux.sh
+```
+
+The `.deb` and `.AppImage` are written to `platform/surfaces/gui/src-tauri/target/release/bundle/`. Install the `.deb` with:
+```bash
+sudo dpkg -i OpenCoworker_*.deb
+```
 
 ## 2. Connect a model
 

--- a/platform/packaging/build_linux.sh
+++ b/platform/packaging/build_linux.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# Build the Linux desktop app + .deb and .AppImage installers.
+#
+#   1. PyInstaller-bundle the server into a standalone binary (no venv needed at runtime).
+#   2. Drop it into Tauri's externalBin slot (binaries/coworker-server-<triple>).
+#   3. `tauri build` → .deb and .AppImage bundles (externalBin is copied in).
+#
+# Prerequisites (Ubuntu/Debian — adapt package names for other distros):
+#   sudo apt install libwebkit2gtk-4.1-dev build-essential curl wget file \
+#     libxdo-dev libssl-dev libayatana-appindicator3-dev librsvg2-dev \
+#     nodejs npm
+#   curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
+#   source ~/.cargo/env
+#
+# A Python venv at platform/.venv with this package installed editable, plus
+# pyinstaller and typer:
+#   python3 -m venv .venv
+#   .venv/bin/pip install -e . pyinstaller 'mcp[cli]'
+#
+# `typer` (pulled in by mcp[cli]) is needed only at build time: PyInstaller
+# walks the `mcp` package and `mcp.cli` calls sys.exit() at import if typer
+# is absent, which aborts the freeze.
+#
+# Experimental (use-at-your-own-risk) connectors are EXCLUDED from this build
+# by default — the spec strips coworker.connectors.experimental. Self-builders
+# can opt in with:
+#   COWORKER_EXPERIMENTAL=1 ./build_linux.sh
+set -euo pipefail
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+PLATFORM="$(cd "$HERE/.." && pwd)"
+GUI="$PLATFORM/surfaces/gui"
+
+# Single source of truth for the version: tauri.conf.json (also stamps the bundle).
+VERSION="$(node -p "require('$GUI/src-tauri/tauri.conf.json').version")"
+TRIPLE="$(rustc -vV | sed -n 's/host: //p')"   # e.g. x86_64-unknown-linux-gnu
+
+echo "==> [1/3] PyInstaller: bundling coworker-server ($TRIPLE)"
+"$PLATFORM/.venv/bin/pyinstaller" --noconfirm --clean \
+  --distpath "$HERE/dist" --workpath "$HERE/build" "$HERE/coworker-server.spec"
+
+echo "==> [2/3] staging externalBin"
+mkdir -p "$GUI/src-tauri/binaries"
+cp "$HERE/dist/coworker-server" "$GUI/src-tauri/binaries/coworker-server-$TRIPLE"
+chmod +x "$GUI/src-tauri/binaries/coworker-server-$TRIPLE"
+
+echo "==> [3/3] tauri build (.deb / .AppImage)"
+( cd "$GUI" && npm run tauri build )
+
+BUNDLE="$GUI/src-tauri/target/release/bundle"
+echo ""
+echo "Done. Installers under: $BUNDLE"
+find "$BUNDLE" \( -name "*.deb" -o -name "*.AppImage" -o -name "*.rpm" \) \
+  2>/dev/null | while read -r f; do echo "  $f"; done


### PR DESCRIPTION
## Summary

OpenCoworker ships pre-built binaries for macOS and Windows, but Linux users had no supported path to build or install the app. This PR closes that gap.

- **`platform/packaging/build_linux.sh`** — Linux counterpart to `build_dmg.sh` and `build_windows.ps1`. Bundles the Python backend into a standalone binary via PyInstaller, stages it into Tauri's `externalBin` slot, and runs `tauri build` to produce a `.deb` and `.AppImage`.
- **`docs/opencoworker-quickstart.md`** — adds a Linux row to the install table and a step-by-step "build from source" section covering system dependencies, Rust, the Python venv setup, and running the script.
- **`README.md`** — adds a Linux entry alongside the macOS and Windows download links.

## Test plan

- [ ] Run `./platform/packaging/build_linux.sh` on Ubuntu (x64) — confirms `.deb` and `.AppImage` are produced under `src-tauri/target/release/bundle/`
- [ ] Install the `.deb` via `sudo dpkg -i` and launch OpenCoworker
- [ ] Verify the quickstart instructions in `docs/opencoworker-quickstart.md` match the actual build steps end-to-end
