### PR TITLE
fix(platform): resolve bare claude/gemini model names in the capability table

### DIFF
--- a/platform/coworker/providers/capabilities.py
+++ b/platform/coworker/providers/capabilities.py
@@ -22,8 +22,10 @@ def capabilities_for(model: str) -> ModelCapabilities:
 
     # Claude / Gemini (both native): tools + vision + parallel tool calls + streaming. The
     # engine executes parallel calls sequentially and each converter folds the results into
-    # the single next user message — exactly what both APIs require.
-    if provider in ("anthropic", "gemini"):
+    # the single next user message — exactly what both APIs require. Match either the provider
+    # prefix (anthropic:/gemini:) or a bare model name (claude-*, gemini-*) so an unprefixed id
+    # isn't misreported as text-only by the conservative default below.
+    if provider in ("anthropic", "gemini") or name.startswith(("claude", "gemini")):
         return ModelCapabilities(
             tools=True, vision=True, parallel_tool_calls=True, streaming=True
         )

--- a/platform/tests/test_capabilities.py
+++ b/platform/tests/test_capabilities.py
@@ -1,0 +1,50 @@
+"""Per-model capability lookup (`capabilities_for`).
+
+The table is a heuristic keyed on the provider prefix or the model name. These pin every
+branch and guard the documented contract that *bare* names (no `provider:` prefix) resolve
+the same as their provider-qualified form — previously bare `claude-*`/`gemini-*` fell
+through to the conservative default and were misreported as text-only.
+"""
+
+from __future__ import annotations
+
+from coworker.providers.capabilities import capabilities_for
+
+
+def _caps(model):
+    c = capabilities_for(model)
+    return (c.tools, c.vision, c.parallel_tool_calls, c.streaming)
+
+
+def test_ollama_is_conservative_but_tool_capable():
+    assert _caps("ollama:qwen3-coder:30b") == (True, False, False, True)
+
+
+def test_anthropic_and_gemini_prefixed_are_full():
+    assert _caps("anthropic:claude-sonnet-4-6") == (True, True, True, True)
+    assert _caps("gemini:gemini-2.5-flash") == (True, True, True, True)
+
+
+def test_bare_claude_and_gemini_match_prefixed():
+    # the documented "accepts bare names" contract — these used to be misreported
+    assert _caps("claude-sonnet-4-6") == (True, True, True, True)
+    assert _caps("gemini-2.5-flash") == (True, True, True, True)
+
+
+def test_bare_and_prefixed_openai_resolve_identically():
+    assert _caps("gpt-5.5") == _caps("openai:gpt-5.5") == (True, True, True, True)
+    assert _caps("gpt-4o") == (True, True, True, True)
+
+
+def test_openai_reasoning_models_constrained():
+    assert _caps("o3-mini") == (True, False, False, True)
+    assert _caps("openai:o1") == (True, False, False, True)
+
+
+def test_deepseek_has_parallel_tools_no_vision():
+    assert _caps("deepseek-chat") == (True, False, True, True)
+
+
+def test_unknown_model_falls_back_to_conservative_default():
+    assert _caps("some-unknown-model") == (True, False, False, True)
+    assert _caps("mystery:whatever-v9") == (True, False, False, True)


### PR DESCRIPTION
### Problem
`capabilities_for` documents that it accepts **bare** model names (`gpt-5.5`) as well as provider-qualified ones (`openai:gpt-5.5`), and it honors that for OpenAI ids (`gpt-*`, the `o`-series). But bare `claude-*` / `gemini-*` names matched none of the branches and fell through to the conservative default — so they were misreported as **no vision, no parallel tool calls**, even though the `anthropic:` / `gemini:` prefixed forms correctly report full capabilities.

### Change
- Match `claude-*` / `gemini-*` by **name** as well as by provider prefix, so an unprefixed id resolves identically to its `anthropic:` / `gemini:` form.
- Add `platform/tests/test_capabilities.py` — the module had no test coverage. It pins every branch (ollama, anthropic/gemini, gpt-4/5, o-series, deepseek, unknown default), the bare-vs-prefixed equivalence, and the conservative fallback.

Intentionally minimal and additive — the conservative default for genuinely unknown models is unchanged. This is in the spirit of the file's own note that the table is "refined as we probe real providers."

Tested with `cd platform && pytest` (full suite green; one unrelated `test_code_tools` grep/`node_modules` failure is pre-existing on `main`).
