### PR TITLE
Fix bugs, and other improvements.

### DIFF
--- a/platform/coworker/providers/__init__.py
+++ b/platform/coworker/providers/__init__.py
@@ -13,9 +13,11 @@ from .registry import (
     ProviderDescriptor,
     ProviderField,
     build_provider_client,
+    detect_provider,
     get_descriptor,
     provider_descriptors,
     provider_names,
+    verify_provider_key,
 )
 from .router import ProviderRouter
 
@@ -37,4 +39,6 @@ __all__ = [
     "provider_names",
     "get_descriptor",
     "build_provider_client",
+    "detect_provider",
+    "verify_provider_key",
 ]

--- a/platform/coworker/providers/registry.py
+++ b/platform/coworker/providers/registry.py
@@ -274,7 +274,10 @@ def verify_provider_key(
                 timeout=timeout,
             )
     except Exception as exc:  # DNS/connection/timeout — never let it bubble to a 500
-        return {"ok": False, "error": f"Couldn't reach {d.title} ({exc.__class__.__name__})."}
+        return {
+            "ok": False,
+            "error": f"Couldn't reach {d.title} ({exc.__class__.__name__}).",
+        }
 
     if resp.status_code < 300:
         return {"ok": True}

--- a/platform/coworker/providers/registry.py
+++ b/platform/coworker/providers/registry.py
@@ -217,3 +217,74 @@ def build_provider_client(
     """Build a `ProviderClient` for `name` from its stored profile. Unknown → OpenAI default."""
     descriptor = _BY_NAME.get(name) or _BY_NAME["openai"]
     return descriptor.build(profile or {}, secrets)
+
+
+def detect_provider(api_key: str) -> Optional[str]:
+    """Best-effort provider guess from an API key's shape, for the onboarding auto-detect.
+    Returns a known provider name or None. Mirrors the GUI's client-side detection so both agree.
+    """
+    key = (api_key or "").strip()
+    if not key:
+        return None
+    if key.startswith("sk-ant-"):
+        return "anthropic"
+    if key.startswith("AIza"):
+        return "gemini"
+    if key.startswith(("sk-", "sk_")):
+        return "openai"
+    return None
+
+
+def verify_provider_key(
+    name: str,
+    *,
+    api_key: Optional[str] = None,
+    base_url: Optional[str] = None,
+    timeout: float = 10.0,
+) -> dict[str, Any]:
+    """Validate a provider's credentials with one cheap, read-only call (list models) — the same
+    pattern connectors use to validate tokens. Transient: callers pass the key directly so a user
+    can Test before saving. Never raises; returns {ok, error?}.
+    """
+    import httpx
+
+    d = _BY_NAME.get(name) or _BY_NAME["openai"]
+    key = (api_key or "").strip()
+    try:
+        if name == "anthropic":
+            resp = httpx.get(
+                "https://api.anthropic.com/v1/models",
+                headers={"x-api-key": key, "anthropic-version": "2023-06-01"},
+                timeout=timeout,
+            )
+        elif name == "gemini":
+            resp = httpx.get(
+                "https://generativelanguage.googleapis.com/v1beta/models",
+                params={"key": key},
+                timeout=timeout,
+            )
+        elif name == "ollama":
+            base = _normalize_ollama_url(base_url)
+            resp = httpx.get(base.rstrip("/") + "/models", timeout=timeout)
+        else:  # openai + any OpenAI-compatible endpoint (Azure, OpenRouter, vLLM…)
+            base = (base_url or "").strip().rstrip("/") or "https://api.openai.com/v1"
+            resp = httpx.get(
+                base + "/models",
+                headers={"Authorization": f"Bearer {key}"},
+                timeout=timeout,
+            )
+    except Exception as exc:  # DNS/connection/timeout — never let it bubble to a 500
+        return {"ok": False, "error": f"Couldn't reach {d.title} ({exc.__class__.__name__})."}
+
+    if resp.status_code < 300:
+        return {"ok": True}
+    if resp.status_code in (401, 403):
+        if name == "ollama":
+            return {"ok": False, "error": "Server rejected the request."}
+        return {"ok": False, "error": "Invalid API key."}
+    if resp.status_code == 404 and name == "ollama":
+        return {
+            "ok": False,
+            "error": "Reached the server, but no OpenAI-compatible /v1 API there.",
+        }
+    return {"ok": False, "error": f"{d.title} returned HTTP {resp.status_code}."}

--- a/platform/coworker/server/app.py
+++ b/platform/coworker/server/app.py
@@ -261,6 +261,14 @@ def create_app(manager: SessionManager) -> FastAPI:
             return {"ok": False, "error": "name required"}
         return manager.set_provider(name, (body or {}).get("fields"))
 
+    @app.post("/v1/providers/verify")
+    async def providers_verify(body: dict) -> dict[str, Any]:
+        # Live read-only credential check (sync httpx) — run off the event loop.
+        name = (body or {}).get("name", "") or "openai"
+        return await asyncio.to_thread(
+            manager.verify_provider, name, (body or {}).get("fields")
+        )
+
     # -- settings (model API key) -----------------------------------------------
     @app.get("/v1/settings")
     def settings_get() -> dict[str, Any]:
@@ -319,6 +327,10 @@ def create_app(manager: SessionManager) -> FastAPI:
     @app.get("/v1/automations")
     def automations_list() -> dict[str, Any]:
         return manager.list_automations()
+
+    @app.post("/v1/automations")
+    def automations_create(body: dict) -> dict[str, Any]:
+        return manager.create_automation(body or {})
 
     @app.get("/v1/automations/{task_id}")
     def automation_get(task_id: str) -> dict[str, Any]:

--- a/platform/coworker/server/manager.py
+++ b/platform/coworker/server/manager.py
@@ -21,7 +21,7 @@ from ..conversations import ConversationStore, title_from
 from ..engine import Approver, TurnEngine
 from ..roots import RootDir
 from ..agents import myhelper_agent
-from ..automation import Scheduler, TaskRun, TaskStore
+from ..automation import Schedule, ScheduledTask, Scheduler, TaskRun, TaskStore
 from ..connectors import (
     Gateway,
     SUPERAGENT_MESSAGING_NOTE,
@@ -57,6 +57,7 @@ from ..providers import (
     ProviderRouter,
     get_descriptor,
     provider_descriptors,
+    verify_provider_key,
 )
 from ..secrets import SecretStore, state_dir
 from ..sessions import SessionRecord
@@ -680,6 +681,27 @@ class SessionManager:
             self.set_default_model(added)
         return {"ok": True, "provider": name, "recommended_model": rec}
 
+    def verify_provider(
+        self, name: str, fields: Optional[dict[str, Any]]
+    ) -> dict[str, Any]:
+        """Test a provider's credentials with a live read-only call, WITHOUT persisting them, so
+        onboarding can offer a "Test" button. Falls back to the stored/env key when the form left
+        the key blank (e.g. testing an already-configured provider)."""
+        import os
+
+        d = get_descriptor(name)
+        if d is None:
+            return {"ok": False, "error": f"unknown provider: {name}"}
+        fields = fields or {}
+        profile = self.secrets.get(f"provider:{name}") or {}
+        api_key = (fields.get("api_key") or profile.get("api_key") or "").strip()
+        if not api_key and d.env_key:
+            api_key = os.environ.get(d.env_key, "").strip()
+        base_url = (fields.get("base_url") or profile.get("base_url") or "").strip()
+        if d.needs_key and not api_key:
+            return {"ok": False, "error": "Enter an API key to test."}
+        return verify_provider_key(name, api_key=api_key, base_url=base_url)
+
     def _model_provider(self, model: str) -> str:
         """The provider a model string routes to (known `prefix:` or the OpenAI default)."""
         if ":" in (model or ""):
@@ -700,7 +722,7 @@ class SessionManager:
         )
 
     # -- settings / prefs (model API key, default model, onboarding) -------------
-    KNOWN_MODELS = ["gpt-5.5", "gpt-4o", "gpt-4o-mini", "o3-mini", "deepseek-chat"]
+    KNOWN_MODELS = ["gpt-5.5", "gpt-4o", "gpt-4o-mini", "o3-mini"]
 
     def _prefs_path(self) -> Path:
         return self._data_base / "prefs.json"
@@ -774,11 +796,25 @@ class SessionManager:
 
         env_key = bool(os.environ.get("OPENAI_API_KEY"))
         stored = bool((self.secrets.get("provider:openai") or {}).get("api_key"))
+        # Only surface models whose provider is actually configured — the composer picker should
+        # reflect what's connected, not the built-in seed list. The active default is always kept
+        # selectable (it's hidden behind the "No model" state until a provider is connected anyway).
+        selectable = [
+            m
+            for m in self._curated_models()
+            if self._provider_configured(self._model_provider(m))
+        ]
+        if self.model not in selectable:
+            selectable.insert(0, self.model)
         return {
             "provider": "openai",
             "model": self.model,
-            "models": self._curated_models(),
+            "models": selectable,
             "has_key": env_key or stored,
+            # Provider-agnostic "can this default model actually run?" — true when the default
+            # model's provider is configured (any provider, not just OpenAI). Drives the GUI's
+            # "No model connected" composer chip and the onboarding Skip warning.
+            "model_ready": self._provider_configured(self._model_provider(self.model)),
             "source": "env" if env_key else ("store" if stored else None),
             "onboarded": bool(self._prefs.get("onboarded")),
             "experimental_connectors": experimental_enabled(self.secrets),
@@ -1196,6 +1232,48 @@ class SessionManager:
             "task": task.public(),
             "runs": [r.to_dict() for r in self.task_store.runs(task_id)],
         }
+
+    def create_automation(self, payload: dict[str, Any]) -> dict[str, Any]:
+        """Create an automation directly from the GUI (the "New automation" / template flow).
+        Mirrors the agent-facing `create_scheduled_task` validation, but binds the task to a
+        fresh per-task scratch workspace instead of an origin conversation's folder."""
+        from croniter import croniter
+
+        title = (payload.get("title") or "").strip()
+        instructions = (payload.get("instructions") or "").strip()
+        cron = (payload.get("cron") or "").strip() or None
+        fire_at = (payload.get("fire_at") or "").strip() or None
+        timezone = (payload.get("timezone") or "").strip() or "local"
+
+        if not title:
+            return {"ok": False, "error": "title is required"}
+        if not instructions:
+            return {"ok": False, "error": "instructions are required"}
+        if not cron and not fire_at:
+            return {
+                "ok": False,
+                "error": "provide a cron (recurring) or a fire_at ISO datetime (one-time)",
+            }
+        if cron and not croniter.is_valid(cron):
+            return {"ok": False, "error": f"invalid cron expression: {cron}"}
+
+        schedule = Schedule(
+            kind="once" if (fire_at and not cron) else "cron",
+            cron=cron,
+            fire_at=fire_at,
+            timezone=timezone,
+        )
+        task = ScheduledTask(
+            title=title,
+            instructions=instructions,
+            schedule=schedule,
+            workspace="",
+            origin_surface="cowork",
+            agent="cowork",
+        )
+        task.workspace = self._provision_scratch(task.task_session_id)
+        self.task_store.save(task)
+        return {"ok": True, "task": task.public()}
 
     def update_automation(
         self, task_id: str, changes: dict[str, Any]

--- a/platform/surfaces/gui/src/App.tsx
+++ b/platform/surfaces/gui/src/App.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useRef, useState, type PointerEvent } from "react";
 import {
   finalizeAutomationRun,
+  getArtifacts,
   getHealth,
   getRecentWorkspaces,
   getSessionMessages,
@@ -141,11 +142,18 @@ export function App() {
   const [sessionId, setSessionId] = useState<string>(newId());
   const [gateCreate, setGateCreate] = useState(false);
   const [showManage, setShowManage] = useState(false);
-  const [manageTab, setManageTab] = useState<"settings" | undefined>(undefined);
+  const [manageTab, setManageTab] = useState<"settings" | "models" | undefined>(undefined);
+  // Whether the default model's provider is actually configured (any provider). Drives the
+  // composer's "No model connected" chip. Default true so we don't flash the chip before settings
+  // load; corrected by loadSettings.
+  const [modelReady, setModelReady] = useState(true);
   const [surface, setSurface] = useState<"session" | "superagent" | "scheduled" | "integrations" | "audit">("session");
   const [helperName, setHelperName] = useState("MyHelper");
   const [browserRefreshKey, setBrowserRefreshKey] = useState(0);
   const [railHidden, setRailHidden] = useState(false);
+  // Count of files this Cowork conversation has produced — surfaces an "Artifacts (N)" button in
+  // the topbar when the side panel is hidden, so produced files are never buried.
+  const [artifactCount, setArtifactCount] = useState(0);
   const [topbarMenuOpen, setTopbarMenuOpen] = useState(false);
   // Inline rename in the topbar (window.prompt is a no-op in the desktop webview).
   const [renamingTitle, setRenamingTitle] = useState(false);
@@ -302,9 +310,16 @@ export function App() {
     getSettings()
       .then((s) => {
         setModels(s.models || []);
+        setModelReady(s.model_ready);
         if (s.surfaces) setSurfaces(s.surfaces);
       })
       .catch(() => {});
+
+  // Open Settings → Configure Models (from the composer's "No model connected" chip).
+  const openModelSetup = () => {
+    setManageTab("models");
+    setShowManage(true);
+  };
 
   useEffect(() => {
     refreshSessions();
@@ -425,11 +440,29 @@ export function App() {
     });
     sessionRef.current = session;
     return () => session.close();
-  }, [booting, sessionId, workspace, agent, refreshSessions]);
+    // NOTE: `workspace` is intentionally NOT a dependency. Every real workspace change
+    // (pick folder, select/switch session, new session) is paired with a `sessionId`
+    // change, so the socket still reconnects when it should. The one workspace-only change
+    // is the `ready` handler adopting the server's provisioned Cowork scratch dir — listing
+    // `workspace` here made that adoption tear down and rebuild the socket immediately after
+    // first connect, dropping the user's first message (the "send twice" bug). The scratch
+    // dir is deterministic from `sessionId` server-side, so skipping that reconnect is safe.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [booting, sessionId, agent, refreshSessions]);
 
   useEffect(() => {
     scrollRef.current?.scrollTo({ top: scrollRef.current.scrollHeight, behavior: "smooth" });
   }, [items, streaming]);
+
+  // Track produced-file count for the topbar "Artifacts" affordance (works even when the rail is
+  // hidden, where the rail itself doesn't fetch). Cowork only; refreshes on file writes/turn end.
+  useEffect(() => {
+    if (agent !== "cowork" || surface !== "session") {
+      setArtifactCount(0);
+      return;
+    }
+    getArtifacts(sessionId).then((a) => setArtifactCount(a.length)).catch(() => {});
+  }, [agent, surface, sessionId, browserRefreshKey]);
 
   const send = (text: string, attachments?: Attachment[]) => {
     setItems((p) => [...p, { kind: "user", text, attachments }]);
@@ -647,6 +680,7 @@ export function App() {
             setOnboarding(false);
             getHealth().then((h) => setModel(h.model)).catch(() => {});
             getSuperagent().then((s) => s?.name && setHelperName(s.name)).catch(() => {});
+            loadSettings(); // pick up a model connected during setup (clears the composer chip)
           }}
         />
       )}
@@ -753,6 +787,18 @@ export function App() {
           </div>
           <div className="main-drag-fill" onPointerDown={beginWindowDrag} />
           <div className="main-topbar-actions">
+            {agent === "cowork" && railHidden && artifactCount > 0 && (
+              <button
+                className="topbar-artifacts-btn"
+                onMouseDown={(e) => e.stopPropagation()}
+                onClick={() => setRailHidden(false)}
+                title="Show files this conversation produced"
+              >
+                <Icon name="file" size={14} />
+                <span>Artifacts</span>
+                <span className="topbar-artifacts-count">{artifactCount}</span>
+              </button>
+            )}
             {agent === "cowork" && (
               <button
                 className="topbar-icon-btn"
@@ -818,6 +864,8 @@ export function App() {
               models={models}
               running={running}
               connected={connected}
+              modelReady={modelReady}
+              onConnectModel={openModelSetup}
               onSend={send}
               onInterrupt={interrupt}
               onModeChange={changeMode}

--- a/platform/surfaces/gui/src/api.ts
+++ b/platform/surfaces/gui/src/api.ts
@@ -360,6 +360,7 @@ export interface ModelSettings {
   model: string;
   models: string[];
   has_key: boolean;
+  model_ready: boolean; // can the default model's provider actually run (any provider)?
   source: "env" | "store" | null;
   onboarded: boolean;
   surfaces: SurfaceVisibility;
@@ -481,6 +482,29 @@ export async function setProvider(
   return res.json();
 }
 
+/** Live read-only credential check (does NOT save the key). Triggered by the user's "Test" click. */
+export async function verifyProvider(
+  name: string,
+  fields: Record<string, string>,
+): Promise<{ ok: boolean; error?: string }> {
+  const res = await fetch(`${httpBase()}/v1/providers/verify`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ name, fields }),
+  });
+  return res.json();
+}
+
+/** Client-side provider guess from an API key's shape (mirrors the server's detect_provider). */
+export function detectProvider(apiKey: string): string | null {
+  const key = (apiKey || "").trim();
+  if (!key) return null;
+  if (key.startsWith("sk-ant-")) return "anthropic";
+  if (key.startsWith("AIza")) return "gemini";
+  if (key.startsWith("sk-") || key.startsWith("sk_")) return "openai";
+  return null;
+}
+
 // -- super-agent --------------------------------------------------------------
 export interface RecentSender {
   user_id: string;
@@ -548,6 +572,21 @@ export interface AutomationRun {
 export async function getAutomations(): Promise<Automation[]> {
   const res = await fetch(`${httpBase()}/v1/automations`);
   return (await res.json()).tasks ?? [];
+}
+
+export async function createAutomation(payload: {
+  title: string;
+  instructions: string;
+  cron?: string;
+  fire_at?: string;
+  timezone?: string;
+}): Promise<{ ok: boolean; error?: string; task?: Automation }> {
+  const res = await fetch(`${httpBase()}/v1/automations`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(payload),
+  });
+  return res.json();
 }
 
 export async function getAutomation(id: string): Promise<{ task: Automation; runs: AutomationRun[] }> {
@@ -634,17 +673,32 @@ export type Handlers = {
 
 export class Session {
   private ws: WebSocket;
+  // Payloads sent before the socket finished opening, replayed on `onopen`. Belt-and-suspenders
+  // against the first message being dropped if the user sends in the connect window.
+  private outbox: object[] = [];
 
   constructor(sessionId: string, workspace: string, agent: string, handlers: Handlers) {
     const q = `?workspace=${encodeURIComponent(workspace)}&agent=${encodeURIComponent(agent)}`;
     this.ws = new WebSocket(`${wsBase()}/ws/session/${sessionId}${q}`);
     this.ws.onmessage = (e) => handlers.onEvent(JSON.parse(e.data));
-    this.ws.onopen = () => handlers.onOpen?.();
+    this.ws.onopen = () => {
+      this.flush();
+      handlers.onOpen?.();
+    };
     this.ws.onclose = () => handlers.onClose?.();
+  }
+
+  private flush() {
+    if (this.ws.readyState !== WebSocket.OPEN) return;
+    const pending = this.outbox;
+    this.outbox = [];
+    for (const p of pending) this.ws.send(JSON.stringify(p));
   }
 
   private send(payload: object) {
     if (this.ws.readyState === WebSocket.OPEN) this.ws.send(JSON.stringify(payload));
+    // Still connecting: queue and flush on open rather than silently dropping.
+    else if (this.ws.readyState === WebSocket.CONNECTING) this.outbox.push(payload);
   }
 
   userMessage(text: string, attachments?: unknown[]) {
@@ -689,16 +743,28 @@ export class Session {
 
 export class SuperagentSession {
   private ws: WebSocket;
+  private outbox: object[] = [];
 
   constructor(handlers: Handlers) {
     this.ws = new WebSocket(`${wsBase()}/ws/superagent`);
     this.ws.onmessage = (e) => handlers.onEvent(JSON.parse(e.data));
-    this.ws.onopen = () => handlers.onOpen?.();
+    this.ws.onopen = () => {
+      this.flush();
+      handlers.onOpen?.();
+    };
     this.ws.onclose = () => handlers.onClose?.();
+  }
+
+  private flush() {
+    if (this.ws.readyState !== WebSocket.OPEN) return;
+    const pending = this.outbox;
+    this.outbox = [];
+    for (const p of pending) this.ws.send(JSON.stringify(p));
   }
 
   private send(payload: object) {
     if (this.ws.readyState === WebSocket.OPEN) this.ws.send(JSON.stringify(payload));
+    else if (this.ws.readyState === WebSocket.CONNECTING) this.outbox.push(payload);
   }
 
   userMessage(text: string, attachments?: unknown[]) {

--- a/platform/surfaces/gui/src/api.ts
+++ b/platform/surfaces/gui/src/api.ts
@@ -545,6 +545,7 @@ export interface Automation {
   title: string;
   instructions: string;
   schedule: string;
+  schedule_raw?: { kind: string; cron?: string | null; fire_at?: string | null; timezone?: string };
   workspace: string;
   agent: string;
   enabled: boolean;

--- a/platform/surfaces/gui/src/components/AuditView.tsx
+++ b/platform/surfaces/gui/src/components/AuditView.tsx
@@ -3,18 +3,18 @@ import { Icon } from "./Icon";
 
 export function AuditView() {
   return (
-    <div className="main">
-      <div className="sa-view-head">
-        <div className="sa-view-title">
-          <Icon name="audit" size={19} className="mark" /> Audit
+    <div className="main page-view">
+      <div className="page-col">
+        <div className="sa-view-head">
+          <div className="sa-view-heading">
+            <div className="sa-view-title"><Icon name="audit" size={21} /> Audit</div>
+            <div className="sa-view-sub">Filterable history of connector and browser tool activity.</div>
+          </div>
         </div>
-        <div className="sa-view-sub">
-          Filterable history of connector and browser tool activity.
-        </div>
-      </div>
-      <div className="main-scroll">
-        <div className="page-panel">
-          <AuditTab />
+        <div className="main-scroll">
+          <div className="page-panel">
+            <AuditTab />
+          </div>
         </div>
       </div>
     </div>

--- a/platform/surfaces/gui/src/components/Composer.tsx
+++ b/platform/surfaces/gui/src/components/Composer.tsx
@@ -14,7 +14,7 @@ const PERMISSION_OPTIONS: Option[] = [
 
 // Fallback list when the server hasn't supplied one yet; the live list (incl. detected Ollama
 // models) arrives via the `models` prop.
-const MODEL_VALUES = ["gpt-5.5", "gpt-4o", "gpt-4o-mini", "o3-mini", "deepseek-chat"];
+const MODEL_VALUES = ["gpt-5.5", "gpt-4o", "gpt-4o-mini", "o3-mini"];
 
 // Identify an attachment by name + payload size so duplicates (e.g. the same file picked twice,
 // or a prefill applied twice) collapse to one chip.
@@ -31,6 +31,10 @@ interface Props {
   models?: string[];
   running: boolean;
   connected: boolean;
+  // False when the default model's provider has no key — the composer shows a "connect a model"
+  // banner and routes sends to setup (preserving the draft) instead of dropping them.
+  modelReady?: boolean;
+  onConnectModel?: () => void;
   onSend: (text: string, attachments?: Attachment[]) => void;
   onInterrupt: () => void;
   onModeChange: (mode: string) => void;
@@ -95,9 +99,16 @@ export function Composer(props: Props) {
     if (next.length) setAttachments((a) => mergeAttachments(a, next));
   };
 
+  const needsModel = props.modelReady === false;
+
   const submit = () => {
     const t = text.trim();
     if ((!t && attachments.length === 0) || props.running) return;
+    // No model connected: keep the draft (don't drop it) and send the user to setup instead.
+    if (needsModel) {
+      props.onConnectModel?.();
+      return;
+    }
     props.onSend(t, attachments);
     setText("");
     setAttachments([]);
@@ -198,14 +209,32 @@ export function Composer(props: Props) {
           {props.workspace !== undefined && (
             <Dropdown value={props.mode} options={PERMISSION_OPTIONS} onChange={props.onModeChange} />
           )}
-          <Dropdown value={props.model} options={modelOptions} onChange={props.onModelChange} />
+          {/* No model connected: don't imply a usable model — show "No model ⚠" that opens setup. */}
+          {needsModel ? (
+            <button
+              className="pill model-warn"
+              onClick={() => props.onConnectModel?.()}
+              title="Connect a model"
+              aria-label="No model connected — connect a model"
+            >
+              <span className="pill-label">No model</span>
+              <span className="model-warn-ico" aria-hidden>⚠</span>
+            </button>
+          ) : (
+            <Dropdown value={props.model} options={modelOptions} onChange={props.onModelChange} />
+          )}
           <span className="spacer" />
           {props.running ? (
             <button className="btn danger" onClick={props.onInterrupt}>
               ⏹ Stop
             </button>
           ) : (
-            <button className="send" onClick={submit} disabled={!props.connected}>
+            <button
+              className="send"
+              onClick={submit}
+              disabled={!props.connected}
+              title={needsModel ? "Connect a model to send" : undefined}
+            >
               ↑
             </button>
           )}
@@ -213,8 +242,17 @@ export function Composer(props: Props) {
       </div>
       <div className="statusline">
         <span>
-          <span className={"dot " + (!props.connected ? "off" : props.running ? "running" : "idle")} />
-          &nbsp;{!props.connected ? "disconnected" : props.running ? "working…" : "ready"}
+          <span
+            className={"dot " + (needsModel || !props.connected ? "off" : props.running ? "running" : "idle")}
+          />
+          &nbsp;
+          {needsModel
+            ? "needs setup — connect a model to send"
+            : !props.connected
+              ? "disconnected"
+              : props.running
+                ? "working…"
+                : "ready"}
         </span>
         <span>Enter to send · Shift+Enter for newline</span>
       </div>

--- a/platform/surfaces/gui/src/components/Icon.tsx
+++ b/platform/surfaces/gui/src/components/Icon.tsx
@@ -26,6 +26,7 @@ type IconName =
   | "moreHorizontal"
   | "pin"
   | "archive"
+  | "trash"
   | "shield"
   | "file"
   | "fileCode"
@@ -256,6 +257,15 @@ export function Icon({
         <svg {...s}>
           <path d="M4.5 7.5h15M6 7.5v10.2c0 1 .8 1.8 1.8 1.8h8.4c1 0 1.8-.8 1.8-1.8V7.5M5.6 4.5h12.8c.6 0 1.1.5 1.1 1.1v1.9h-15V5.6c0-.6.5-1.1 1.1-1.1z" />
           <path d="M9.5 11.5h5" />
+        </svg>
+      );
+    case "trash":
+      return (
+        <svg {...s}>
+          <path d="M4.5 7h15" />
+          <path d="M10 11v6M14 11v6" />
+          <path d="M6.5 7l.9 12c.1.9.8 1.5 1.7 1.5h7.8c.9 0 1.6-.6 1.7-1.5l.9-12" />
+          <path d="M9.2 7V4.9c0-.5.4-.9.9-.9h3.8c.5 0 .9.4.9.9V7" />
         </svg>
       );
   }

--- a/platform/surfaces/gui/src/components/IntegrationsView.tsx
+++ b/platform/surfaces/gui/src/components/IntegrationsView.tsx
@@ -4,24 +4,23 @@ import { Icon } from "./Icon";
 // Combined "Integrations" surface: messaging connectors + MCP servers in one place.
 export function IntegrationsView() {
   return (
-    <div className="main">
-      <div className="sa-view-head">
-        <div className="sa-view-title">
-          <Icon name="plug" size={19} className="mark" /> Integrations
-        </div>
-        <div className="sa-view-sub">
-          External accounts and tools OpenCoworker can use — messaging connectors and MCP servers, with
-          per-tool controls and approval boundaries.
-        </div>
-      </div>
-      <div className="main-scroll">
-        <div className="page-panel">
-          <div className="sa-sub">Connectors</div>
-          <ConnectorsTab />
-          <div className="sa-sub" style={{ marginTop: 26 }}>
-            MCP servers
+    <div className="main page-view">
+      <div className="page-col">
+        <div className="sa-view-head">
+          <div className="sa-view-heading">
+            <div className="sa-view-title"><Icon name="plug" size={21} /> Integrations</div>
+            <div className="sa-view-sub">Connect the apps and tools OpenCoworker can use.</div>
           </div>
-          <McpTab />
+        </div>
+        <div className="main-scroll">
+          <div className="page-panel">
+            <div className="sa-sub">Connectors</div>
+            <ConnectorsTab />
+            <div className="sa-sub" style={{ marginTop: 26 }}>
+              MCP servers
+            </div>
+            <McpTab />
+          </div>
         </div>
       </div>
     </div>

--- a/platform/surfaces/gui/src/components/ManageModal.tsx
+++ b/platform/surfaces/gui/src/components/ManageModal.tsx
@@ -22,6 +22,7 @@ import {
   setSuperagentName,
   setSuperagentWorkspace,
   updateConnectorTools,
+  verifyProvider,
   type AuditEvent,
   type Connector,
   type McpServer,
@@ -97,6 +98,12 @@ export function ManageModal({
             <div className="manage-empty">Skill management — coming soon.</div>
           )}
         </div>
+        <div className="manage-foot">
+          <span className="manage-foot-note dim">● Changes save automatically</span>
+          <button className="btn-primary sm" onClick={onClose}>
+            Done — back to chat
+          </button>
+        </div>
       </div>
     </div>
   );
@@ -115,6 +122,7 @@ function ModelsTab() {
   const [sub, setSub] = useState<"api" | "local">("api");
   const [apiProv, setApiProv] = useState("openai");
   const [endpoint, setEndpoint] = useState(""); // OpenAI custom endpoint (Azure, OpenRouter, …)
+  const [verify, setVerify] = useState<{ state: "idle" | "testing" | "ok" | "error"; msg?: string }>({ state: "idle" });
 
   const refresh = () => getSettings().then(setSettings).catch(() => setSettings(null));
   const loadProviders = () =>
@@ -154,19 +162,38 @@ function ModelsTab() {
   const provName = sub === "local" ? "ollama" : apiProv;
   const selProv = providers.find((p) => p.name === provName);
 
+  const keyFields = (): Record<string, string> => {
+    const fields: Record<string, string> = {};
+    if (draft.trim()) fields.api_key = draft.trim();
+    if (apiProv === "openai") fields.base_url = endpoint.trim();
+    return fields;
+  };
+
+  const testKey = async () => {
+    if (!draft.trim() && !selProv?.configured) return;
+    setVerify({ state: "testing" });
+    const res = await verifyProvider(apiProv, keyFields());
+    setVerify(res.ok ? { state: "ok" } : { state: "error", msg: res.error || "Couldn't verify." });
+  };
+
   const save = async () => {
     if (!draft.trim() && !(apiProv === "openai" && endpoint.trim())) return;
     setBusy(true);
     setMsg(null);
-    const fields: Record<string, string> = {};
-    if (draft.trim()) fields.api_key = draft.trim();
-    if (apiProv === "openai") fields.base_url = endpoint.trim();
-    const res = await setProvider(apiProv, fields);
+    const res = await setProvider(apiProv, keyFields());
     setBusy(false);
     if (res.ok) {
       setDraft("");
-      setMsg("Saved. The key is stored locally and never sent to the model.");
-      refresh();
+      setVerify({ state: "idle" });
+      // set_provider auto-adds the provider's model and makes it the default if the old default
+      // wasn't usable — so the composer is ready immediately. Confirm that to the user.
+      const updated = await getSettings().catch(() => null);
+      if (updated) setSettings(updated);
+      setMsg(
+        updated
+          ? `Saved. “${updated.model}” is ready in the composer — stored locally, never sent to the model.`
+          : "Saved. The key is stored locally and never sent to the model.",
+      );
       loadProviders();
     } else {
       setMsg(res.error || "Failed to save key.");
@@ -226,6 +253,7 @@ function ModelsTab() {
                 setApiProv(e.target.value);
                 setDraft("");
                 setMsg(null);
+                setVerify({ state: "idle" });
               }}
             >
               {providers
@@ -239,9 +267,9 @@ function ModelsTab() {
           </label>
           <div className="conn-meta" style={{ marginBottom: 12 }}>
             {selProv?.configured ? (
-              <span className="ok">key configured{provName === "openai" && settings.source === "env" ? " (from environment)" : ""}</span>
+              <span className="ok">● Connected — key set{provName === "openai" && settings.source === "env" ? " (from environment)" : ""}</span>
             ) : (
-              <span className="danger">no API key — calls to this provider will fail</span>
+              <span className="danger">● Not connected — add a key below to use this provider</span>
             )}
           </div>
         </>
@@ -297,6 +325,14 @@ function ModelsTab() {
           </label>
           <div className="conn-setup-actions">
             <button
+              className="btn sm"
+              onClick={testKey}
+              disabled={verify.state === "testing" || (!draft.trim() && !selProv?.configured)}
+              title="Check the key works — without saving it"
+            >
+              {verify.state === "testing" ? "Testing…" : "Test"}
+            </button>
+            <button
               className="btn-primary sm"
               onClick={save}
               disabled={busy || (!draft.trim() && !(apiProv === "openai" && endpoint.trim()))}
@@ -304,6 +340,8 @@ function ModelsTab() {
               {busy ? "Saving…" : "Save"}
             </button>
           </div>
+          {verify.state === "ok" && <div className="conn-meta ok" style={{ marginTop: 10 }}>✓ Key verified.</div>}
+          {verify.state === "error" && <div className="conn-meta danger" style={{ marginTop: 10 }}>{verify.msg}</div>}
           {msg && <div className="conn-meta" style={{ marginTop: 10 }}>{msg}</div>}
           {checklist}
         </>

--- a/platform/surfaces/gui/src/components/ManageModal.tsx
+++ b/platform/surfaces/gui/src/components/ManageModal.tsx
@@ -274,7 +274,7 @@ function ModelsTab() {
           </div>
         </>
       ) : (
-        <div className="conn-meta dim" style={{ marginBottom: 12 }}>
+        <div className="conn-note dim" style={{ marginBottom: 12 }}>
           Run models locally with <code>ollama serve</code>. OpenCoworker uses Ollama's
           OpenAI-compatible API, so tools work. No API key needed.
         </div>
@@ -283,7 +283,7 @@ function ModelsTab() {
       {sub === "api" ? (
         <>
           {provName === "openai" && settings.source === "env" ? (
-            <div className="conn-meta dim">
+            <div className="conn-note dim">
               A key is set via <code>OPENAI_API_KEY</code> in this server's environment. You can override
               it below; the stored key is used only when the environment variable is absent.
             </div>

--- a/platform/surfaces/gui/src/components/Onboarding.tsx
+++ b/platform/surfaces/gui/src/components/Onboarding.tsx
@@ -1,16 +1,19 @@
 import { useEffect, useState } from "react";
 import {
+  detectProvider,
   getProviders,
   getSettings,
   setOnboarded,
   setProvider,
   setScratchBase,
+  verifyProvider,
   type ProviderInfo,
 } from "../api";
 import {
   getAutostart,
   getKeepAwake,
   isTauri,
+  openExternal,
   pickFolder,
   setAutostart,
   setKeepAwake,
@@ -18,6 +21,25 @@ import {
 import { ModelChecklist } from "./ModelChecklist";
 
 const STEPS = ["Welcome", "Files", "Model", "Always-on"];
+
+// Where a non-developer gets an API key for each provider — shown in the "Don't have a key?"
+// helper on the model step. Rendered as a copyable link so it works even in the desktop webview.
+const KEY_HELP: Record<string, { url: string; steps: string }> = {
+  openai: {
+    url: "https://platform.openai.com/api-keys",
+    steps: "Sign in, click “Create new secret key”, then copy it here.",
+  },
+  anthropic: {
+    url: "https://console.anthropic.com/settings/keys",
+    steps: "Sign in, click “Create Key”, then copy it here.",
+  },
+  gemini: {
+    url: "https://aistudio.google.com/apikey",
+    steps: "Sign in, click “Create API key”, then copy it here.",
+  },
+};
+
+type Verify = { state: "idle" | "testing" | "ok" | "error"; msg?: string };
 
 /**
  * First-run setup wizard (desktop). Walks through where files are saved, connecting a model
@@ -44,10 +66,17 @@ export function Onboarding({ onDone }: { onDone: () => void }) {
   // provider choice (API pane) + local models (Ollama)
   const [conn, setConn] = useState<"api" | "local">("api");
   const [apiProv, setApiProv] = useState("openai");
+  // True once the user manually picks a provider — stops key auto-detect from overriding them.
+  const [manualProv, setManualProv] = useState(false);
+  const [detected, setDetected] = useState<string | null>(null);
+  const [verify, setVerify] = useState<Verify>({ state: "idle" });
+  const [keyHelpOpen, setKeyHelpOpen] = useState(false);
   const [endpoint, setEndpoint] = useState(""); // OpenAI custom endpoint (Azure, OpenRouter, …)
   const [providers, setProviders] = useState<ProviderInfo[]>([]);
   const [ollamaUrl, setOllamaUrl] = useState("");
   const [ollamaMsg, setOllamaMsg] = useState<string | null>(null);
+  // First Skip click with no model connected asks for confirmation rather than leaving silently.
+  const [skipConfirm, setSkipConfirm] = useState(false);
 
   // always-on
   const [autostart, setAuto] = useState(false);
@@ -94,14 +123,41 @@ export function Onboarding({ onDone }: { onDone: () => void }) {
     setScratchMsg(res.ok ? "Saved." : res.error || "Couldn't use that folder.");
   };
 
+  // Build the {api_key, base_url?} payload for the currently selected API provider.
+  const keyFields = (): Record<string, string> => {
+    const fields: Record<string, string> = { api_key: keyDraft.trim() };
+    if (apiProv === "openai") fields.base_url = endpoint.trim();
+    return fields;
+  };
+
+  // Guess the provider from the key as the user types/pastes it, and switch the dropdown to match
+  // (until they pick one by hand). Mirrors the "OpenAI key detected automatically" affordance.
+  const onKeyChange = (v: string) => {
+    setKeyDraft(v);
+    setKeyMsg(null);
+    setVerify({ state: "idle" });
+    const det = detectProvider(v);
+    setDetected(det);
+    if (det && !manualProv && det !== apiProv && providers.some((p) => p.name === det)) {
+      setApiProv(det);
+    }
+  };
+
+  const testKey = async () => {
+    if (!keyDraft.trim() && !selProv?.configured) return;
+    setVerify({ state: "testing" });
+    setKeyMsg(null);
+    const res = await verifyProvider(apiProv, keyFields());
+    setVerify(res.ok ? { state: "ok" } : { state: "error", msg: res.error || "Couldn't verify." });
+  };
+
   const saveKey = async () => {
     if (!keyDraft.trim()) return;
     setKeyMsg(null);
-    const fields: Record<string, string> = { api_key: keyDraft.trim() };
-    if (apiProv === "openai") fields.base_url = endpoint.trim();
-    const res = await setProvider(apiProv, fields);
+    const res = await setProvider(apiProv, keyFields());
     if (res.ok) {
       setKeyDraft("");
+      setVerify({ state: "idle" });
       setKeyMsg("Saved locally.");
       refreshProviders();
       refreshSettings(); // the provider's recommended model may have been added to the list
@@ -137,9 +193,31 @@ export function Onboarding({ onDone }: { onDone: () => void }) {
   const toggleAuto = async (v: boolean) => setAuto(!!(await setAutostart(v)));
   const toggleKeep = async (v: boolean) => setKeep(!!(await setKeepAwake(v)));
 
+  // The provider the default model routes to (prefix before `:`, else OpenAI). A model is "ready"
+  // only if that provider is configured — used to warn when Skipping with nothing connected.
+  const modelProviderName = (m: string): string => {
+    const i = (m || "").indexOf(":");
+    if (i > 0) {
+      const p = m.slice(0, i);
+      if (providers.some((x) => x.name === p)) return p;
+    }
+    return "openai";
+  };
+  const modelReady = providers.some(
+    (p) => p.name === modelProviderName(model) && p.configured,
+  );
+
   const finish = async () => {
     await setOnboarded(!showAgain); // ticked "show again" → keep showing → onboarded=false
     onDone();
+  };
+  // Skip warns once if no model is connected (chat would stay paused), then leaves on confirm.
+  const requestSkip = () => {
+    if (!modelReady && !skipConfirm) {
+      setSkipConfirm(true);
+      return;
+    }
+    finish();
   };
 
   const last = step === STEPS.length - 1;
@@ -162,9 +240,16 @@ export function Onboarding({ onDone }: { onDone: () => void }) {
               <div className="ob-mark">✳</div>
               <h2>Welcome to OpenCoworker</h2>
               <p className="ob-sub">
-                A quick setup: choose where your files are saved, then connect a model — an API
-                key or a local Ollama model. Takes about a minute.
+                An open-source desktop agent that does real work on your machine — research, code,
+                and documents. Your files and your keys stay on this computer; nothing leaves
+                unless you say so.
               </p>
+              <ul className="ob-valueprops">
+                <li><strong>Private by default</strong> — runs locally, bring your own API key (or use a free local model).</li>
+                <li><strong>Real deliverables</strong> — it writes files, reports, and code, not just chat.</li>
+                <li><strong>Always reachable</strong> — schedule automations and connect your tools.</li>
+              </ul>
+              <p className="ob-sub dim">A quick setup takes about a minute.</p>
             </div>
           )}
 
@@ -225,9 +310,12 @@ export function Onboarding({ onDone }: { onDone: () => void }) {
                     className="ob-select"
                     value={apiProv}
                     onChange={(e) => {
+                      setManualProv(true);
                       setApiProv(e.target.value);
                       setKeyDraft("");
                       setKeyMsg(null);
+                      setVerify({ state: "idle" });
+                      setDetected(null);
                     }}
                   >
                     {apiProviders.map((p) => (
@@ -266,9 +354,17 @@ export function Onboarding({ onDone }: { onDone: () => void }) {
                       value={keyDraft}
                       autoComplete="off"
                       spellCheck={false}
-                      onChange={(e) => setKeyDraft(e.target.value)}
-                      onKeyDown={(e) => e.key === "Enter" && saveKey()}
+                      onChange={(e) => onKeyChange(e.target.value)}
+                      onKeyDown={(e) => e.key === "Enter" && testKey()}
                     />
+                    <button
+                      className="btn"
+                      onClick={testKey}
+                      disabled={verify.state === "testing" || (!keyDraft.trim() && !selProv?.configured)}
+                      title="Check the key works — without saving it"
+                    >
+                      {verify.state === "testing" ? "Testing…" : "Test"}
+                    </button>
                     <button
                       className="btn primary"
                       onClick={saveKey}
@@ -277,6 +373,33 @@ export function Onboarding({ onDone }: { onDone: () => void }) {
                       Save
                     </button>
                   </div>
+
+                  {detected && !manualProv && (
+                    <div className="ob-note ob-detected">
+                      ✓ {providers.find((p) => p.name === detected)?.title || detected} key detected
+                      automatically. <span className="dim">Not right? Pick a provider above.</span>
+                    </div>
+                  )}
+                  {verify.state === "ok" && <div className="ob-note ob-ok">✓ Key verified — you're good to go.</div>}
+                  {verify.state === "error" && <div className="ob-note ob-err">{verify.msg}</div>}
+
+                  <div className="ob-keyhelp">
+                    <button className="ob-link" onClick={() => setKeyHelpOpen((o) => !o)}>
+                      {keyHelpOpen ? "▾" : "▸"} Don't have an API key? Get one in about 2 minutes
+                    </button>
+                    {keyHelpOpen && KEY_HELP[apiProv] && (
+                      <div className="ob-keyhelp-body">
+                        <div>{KEY_HELP[apiProv].steps}</div>
+                        <div className="ob-row" style={{ marginTop: 6 }}>
+                          <button className="btn" onClick={() => openExternal(KEY_HELP[apiProv].url)}>
+                            Open {selProv?.title || "provider"} ↗
+                          </button>
+                          <code className="ob-url">{KEY_HELP[apiProv].url}</code>
+                        </div>
+                      </div>
+                    )}
+                  </div>
+
                   <div className="ob-note dim">
                     Stored locally{secretsPath ? ` at ${secretsPath}` : ""}, readable only by your account. Never sent to the model.
                   </div>
@@ -379,8 +502,24 @@ export function Onboarding({ onDone }: { onDone: () => void }) {
           )}
         </div>
 
+        {skipConfirm && (
+          <div className="ob-skipwarn">
+            <span>
+              No model is connected yet — chat stays paused until you add one. You can still browse,
+              and connect a model later from Settings.
+            </span>
+            <div className="ob-skipwarn-actions">
+              <button className="btn" onClick={() => { setSkipConfirm(false); setStep(2); setConn("api"); }}>
+                Connect a model
+              </button>
+              <button className="btn ghost" onClick={finish}>
+                Skip anyway
+              </button>
+            </div>
+          </div>
+        )}
         <div className="ob-foot">
-          <button className="btn ghost" onClick={finish}>
+          <button className="btn ghost" onClick={requestSkip}>
             Skip
           </button>
           <div className="ob-foot-right">

--- a/platform/surfaces/gui/src/components/Onboarding.tsx
+++ b/platform/surfaces/gui/src/components/Onboarding.tsx
@@ -374,14 +374,17 @@ export function Onboarding({ onDone }: { onDone: () => void }) {
                     </button>
                   </div>
 
-                  {detected && !manualProv && (
-                    <div className="ob-note ob-detected">
+                  {/* One status line at a time: verified (strongest) > error > auto-detected. */}
+                  {verify.state === "ok" ? (
+                    <div className="ob-status ob-ok">✓ Key verified — you're good to go.</div>
+                  ) : verify.state === "error" ? (
+                    <div className="ob-status ob-err">{verify.msg}</div>
+                  ) : detected && !manualProv ? (
+                    <div className="ob-status ob-detected">
                       ✓ {providers.find((p) => p.name === detected)?.title || detected} key detected
                       automatically. <span className="dim">Not right? Pick a provider above.</span>
                     </div>
-                  )}
-                  {verify.state === "ok" && <div className="ob-note ob-ok">✓ Key verified — you're good to go.</div>}
-                  {verify.state === "error" && <div className="ob-note ob-err">{verify.msg}</div>}
+                  ) : null}
 
                   <div className="ob-keyhelp">
                     <button className="ob-link" onClick={() => setKeyHelpOpen((o) => !o)}>
@@ -400,7 +403,7 @@ export function Onboarding({ onDone }: { onDone: () => void }) {
                     )}
                   </div>
 
-                  <div className="ob-note dim">
+                  <div className="ob-note dim" style={{ marginTop: 18 }}>
                     Stored locally{secretsPath ? ` at ${secretsPath}` : ""}, readable only by your account. Never sent to the model.
                   </div>
                   {keyMsg && <div className="ob-note">{keyMsg}</div>}

--- a/platform/surfaces/gui/src/components/RightRail.tsx
+++ b/platform/surfaces/gui/src/components/RightRail.tsx
@@ -103,7 +103,20 @@ export function RightRail({ active, sessionId, refreshKey, toolNames, todo, runn
             title={`Artifacts${artifacts.length ? ` (${artifacts.length})` : ""}`}
             open={open.artifacts}
             onToggle={() => setOpen({ ...open, artifacts: !open.artifacts })}
-            action={<button className="rail-mini-btn" onClick={(e) => { e.stopPropagation(); refreshArtifacts(); }} title="Refresh artifacts"><Icon name="refresh" size={13} /></button>}
+            action={
+              <>
+                {artifacts.length > 0 && (
+                  <button
+                    className="rail-mini-btn"
+                    onClick={(e) => { e.stopPropagation(); revealArtifact(sessionId, artifacts[0].path, "reveal"); }}
+                    title="Show the folder where these files are saved"
+                  >
+                    <Icon name="folder" size={13} />
+                  </button>
+                )}
+                <button className="rail-mini-btn" onClick={(e) => { e.stopPropagation(); refreshArtifacts(); }} title="Refresh artifacts"><Icon name="refresh" size={13} /></button>
+              </>
+            }
           >
             {artifacts.length === 0 ? (
               <div className="rail-muted">No previewable files yet.</div>

--- a/platform/surfaces/gui/src/components/ScheduledView.tsx
+++ b/platform/surfaces/gui/src/components/ScheduledView.tsx
@@ -8,6 +8,19 @@ import {
   type Automation,
   type AutomationRun,
 } from "../api";
+import { Icon } from "./Icon";
+
+// Parse a simple "min hour * * dow" cron back into the time + frequency the editor uses.
+// Falls back to 09:00 / daily for anything it doesn't recognize (e.g. agent-written crons).
+function fromCron(cron?: string | null): { time: string; freq: string } {
+  const parts = (cron || "").trim().split(/\s+/);
+  if (parts.length !== 5) return { time: "09:00", freq: "daily" };
+  const [m, h, , , dow] = parts;
+  const hh = String(Math.min(23, Math.max(0, parseInt(h, 10) || 9))).padStart(2, "0");
+  const mm = String(Math.min(59, Math.max(0, parseInt(m, 10) || 0))).padStart(2, "0");
+  const freq = dow === "1-5" ? "weekdays" : dow === "0,6" || dow === "6,0" ? "weekends" : "daily";
+  return { time: `${hh}:${mm}`, freq };
+}
 
 const fmt = (t: number | null) =>
   t ? new Date(t * 1000).toLocaleString(undefined, { dateStyle: "medium", timeStyle: "short" }) : "—";
@@ -110,20 +123,14 @@ export function ScheduledView({ onOpenRun, onRunNow }: Props) {
   const empty = tasks.length === 0;
 
   return (
-    <div className="main">
-      <div className="sa-view-head sched-head">
-        <div>
-          <div className="sa-view-title">
-            <span className="mark">⏰</span> Scheduled tasks
-          </div>
-          <div className="sa-view-sub">
-            Run tasks on a schedule — pick a template below or build your own.
-          </div>
+    <div className="main page-view">
+      <div className="page-col">
+      <div className="sa-view-head">
+        <div className="sa-view-heading">
+          <div className="sa-view-title"><Icon name="clock" size={21} /> Automations</div>
+          <div className="sa-view-sub">Recurring tasks OpenCoworker runs on a schedule.</div>
         </div>
-        <button
-          className="btn-primary sm"
-          onClick={() => setShowForm((v) => !v)}
-        >
+        <button className="btn new-action" onClick={() => setShowForm((v) => !v)}>
           + New automation
         </button>
       </div>
@@ -152,7 +159,7 @@ export function ScheduledView({ onOpenRun, onRunNow }: Props) {
                 <div className="tmpl-card" key={t.key}>
                   <div className="tmpl-title">{t.title}</div>
                   <div className="tmpl-blurb">{t.blurb}</div>
-                  <div className="tmpl-when">🕐 {t.when}</div>
+                  <div className="tmpl-when"><Icon name="clock" size={12} /> {t.when}</div>
                   <button
                     className="btn sm tmpl-add"
                     disabled={busy !== null}
@@ -183,18 +190,29 @@ export function ScheduledView({ onOpenRun, onRunNow }: Props) {
               <div className="sched-card" key={t.id} onClick={() => setOpenId(t.id)}>
                 <div className="sched-card-top">
                   <span className="conn-name">{t.title}</span>
-                  <span className={"sched-pill" + (t.enabled ? " on" : "")}>
-                    🕐 {t.enabled ? t.schedule : "paused"}
-                  </span>
+                  <button
+                    className="sched-card-del"
+                    title="Delete automation"
+                    aria-label={`Delete ${t.title}`}
+                    onClick={async (e) => {
+                      e.stopPropagation();
+                      await deleteAutomation(t.id);
+                      refresh();
+                    }}
+                  >
+                    <Icon name="trash" size={14} />
+                  </button>
                 </div>
-                <div className="conn-meta">
-                  next {fmt(t.next_run)} · {t.run_count} run{t.run_count === 1 ? "" : "s"}
+                <div className="sched-card-meta">
+                  <Icon name="clock" size={13} className="sched-clock" />
+                  {t.enabled ? t.schedule : "Paused"} · next {fmt(t.next_run)} · {t.run_count} run{t.run_count === 1 ? "" : "s"}
                   {t.last_status ? ` · last ${t.last_status}` : ""}
                 </div>
               </div>
             ))}
           </div>
         )}
+      </div>
       </div>
     </div>
   );
@@ -287,6 +305,12 @@ function TaskDetail({
 }) {
   const [task, setTask] = useState<Automation | null>(null);
   const [runs, setRuns] = useState<AutomationRun[]>([]);
+  const [editing, setEditing] = useState(false);
+  const [title, setTitle] = useState("");
+  const [instructions, setInstructions] = useState("");
+  const [time, setTime] = useState("09:00");
+  const [freq, setFreq] = useState("daily");
+  const [saving, setSaving] = useState(false);
 
   const refresh = () =>
     getAutomation(id)
@@ -301,6 +325,28 @@ function TaskDetail({
 
   if (!task) return <div className="main"><div className="main-scroll"><div className="manage-empty">Loading…</div></div></div>;
 
+  const startEdit = () => {
+    setTitle(task.title);
+    setInstructions(task.instructions);
+    const { time: t, freq: f } = fromCron(task.schedule_raw?.cron);
+    setTime(t);
+    setFreq(f);
+    setEditing(true);
+  };
+  const saveEdit = async () => {
+    setSaving(true);
+    try {
+      await updateAutomation(id, {
+        title: title.trim(),
+        instructions: instructions.trim(),
+        cron: toCron(time, freq),
+      });
+      await refresh();
+      setEditing(false);
+    } finally {
+      setSaving(false);
+    }
+  };
   const toggle = async () => {
     await updateAutomation(id, { enabled: !task.enabled });
     refresh();
@@ -311,33 +357,81 @@ function TaskDetail({
   };
 
   return (
-    <div className="main">
+    <div className="main page-view">
+      <div className="page-col">
       <div className="sa-view-head">
-        <div className="sa-view-title">
-          <button className="link" onClick={onBack}>← Scheduled</button>
-        </div>
+        <button className="sa-back" onClick={onBack}>← Automations</button>
       </div>
       <div className="main-scroll">
         <div className="sched-detail">
           <div className="sched-detail-head">
-            <h2>{task.title}</h2>
+            {editing ? (
+              <input
+                className="tmpl-input sched-edit-title"
+                value={title}
+                onChange={(e) => setTitle(e.target.value)}
+                placeholder="Title"
+              />
+            ) : (
+              <h2>{task.title}</h2>
+            )}
             <div className="sched-actions">
-              <button className="btn-primary sm" onClick={() => onRunNow(id)}>
-                ▶ Run now
-              </button>
-              <button className="link danger" onClick={remove}>delete</button>
+              {editing ? (
+                <>
+                  <button className="btn-primary sm" disabled={saving || !title.trim() || !instructions.trim()} onClick={saveEdit}>
+                    {saving ? "Saving…" : "Save"}
+                  </button>
+                  <button className="link" onClick={() => setEditing(false)}>cancel</button>
+                </>
+              ) : (
+                <>
+                  <button className="btn-primary sm" onClick={() => onRunNow(id)}>
+                    ▶ Run now
+                  </button>
+                  <button className="btn sm" onClick={startEdit}>Edit</button>
+                  <button className="btn sm danger-btn" onClick={remove}>
+                    <Icon name="trash" size={14} /> Delete
+                  </button>
+                </>
+              )}
             </div>
           </div>
-          <div className="conn-meta">
-            <label className="switch">
-              <input type="checkbox" checked={task.enabled} onChange={toggle} />
-              <span className="slider" />
-            </label>{" "}
-            {task.enabled ? `Active · next ${fmt(task.next_run)}` : "Paused"} · {task.schedule}
-          </div>
+
+          {editing ? (
+            <div className="tmpl-sched sched-edit-sched">
+              <label className="tmpl-field">
+                <span>At</span>
+                <input type="time" className="tmpl-input tmpl-time" value={time} onChange={(e) => setTime(e.target.value)} />
+              </label>
+              <label className="tmpl-field">
+                <span>Repeat</span>
+                <select className="tmpl-input tmpl-select" value={freq} onChange={(e) => setFreq(e.target.value)}>
+                  <option value="daily">Every day</option>
+                  <option value="weekdays">Weekdays</option>
+                  <option value="weekends">Weekends</option>
+                </select>
+              </label>
+            </div>
+          ) : (
+            <div className="conn-meta">
+              <label className="switch">
+                <input type="checkbox" checked={task.enabled} onChange={toggle} />
+                <span className="slider" />
+              </label>{" "}
+              {task.enabled ? `Active · next ${fmt(task.next_run)}` : "Paused"} · {task.schedule}
+            </div>
+          )}
 
           <div className="sa-sub">Instructions</div>
-          <div className="sched-instructions">{task.instructions}</div>
+          {editing ? (
+            <textarea
+              className="tmpl-input tmpl-textarea sched-edit-instr"
+              value={instructions}
+              onChange={(e) => setInstructions(e.target.value)}
+            />
+          ) : (
+            <div className="sched-instructions">{task.instructions}</div>
+          )}
 
           <div className="sa-sub">Runs</div>
           <div className="dim" style={{ marginBottom: 8, fontSize: 12.5 }}>
@@ -365,6 +459,7 @@ function TaskDetail({
             </div>
           ))}
         </div>
+      </div>
       </div>
     </div>
   );

--- a/platform/surfaces/gui/src/components/ScheduledView.tsx
+++ b/platform/surfaces/gui/src/components/ScheduledView.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from "react";
 import {
+  createAutomation,
   deleteAutomation,
   getAutomation,
   getAutomations,
@@ -11,6 +12,51 @@ import {
 const fmt = (t: number | null) =>
   t ? new Date(t * 1000).toLocaleString(undefined, { dateStyle: "medium", timeStyle: "short" }) : "—";
 
+// One-click prebuilt templates. Each maps directly to a createAutomation payload.
+interface Template {
+  key: string;
+  title: string;
+  blurb: string;
+  instructions: string;
+  cron: string;
+  when: string;
+}
+
+const TEMPLATES: Template[] = [
+  {
+    key: "news",
+    title: "Morning news briefing",
+    blurb: "A 5-bullet tech & world news digest, saved as markdown.",
+    instructions:
+      "Search the web for the most important technology and world news from the last 24 hours and write a concise 5-bullet briefing, saved as a markdown file.",
+    cron: "0 8 * * *",
+    when: "Every day · 8:00 AM",
+  },
+  {
+    key: "inbox",
+    title: "Inbox digest",
+    blurb: "One short digest of your unread email.",
+    instructions: "Summarize my unread email into one short digest note.",
+    cron: "0 9 * * 1-5",
+    when: "Weekdays · 9:00 AM",
+  },
+  {
+    key: "cleanup",
+    title: "Folder cleanup",
+    blurb: "Sort recent Downloads into tidy folders by type.",
+    instructions: "Sort my recent Downloads into tidy folders by file type.",
+    cron: "30 17 * * 5",
+    when: "Fridays · 5:30 PM",
+  },
+];
+
+// Map a simple time-of-day + frequency selection to a 5-field cron string.
+function toCron(time: string, freq: string): string {
+  const [h, m] = (time || "09:00").split(":").map((x) => parseInt(x, 10) || 0);
+  const dow = freq === "weekdays" ? "1-5" : freq === "weekends" ? "0,6" : "*";
+  return `${m} ${h} * * ${dow}`;
+}
+
 interface Props {
   onOpenRun: (sessionId: string, workspace: string, agent: string) => void;
   onRunNow: (taskId: string) => void;
@@ -19,6 +65,8 @@ interface Props {
 export function ScheduledView({ onOpenRun, onRunNow }: Props) {
   const [tasks, setTasks] = useState<Automation[]>([]);
   const [openId, setOpenId] = useState<string | null>(null);
+  const [showForm, setShowForm] = useState(false);
+  const [busy, setBusy] = useState<string | null>(null);
 
   const refresh = () => getAutomations().then(setTasks).catch(() => setTasks([]));
   useEffect(() => {
@@ -26,6 +74,27 @@ export function ScheduledView({ onOpenRun, onRunNow }: Props) {
     const h = setInterval(refresh, 5000);
     return () => clearInterval(h);
   }, []);
+
+  // Create from a payload, refresh the list, and open the new task's detail.
+  const create = async (payload: {
+    title: string;
+    instructions: string;
+    cron?: string;
+  }) => {
+    setBusy(payload.title);
+    try {
+      const res = await createAutomation(payload);
+      await refresh();
+      if (res.ok && res.task) {
+        setShowForm(false);
+        setOpenId(res.task.id);
+      } else if (res.error) {
+        alert(res.error);
+      }
+    } finally {
+      setBusy(null);
+    }
+  };
 
   if (openId) {
     return (
@@ -38,15 +107,25 @@ export function ScheduledView({ onOpenRun, onRunNow }: Props) {
     );
   }
 
+  const empty = tasks.length === 0;
+
   return (
     <div className="main">
-      <div className="sa-view-head">
-        <div className="sa-view-title">
-          <span className="mark">⏰</span> Scheduled tasks
+      <div className="sa-view-head sched-head">
+        <div>
+          <div className="sa-view-title">
+            <span className="mark">⏰</span> Scheduled tasks
+          </div>
+          <div className="sa-view-sub">
+            Run tasks on a schedule — pick a template below or build your own.
+          </div>
         </div>
-        <div className="sa-view-sub">
-          Run tasks on a schedule. Ask OpenCoworker or MyHelper to "set up an automation…".
-        </div>
+        <button
+          className="btn-primary sm"
+          onClick={() => setShowForm((v) => !v)}
+        >
+          + New automation
+        </button>
       </div>
       <div className="main-scroll">
         <div className="sched-banner">
@@ -56,13 +135,48 @@ export function ScheduledView({ onOpenRun, onRunNow }: Props) {
             the scheduled time, the task runs once when the server next starts (catch-up).
           </span>
         </div>
-        {tasks.length === 0 ? (
-          <div className="hero">
-            <h1 className="greeting"><span className="mark">⏰</span> No scheduled tasks yet.</h1>
-            <div className="suggest-head">
-              In an OpenCoworker session, try: "Search the web and give me a news briefing every day at 7:10pm."
+
+        {showForm && (
+          <NewAutomationForm
+            busy={busy !== null}
+            onCancel={() => setShowForm(false)}
+            onCreate={create}
+          />
+        )}
+
+        {(empty || showForm) && (
+          <div className="tmpl-wrap">
+            <div className="sa-sub tmpl-head">Start from a template</div>
+            <div className="tmpl-grid">
+              {TEMPLATES.map((t) => (
+                <div className="tmpl-card" key={t.key}>
+                  <div className="tmpl-title">{t.title}</div>
+                  <div className="tmpl-blurb">{t.blurb}</div>
+                  <div className="tmpl-when">🕐 {t.when}</div>
+                  <button
+                    className="btn sm tmpl-add"
+                    disabled={busy !== null}
+                    onClick={() =>
+                      create({ title: t.title, instructions: t.instructions, cron: t.cron })
+                    }
+                  >
+                    {busy === t.title ? "Creating…" : "Use this"}
+                  </button>
+                </div>
+              ))}
             </div>
           </div>
+        )}
+
+        {empty ? (
+          !showForm && (
+            <div className="hero tmpl-empty">
+              <div className="suggest-head">
+                No scheduled tasks yet — use a template above, click <strong>+ New automation</strong>,
+                or just ask OpenCoworker in a session.
+              </div>
+            </div>
+          )
         ) : (
           <div className="sched-list">
             {tasks.map((t) => (
@@ -81,6 +195,80 @@ export function ScheduledView({ onOpenRun, onRunNow }: Props) {
             ))}
           </div>
         )}
+      </div>
+    </div>
+  );
+}
+
+function NewAutomationForm({
+  busy,
+  onCancel,
+  onCreate,
+}: {
+  busy: boolean;
+  onCancel: () => void;
+  onCreate: (p: { title: string; instructions: string; cron?: string }) => void;
+}) {
+  const [title, setTitle] = useState("");
+  const [instructions, setInstructions] = useState("");
+  const [time, setTime] = useState("09:00");
+  const [freq, setFreq] = useState("daily");
+
+  const valid = title.trim() && instructions.trim();
+
+  return (
+    <div className="tmpl-form">
+      <div className="sa-sub tmpl-head">New automation</div>
+      <input
+        className="tmpl-input"
+        placeholder="Title (e.g. Daily standup notes)"
+        value={title}
+        onChange={(e) => setTitle(e.target.value)}
+      />
+      <textarea
+        className="tmpl-input tmpl-textarea"
+        placeholder="What should it do each run? (e.g. Summarize today's calendar and open tasks.)"
+        value={instructions}
+        onChange={(e) => setInstructions(e.target.value)}
+      />
+      <div className="tmpl-sched">
+        <label className="tmpl-field">
+          <span>At</span>
+          <input
+            type="time"
+            className="tmpl-input tmpl-time"
+            value={time}
+            onChange={(e) => setTime(e.target.value)}
+          />
+        </label>
+        <label className="tmpl-field">
+          <span>Repeat</span>
+          <select
+            className="tmpl-input tmpl-select"
+            value={freq}
+            onChange={(e) => setFreq(e.target.value)}
+          >
+            <option value="daily">Every day</option>
+            <option value="weekdays">Weekdays</option>
+            <option value="weekends">Weekends</option>
+          </select>
+        </label>
+      </div>
+      <div className="tmpl-form-actions">
+        <button
+          className="btn-primary sm"
+          disabled={!valid || busy}
+          onClick={() =>
+            onCreate({
+              title: title.trim(),
+              instructions: instructions.trim(),
+              cron: toCron(time, freq),
+            })
+          }
+        >
+          {busy ? "Creating…" : "Create automation"}
+        </button>
+        <button className="link" onClick={onCancel}>cancel</button>
       </div>
     </div>
   );

--- a/platform/surfaces/gui/src/components/SessionIntro.tsx
+++ b/platform/surfaces/gui/src/components/SessionIntro.tsx
@@ -67,11 +67,32 @@ export function SessionIntro({
         <span className="mark">✳</span> What should we produce?
       </h1>
       <p className="intro-lede">
-        I work in a private temporary space — share folders or connect your tools, and I can do more.
+        Pick a task to start — I'll do the work and save the result. Or just type what you need below.
       </p>
 
+      {/* Lead with one-click tasks (the fastest path to value); setup comes after. */}
+      <div className="intro-tasks">
+        {TASKS.map((t, i) => (
+          <button className="task-card" key={i} onClick={() => runTask(t)}>
+            <span className="task-card-ico">{t.ico}</span>
+            <span className="task-card-text">{t.text}</span>
+            <span className="task-card-hint">{t.pickFile ? "Pick a file →" : "Start →"}</span>
+          </button>
+        ))}
+        <input
+          ref={fileInput}
+          type="file"
+          accept=".csv,.tsv,.txt,text/csv"
+          style={{ display: "none" }}
+          onChange={(e) => {
+            onFile(e.target.files);
+            e.target.value = "";
+          }}
+        />
+      </div>
+
       <div className="suggestions intro-setup">
-        <div className="suggest-head">Set me up</div>
+        <div className="suggest-head">Set me up (optional)</div>
         <div className="suggest" onClick={() => setAddingFolder((v) => !v)}>
           <span className="ico"><Icon name="folderPlus" size={16} /></span>
           Give me access to a folder
@@ -97,27 +118,6 @@ export function SessionIntro({
           Connect Gmail, Calendar, Drive…
           {active.length > 0 && <span className="suggest-hint">· {active.join(" ✓ · ")} ✓</span>}
         </div>
-      </div>
-
-      <div className="suggestions">
-        <div className="suggest-head">Try a task</div>
-        {TASKS.map((t, i) => (
-          <div className="suggest" key={i} onClick={() => runTask(t)}>
-            <span className="ico">{t.ico}</span>
-            {t.text}
-            {t.pickFile && <span className="suggest-hint">· pick a file</span>}
-          </div>
-        ))}
-        <input
-          ref={fileInput}
-          type="file"
-          accept=".csv,.tsv,.txt,text/csv"
-          style={{ display: "none" }}
-          onChange={(e) => {
-            onFile(e.target.files);
-            e.target.value = "";
-          }}
-        />
       </div>
     </div>
   );

--- a/platform/surfaces/gui/src/components/SuperAgentView.tsx
+++ b/platform/surfaces/gui/src/components/SuperAgentView.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState } from "react";
 import { getSuperagent, SuperagentSession, type SuperagentStatus } from "../api";
 import type { ApprovalDecision, Item, WsEvent } from "../types";
+import { Icon } from "./Icon";
 import { Transcript } from "./Transcript";
 
 const newId = () =>
@@ -140,13 +141,15 @@ export function SuperAgentView() {
   return (
     <div className="main">
       <div className="sa-view-head">
-        <div className="sa-view-title">
-          <span className="mark">✳</span> {status?.name || "MyHelper"}
-          <span className={"sa-status-dot" + (connected ? " on" : "")} />
-        </div>
-        <div className="sa-view-sub">
-          {listening.length ? `listening on ${listening.join(", ")}` : "no bots connected"} ·{" "}
-          {status?.workspace || ""}
+        <div className="sa-view-heading">
+          <div className="sa-view-title">
+            <Icon name="sparkle" size={21} /> {status?.name || "MyHelper"}
+            <span className={"sa-status-dot" + (connected ? " on" : "")} />
+          </div>
+          <div className="sa-view-sub">
+            {listening.length ? `listening on ${listening.join(", ")}` : "no bots connected"} ·{" "}
+            {status?.workspace || ""}
+          </div>
         </div>
       </div>
 

--- a/platform/surfaces/gui/src/styles.css
+++ b/platform/surfaces/gui/src/styles.css
@@ -912,28 +912,63 @@ button.btn.sm { padding: 5px 13px; font-size: 12.5px; }
 .dim { color: var(--faint); }
 
 /* -- Super-agent view (full surface) ---------------------------------------- */
-.sa-view-head { padding: 14px 22px 12px; border-bottom: 1px solid var(--line); background: var(--panel); }
-.sa-view-title { display: flex; align-items: center; gap: 8px; font-family: var(--serif); font-size: 18px; color: var(--ink); }
-.sa-view-title .mark { color: var(--accent); }
-.sa-status-dot { width: 8px; height: 8px; border-radius: 50%; background: var(--line-strong); margin-left: 4px; }
+/* Document-style views (Automations, Integrations, Audit): chrome-less page on the same dotted
+   surface as the sessions. `page-col` is an invisible content column (left-aligned, capped width)
+   that both the header and body share, so the page title lines up with its content. */
+.page-col {
+  flex: 1 1 auto; min-height: 0; width: 100%; max-width: 1080px;
+  display: flex; flex-direction: column; overflow: hidden;
+}
+.page-col .main-scroll { padding: 6px 40px 44px; }
+.page-col .page-panel { max-width: none; width: 100%; margin: 0; }
+
+.sa-view-head {
+  display: flex; align-items: flex-start; justify-content: space-between; gap: 16px;
+  padding: 34px 40px 18px; background: transparent;
+}
+.sa-view-heading { min-width: 0; }
+/* Big, quiet page title with a small monochrome inline icon — no badge, no bar. */
+.sa-view-title { display: flex; align-items: center; gap: 9px; font-size: 25px; font-weight: 600; letter-spacing: -0.02em; color: var(--ink); line-height: 1.2; }
+.sa-view-title svg { color: var(--muted); flex: none; }
+.sa-status-dot { width: 8px; height: 8px; border-radius: 50%; background: var(--line-strong); }
 .sa-status-dot.on { background: var(--ok-dot); }
-.sa-view-sub { font-size: 12px; color: var(--faint); margin-top: 3px; }
+.sa-view-sub { font-size: 13.5px; color: var(--muted); margin-top: 6px; }
+.sa-back { background: none; border: none; padding: 0; font: inherit; font-size: 13.5px; color: var(--muted); cursor: pointer; }
+.sa-back:hover { color: var(--ink); }
+/* Quiet outline action in the header (e.g. "+ New automation"). */
+button.btn.new-action { font-size: 13px; padding: 7px 13px; border-radius: 9px; color: var(--ink); border: 1px solid var(--line-strong); background: var(--panel); }
+button.btn.new-action:hover { border-color: var(--accent); color: var(--accent); }
 .sa-composer { display: flex; gap: 10px; align-items: flex-end; max-width: 760px; margin: 0 auto 16px; width: calc(100% - 44px); background: var(--panel); border: 1px solid var(--line-strong); border-radius: 16px; padding: 10px 12px; }
 .sa-composer textarea { flex: 1; resize: none; border: none; outline: none; font: inherit; font-size: 15px; line-height: 1.5; background: transparent; color: var(--ink); max-height: 160px; }
 .sa-composer textarea::placeholder { color: var(--faint); }
 
 /* -- Scheduled view --------------------------------------------------------- */
-.sched-list { display: flex; flex-direction: column; gap: 8px; max-width: 760px; margin: 14px auto; width: calc(100% - 44px); }
-.sched-card { border: 1px solid var(--line); border-radius: 11px; background: var(--panel); padding: 12px 14px; cursor: pointer; }
+.sched-list { display: flex; flex-direction: column; gap: 9px; max-width: 820px; margin: 16px 0; }
+.sched-card { border: 1px solid var(--line); border-radius: 12px; background: var(--panel); padding: 13px 16px; cursor: pointer; transition: border-color 0.12s; }
 .sched-card:hover { border-color: var(--line-strong); }
-.sched-card-top { display: flex; align-items: center; justify-content: space-between; gap: 10px; margin-bottom: 4px; }
-.sched-pill { font-size: 11.5px; color: var(--muted); background: var(--paper); border: 1px solid var(--line); border-radius: 999px; padding: 2px 9px; }
-.sched-pill.on { color: var(--ok); background: var(--ok-soft); border-color: var(--ok-line); }
+.sched-card-top { display: flex; align-items: center; justify-content: space-between; gap: 10px; margin-bottom: 5px; }
+.sched-card-meta { display: flex; align-items: center; gap: 6px; font-size: 12px; color: var(--muted); }
+.sched-card-meta .sched-clock { color: var(--faint); flex: none; }
 .sched-detail { max-width: 760px; margin: 14px auto; width: calc(100% - 44px); display: flex; flex-direction: column; gap: 10px; }
 .sched-detail-head { display: flex; align-items: center; justify-content: space-between; }
 .sched-detail-head h2 { font-family: var(--serif); font-size: 22px; margin: 0; }
 .sched-actions { display: flex; align-items: center; gap: 12px; }
 .sched-instructions { font-size: 13.5px; color: var(--ink); white-space: pre-wrap; background: var(--panel); border: 1px solid var(--line); border-radius: 10px; padding: 11px 13px; line-height: 1.5; }
+/* Quick-delete on a list card: revealed on hover, never steals the row click. */
+.sched-card-del {
+  display: grid; place-items: center; flex: none;
+  width: 26px; height: 26px; border-radius: 7px; border: none;
+  background: transparent; color: var(--faint); cursor: pointer;
+  opacity: 0; transition: opacity 0.12s, color 0.12s, background 0.12s;
+}
+.sched-card:hover .sched-card-del { opacity: 1; }
+.sched-card-del:hover { color: var(--danger); background: var(--paper); }
+/* Detail "Delete" button — danger-tinted line button with the trash glyph. */
+button.btn.sm.danger-btn { display: inline-flex; align-items: center; gap: 5px; color: var(--danger); border-color: var(--line-strong); }
+button.btn.sm.danger-btn:hover { border-color: var(--danger); }
+.sched-edit-title { font-size: 18px; font-weight: 600; max-width: 360px; }
+.sched-edit-sched { margin: 12px 0 4px; }
+.sched-edit-instr { min-height: 96px; }
 .sched-run { border-bottom: 1px solid var(--line); }
 .sched-run-row { display: flex; align-items: center; justify-content: space-between; font-size: 13px; padding: 8px 2px; cursor: pointer; color: var(--muted); }
 .sched-run-body { font-size: 13.5px; color: var(--ink); padding: 4px 2px 12px; white-space: pre-wrap; line-height: 1.5; }
@@ -945,7 +980,7 @@ button.btn.sm { padding: 5px 13px; font-size: 12.5px; }
 .sched-run-go { color: var(--accent); font-size: 12.5px; font-weight: 500; }
 .sched-run-peek { font-size: 12.5px; color: var(--muted); line-height: 1.45; max-height: 2.9em; overflow: hidden; margin-top: 2px; }
 
-.sched-banner { max-width: 760px; margin: 14px auto 0; width: calc(100% - 44px); display: flex; align-items: flex-start; gap: 10px; font-size: 12.5px; color: var(--muted); line-height: 1.5; background: var(--paper); border: 1px solid var(--line); border-radius: 11px; padding: 10px 13px; }
+.sched-banner { max-width: 820px; margin: 14px 0 0; display: flex; align-items: flex-start; gap: 10px; font-size: 12.5px; color: var(--muted); line-height: 1.5; background: var(--paper); border: 1px solid var(--line); border-radius: 11px; padding: 10px 13px; }
 .sched-banner .ico { color: var(--accent); flex: none; margin-top: 1px; }
 .sched-banner strong { color: var(--ink); font-weight: 600; }
 .page-panel { max-width: 920px; margin: 14px auto 40px; width: calc(100% - 44px); }
@@ -1122,10 +1157,13 @@ button.btn.ghost:hover { color: var(--ink); }
 .ob-valueprops li::before { content: "✓"; position: absolute; left: 0; top: 0; color: var(--ok); font-weight: 700; }
 .ob-valueprops strong { color: var(--ink); font-weight: 600; }
 
-/* Model step: detect / verify states + key help */
-.ob-note.ob-detected { color: var(--ok); }
-.ob-note.ob-err { color: var(--danger); }
-.ob-keyhelp { margin-top: 12px; }
+/* Model step: detect / verify status (one line) + key help — generous spacing so the stacked
+   states don't feel cramped. */
+.ob-status { margin-top: 12px; font-size: 12.5px; line-height: 1.5; }
+.ob-status.ob-ok { color: var(--ok); }
+.ob-status.ob-detected { color: var(--ok); }
+.ob-status.ob-err { color: var(--danger); }
+.ob-keyhelp { margin-top: 18px; }
 .ob-link {
   background: none; border: none; padding: 0; cursor: pointer;
   color: var(--accent); font: inherit; font-size: 12.5px;
@@ -1180,18 +1218,20 @@ button.btn.ghost:hover { color: var(--ink); }
 /* ---- Automation templates ---- */
 .sched-head { display: flex; align-items: flex-start; justify-content: space-between; gap: 14px; }
 
-.tmpl-wrap { max-width: 760px; margin: 16px auto 0; width: calc(100% - 44px); }
-.tmpl-head { margin-bottom: 8px; }
-.tmpl-grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 10px; }
+.tmpl-wrap { max-width: 820px; margin: 18px 0 0; }
+.tmpl-head { margin-bottom: 10px; font-size: 12px; color: var(--faint); text-transform: uppercase; letter-spacing: 0.05em; }
+.tmpl-grid { display: grid; grid-template-columns: repeat(2, 1fr); gap: 12px; }
 .tmpl-card {
-  display: flex; flex-direction: column; gap: 4px;
-  border: 1px solid var(--line); border-radius: 11px; background: var(--panel); padding: 13px 14px;
+  display: flex; flex-direction: column; gap: 5px;
+  border: 1px solid var(--line); border-radius: 13px; background: var(--panel); padding: 15px 16px;
+  transition: border-color 0.12s;
 }
 .tmpl-card:hover { border-color: var(--line-strong); }
 .tmpl-title { font-size: 13.5px; font-weight: 600; color: var(--ink); }
-.tmpl-blurb { font-size: 12px; color: var(--muted); line-height: 1.4; flex: 1; }
-.tmpl-when { font-size: 11.5px; color: var(--faint); margin-top: 2px; }
-.tmpl-add { align-self: flex-start; margin-top: 8px; }
+.tmpl-blurb { font-size: 12.5px; color: var(--muted); line-height: 1.45; flex: 1; }
+.tmpl-when { display: flex; align-items: center; gap: 5px; font-size: 11.5px; color: var(--faint); margin-top: 2px; }
+.tmpl-when svg { flex: none; }
+.tmpl-add { align-self: flex-start; margin-top: 10px; }
 
 .tmpl-form {
   max-width: 760px; margin: 14px auto 0; width: calc(100% - 44px);

--- a/platform/surfaces/gui/src/styles.css
+++ b/platform/surfaces/gui/src/styles.css
@@ -412,6 +412,11 @@ button.btn.danger { color: var(--accent); }
 }
 .pill:hover { color: var(--ink); background: var(--paper); }
 .pill-label { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+/* "No model ⚠" shown in place of the model picker until a provider is connected — no box,
+   just warn-colored text + a small glyph, matching the other composer pills. */
+.pill.model-warn { color: var(--warn-ink); }
+.pill.model-warn:hover { color: var(--warn-ink); background: var(--paper); }
+.model-warn-ico { color: var(--warn-ink); font-size: 12px; line-height: 1; }
 .pill .caret { color: var(--faint); flex: none; }
 .pill:hover .caret { color: var(--muted); }
 
@@ -665,6 +670,35 @@ button.btn.danger { color: var(--accent); }
 .intro .suggestions { margin-top: 36px; }
 .intro .suggestions.intro-setup { margin-top: 30px; }
 .intro .suggest-head { margin-bottom: 6px; }
+
+/* Lead-with-tasks: prominent one-click task cards on the Cowork start screen */
+.intro-tasks { margin-top: 28px; display: grid; grid-template-columns: 1fr; gap: 10px; }
+.task-card {
+  display: flex; align-items: center; gap: 12px;
+  width: 100%; text-align: left; cursor: pointer;
+  padding: 14px 16px;
+  background: var(--panel); border: 1px solid var(--line-strong); border-radius: 12px;
+  font: inherit; color: var(--ink);
+  transition: border-color 0.12s, box-shadow 0.12s;
+}
+.task-card:hover { border-color: var(--accent); box-shadow: 0 0 0 3px var(--accent-soft); }
+.task-card-ico { color: var(--accent); font-size: 18px; width: 22px; text-align: center; flex: none; }
+.task-card-text { flex: 1; font-size: 14px; }
+.task-card-hint { color: var(--faint); font-size: 12.5px; flex: none; }
+
+/* Topbar "Artifacts (N)" affordance, shown when the side panel is hidden */
+.topbar-artifacts-btn {
+  display: inline-flex; align-items: center; gap: 6px;
+  padding: 5px 10px; margin-right: 6px;
+  border: 1px solid var(--line-strong); border-radius: 8px;
+  background: var(--panel); color: var(--muted); cursor: pointer;
+  font: inherit; font-size: 12.5px;
+}
+.topbar-artifacts-btn:hover { color: var(--ink); border-color: var(--accent); }
+.topbar-artifacts-count {
+  min-width: 17px; padding: 0 5px; border-radius: 9px;
+  background: var(--accent); color: #fff; font-size: 11px; font-weight: 600; text-align: center;
+}
 /* the inline add-folder form sits indented under its "Give me access…" row */
 .intro-addfolder { padding: 4px 6px 14px 45px; border-top: 1px solid var(--line); }
 .suggest-hint { color: var(--faint); font-size: 12px; margin-left: 4px; }
@@ -805,10 +839,16 @@ button.link:disabled { color: var(--faint); cursor: default; }
 .conn-name { font-size: 14px; color: var(--ink); display: flex; align-items: center; gap: 8px; }
 .conn-tag { font-size: 10px; letter-spacing: 0.04em; text-transform: uppercase; color: var(--muted); border: 1px solid var(--line-strong); border-radius: 999px; padding: 1px 7px; }
 .conn-meta { font-size: 11.5px; color: var(--faint); margin-top: 2px; display: flex; align-items: center; gap: 5px; }
+.conn-meta.ok, .conn-meta .ok { color: var(--ok); }
+.conn-meta.danger, .conn-meta .danger { color: var(--danger); }
 .conn-dot { width: 7px; height: 7px; border-radius: 50%; background: var(--ok-dot); display: inline-block; }
+.manage-body { flex: 1 1 auto; min-height: 0; }
+.manage-foot { display: flex; align-items: center; justify-content: space-between; padding: 11px 16px; border-top: 1px solid var(--line); }
+.manage-foot-note { font-size: 12px; display: flex; align-items: center; gap: 5px; }
 .conn-soon { font-size: 12px; color: var(--faint); }
 .conn-actions { display: flex; align-items: center; gap: 10px; }
 button.btn-primary.sm { padding: 5px 13px; font-size: 12.5px; }
+button.btn.sm { padding: 5px 13px; font-size: 12.5px; }
 
 .conn-setup { margin-top: 12px; padding-top: 12px; border-top: 1px solid var(--line); display: flex; flex-direction: column; gap: 11px; }
 .conn-steps { margin: 0; padding-left: 18px; display: flex; flex-direction: column; gap: 4px; font-size: 12.5px; color: var(--muted); line-height: 1.45; }
@@ -817,6 +857,17 @@ button.btn-primary.sm { padding: 5px 13px; font-size: 12.5px; }
 .conn-field-label em { color: var(--faint); font-style: normal; }
 .conn-field input { font: inherit; font-size: 13px; padding: 8px 11px; border: 1px solid var(--line-strong); border-radius: 9px; background: var(--paper); color: var(--ink); outline: none; }
 .conn-field input:focus { border-color: var(--accent); }
+/* Match the <select> (provider picker) to the text inputs: same box + a custom chevron so it
+   isn't the browser-default control. */
+.conn-field select {
+  font: inherit; font-size: 13px; padding: 8px 32px 8px 11px;
+  border: 1px solid var(--line-strong); border-radius: 9px;
+  background-color: var(--paper); color: var(--ink); outline: none; cursor: pointer;
+  appearance: none; -webkit-appearance: none;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 24 24' fill='none' stroke='%23888' stroke-width='2.5' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpolyline points='6 9 12 15 18 9'/%3E%3C/svg%3E");
+  background-repeat: no-repeat; background-position: right 11px center; background-size: 12px;
+}
+.conn-field select:focus { border-color: var(--accent); }
 .conn-field-help { font-size: 11.5px; color: var(--faint); }
 .conn-setup-actions { display: flex; gap: 12px; align-items: center; }
 .model-list { display: flex; flex-wrap: wrap; gap: 6px; margin-bottom: 10px; }
@@ -1065,6 +1116,40 @@ button.btn-primary.sm { padding: 5px 13px; font-size: 12.5px; }
 button.btn.ghost { background: transparent; border-color: transparent; color: var(--muted); }
 button.btn.ghost:hover { color: var(--ink); }
 
+/* Welcome value-prop bullets */
+.ob-valueprops { list-style: none; margin: 0 0 18px; padding: 0; display: flex; flex-direction: column; gap: 10px; }
+.ob-valueprops li { position: relative; padding-left: 22px; font-size: 13.5px; color: var(--muted); line-height: 1.5; }
+.ob-valueprops li::before { content: "✓"; position: absolute; left: 0; top: 0; color: var(--ok); font-weight: 700; }
+.ob-valueprops strong { color: var(--ink); font-weight: 600; }
+
+/* Model step: detect / verify states + key help */
+.ob-note.ob-detected { color: var(--ok); }
+.ob-note.ob-err { color: var(--danger); }
+.ob-keyhelp { margin-top: 12px; }
+.ob-link {
+  background: none; border: none; padding: 0; cursor: pointer;
+  color: var(--accent); font: inherit; font-size: 12.5px;
+}
+.ob-link:hover { text-decoration: underline; }
+.ob-keyhelp-body {
+  margin-top: 8px; padding: 10px 12px;
+  background: var(--accent-soft); border: 1px solid var(--line);
+  border-radius: 9px; font-size: 12.5px; color: var(--ink);
+}
+.ob-url {
+  flex: 1; font-size: 11.5px; color: var(--muted);
+  overflow-wrap: anywhere; user-select: all;
+}
+
+/* Skip-without-a-model warning bar */
+.ob-skipwarn {
+  grid-column: 2; margin: 0 40px; padding: 12px 14px;
+  background: var(--warn-soft); border: 1px solid var(--warn-ink);
+  border-radius: 10px; font-size: 12.5px; color: var(--warn-ink);
+  display: flex; flex-direction: column; gap: 10px;
+}
+.ob-skipwarn-actions { display: flex; gap: 8px; }
+
 /* ---- Attachments ----------------------------------------------------------- */
 .composer.dragging { border-color: var(--accent); box-shadow: 0 0 0 3px var(--accent-soft); }
 .attach-row { display: flex; flex-wrap: wrap; gap: 8px; margin-bottom: 8px; }
@@ -1091,3 +1176,38 @@ button.btn.ghost:hover { color: var(--ink); }
 .bubble-attachments { display: flex; flex-wrap: wrap; gap: 8px; margin-bottom: 6px; }
 .msg-img { max-width: 220px; max-height: 220px; border-radius: 10px; border: 1px solid var(--line-strong); display: block; }
 .msg-file { font-size: 12px; color: var(--muted); border: 1px solid var(--line); border-radius: 8px; padding: 4px 8px; }
+
+/* ---- Automation templates ---- */
+.sched-head { display: flex; align-items: flex-start; justify-content: space-between; gap: 14px; }
+
+.tmpl-wrap { max-width: 760px; margin: 16px auto 0; width: calc(100% - 44px); }
+.tmpl-head { margin-bottom: 8px; }
+.tmpl-grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 10px; }
+.tmpl-card {
+  display: flex; flex-direction: column; gap: 4px;
+  border: 1px solid var(--line); border-radius: 11px; background: var(--panel); padding: 13px 14px;
+}
+.tmpl-card:hover { border-color: var(--line-strong); }
+.tmpl-title { font-size: 13.5px; font-weight: 600; color: var(--ink); }
+.tmpl-blurb { font-size: 12px; color: var(--muted); line-height: 1.4; flex: 1; }
+.tmpl-when { font-size: 11.5px; color: var(--faint); margin-top: 2px; }
+.tmpl-add { align-self: flex-start; margin-top: 8px; }
+
+.tmpl-form {
+  max-width: 760px; margin: 14px auto 0; width: calc(100% - 44px);
+  display: flex; flex-direction: column; gap: 9px;
+  border: 1px solid var(--line); border-radius: 11px; background: var(--panel); padding: 14px 16px;
+}
+.tmpl-input {
+  font: inherit; font-size: 13px; color: var(--ink); background: var(--panel);
+  border: 1px solid var(--line-strong); border-radius: 8px; padding: 7px 10px; outline: none;
+}
+.tmpl-input:focus { border-color: var(--accent); box-shadow: 0 0 0 3px var(--accent-soft); }
+.tmpl-input::placeholder { color: var(--faint); }
+.tmpl-textarea { resize: vertical; min-height: 64px; line-height: 1.45; }
+.tmpl-sched { display: flex; gap: 14px; flex-wrap: wrap; }
+.tmpl-field { display: flex; flex-direction: column; gap: 4px; font-size: 11.5px; color: var(--muted); }
+.tmpl-time, .tmpl-select { padding: 6px 9px; }
+.tmpl-form-actions { display: flex; align-items: center; gap: 12px; margin-top: 2px; }
+
+.tmpl-empty { margin-top: 18px; }

--- a/platform/surfaces/gui/src/styles.css
+++ b/platform/surfaces/gui/src/styles.css
@@ -841,6 +841,10 @@ button.link:disabled { color: var(--faint); cursor: default; }
 .conn-meta { font-size: 11.5px; color: var(--faint); margin-top: 2px; display: flex; align-items: center; gap: 5px; }
 .conn-meta.ok, .conn-meta .ok { color: var(--ok); }
 .conn-meta.danger, .conn-meta .danger { color: var(--danger); }
+/* Informational paragraph (may contain inline <code>) — a normal text block, NOT the flex
+   status row .conn-meta uses, so sentences don't get split into gapped flex items. */
+.conn-note { font-size: 11.5px; color: var(--faint); line-height: 1.5; }
+.conn-note code { white-space: nowrap; }
 .conn-dot { width: 7px; height: 7px; border-radius: 50%; background: var(--ok-dot); display: inline-block; }
 .manage-body { flex: 1 1 auto; min-height: 0; }
 .manage-foot { display: flex; align-items: center; justify-content: space-between; padding: 11px 16px; border-top: 1px solid var(--line); }

--- a/platform/surfaces/gui/src/tauri.ts
+++ b/platform/surfaces/gui/src/tauri.ts
@@ -33,3 +33,15 @@ export const setKeepAwake = (enabled: boolean) => invoke<boolean>("set_keep_awak
 
 /** Begin native window dragging from a custom title/header region. */
 export const startWindowDrag = () => invoke<boolean>("start_window_drag");
+
+/** Best-effort open a URL in the user's browser. Uses the Tauri opener plugin if present, else
+ * `window.open`. The caller should also render the raw URL so it stays copyable if both no-op
+ * (the desktop webview has no opener plugin wired yet). */
+export function openExternal(url: string): void {
+  const opener = (globalThis as any).__TAURI__?.opener;
+  if (opener?.openUrl) {
+    opener.openUrl(url).catch(() => window.open(url, "_blank", "noopener,noreferrer"));
+    return;
+  }
+  window.open(url, "_blank", "noopener,noreferrer");
+}

--- a/platform/tests/test_automation_create.py
+++ b/platform/tests/test_automation_create.py
@@ -1,0 +1,73 @@
+"""Tests for the GUI-driven `create_automation` path (the "New automation" / template flow).
+
+No network and no LLM: this exercises validation + that a valid create lands in the task store
+with a freshly provisioned scratch workspace.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from coworker.server.manager import SessionManager
+
+
+def _manager(tmp_path, monkeypatch) -> SessionManager:
+    monkeypatch.setenv("COWORKER_STATE_DIR", str(tmp_path / "state"))
+    return SessionManager(data_dir=tmp_path / "data")
+
+
+def test_create_automation_success(tmp_path, monkeypatch):
+    manager = _manager(tmp_path, monkeypatch)
+    out = manager.create_automation(
+        {
+            "title": "Morning news briefing",
+            "instructions": "Search the web and write a 5-bullet briefing.",
+            "cron": "0 8 * * *",
+        }
+    )
+    assert out["ok"] is True
+    task = out["task"]
+    assert task["title"] == "Morning news briefing"
+    assert task["schedule"] == "Every day at ~8:00 AM"
+    # it really landed in the store and is bound to a fresh scratch workspace
+    saved = manager.task_store.get(task["id"])
+    assert saved is not None
+    assert saved.agent == "cowork"
+    assert Path(saved.workspace).is_dir()
+
+
+def test_create_automation_invalid_cron(tmp_path, monkeypatch):
+    manager = _manager(tmp_path, monkeypatch)
+    out = manager.create_automation(
+        {
+            "title": "Bad",
+            "instructions": "do something",
+            "cron": "not-a-cron",
+        }
+    )
+    assert out["ok"] is False
+    assert "invalid cron" in out["error"]
+    assert manager.task_store.list() == []
+
+
+def test_create_automation_missing_instructions(tmp_path, monkeypatch):
+    manager = _manager(tmp_path, monkeypatch)
+    out = manager.create_automation(
+        {
+            "title": "No instructions",
+            "instructions": "  ",
+            "cron": "0 8 * * *",
+        }
+    )
+    assert out["ok"] is False
+    assert "instructions" in out["error"]
+    assert manager.task_store.list() == []
+
+
+def test_create_automation_requires_schedule(tmp_path, monkeypatch):
+    manager = _manager(tmp_path, monkeypatch)
+    out = manager.create_automation(
+        {"title": "No schedule", "instructions": "do something"}
+    )
+    assert out["ok"] is False
+    assert manager.task_store.list() == []

--- a/platform/tests/test_provider_verify.py
+++ b/platform/tests/test_provider_verify.py
@@ -1,0 +1,102 @@
+"""Tests for provider key detection + the live (read-only) Test/verify path. SDK-free: the
+single httpx.get is monkeypatched so no network is touched."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from coworker.providers import detect_provider, verify_provider_key
+
+
+# -- detect_provider ------------------------------------------------------------
+@pytest.mark.parametrize(
+    "key,expected",
+    [
+        ("sk-ant-api03-abc", "anthropic"),
+        ("AIzaSyAbc123", "gemini"),
+        ("sk-proj-abc", "openai"),
+        ("sk_live_abc", "openai"),
+        ("", None),
+        ("   ", None),
+        ("nonsense", None),
+    ],
+)
+def test_detect_provider(key, expected):
+    assert detect_provider(key) == expected
+
+
+# -- verify_provider_key: status-code mapping + per-provider request shape -------
+def _patch_get(monkeypatch, status=200, capture=None, raise_exc=None):
+    def fake_get(url, **kwargs):
+        if capture is not None:
+            capture["url"] = url
+            capture.update(kwargs)
+        if raise_exc is not None:
+            raise raise_exc
+        return SimpleNamespace(status_code=status)
+
+    monkeypatch.setattr("httpx.get", fake_get)
+
+
+def test_verify_openai_ok(monkeypatch):
+    cap: dict = {}
+    _patch_get(monkeypatch, status=200, capture=cap)
+    assert verify_provider_key("openai", api_key="sk-x") == {"ok": True}
+    assert cap["url"] == "https://api.openai.com/v1/models"
+    assert cap["headers"]["Authorization"] == "Bearer sk-x"
+
+
+def test_verify_openai_custom_endpoint(monkeypatch):
+    cap: dict = {}
+    _patch_get(monkeypatch, status=200, capture=cap)
+    verify_provider_key("openai", api_key="sk-x", base_url="https://gw.example/openai/v1/")
+    # trailing slash trimmed, /models appended to the custom endpoint
+    assert cap["url"] == "https://gw.example/openai/v1/models"
+
+
+def test_verify_bad_key_is_invalid(monkeypatch):
+    _patch_get(monkeypatch, status=401)
+    assert verify_provider_key("openai", api_key="sk-bad") == {
+        "ok": False,
+        "error": "Invalid API key.",
+    }
+
+
+def test_verify_anthropic_headers(monkeypatch):
+    cap: dict = {}
+    _patch_get(monkeypatch, status=200, capture=cap)
+    verify_provider_key("anthropic", api_key="sk-ant-x")
+    assert cap["url"] == "https://api.anthropic.com/v1/models"
+    assert cap["headers"]["x-api-key"] == "sk-ant-x"
+    assert "anthropic-version" in cap["headers"]
+
+
+def test_verify_gemini_key_param(monkeypatch):
+    cap: dict = {}
+    _patch_get(monkeypatch, status=200, capture=cap)
+    verify_provider_key("gemini", api_key="AIza-x")
+    assert cap["params"]["key"] == "AIza-x"
+
+
+def test_verify_ollama_uses_v1_models_no_key(monkeypatch):
+    cap: dict = {}
+    _patch_get(monkeypatch, status=200, capture=cap)
+    verify_provider_key("ollama", base_url="http://localhost:11434")
+    assert cap["url"] == "http://localhost:11434/v1/models"
+    assert "headers" not in cap  # keyless
+
+
+def test_verify_network_error_is_clean(monkeypatch):
+    _patch_get(monkeypatch, raise_exc=ConnectionError("boom"))
+    res = verify_provider_key("openai", api_key="sk-x")
+    assert res["ok"] is False
+    assert "Couldn't reach" in res["error"]
+
+
+def test_verify_unexpected_status(monkeypatch):
+    _patch_get(monkeypatch, status=500)
+    res = verify_provider_key("anthropic", api_key="sk-ant-x")
+    assert res["ok"] is False
+    assert "500" in res["error"]

--- a/platform/tests/test_provider_verify.py
+++ b/platform/tests/test_provider_verify.py
@@ -51,7 +51,9 @@ def test_verify_openai_ok(monkeypatch):
 def test_verify_openai_custom_endpoint(monkeypatch):
     cap: dict = {}
     _patch_get(monkeypatch, status=200, capture=cap)
-    verify_provider_key("openai", api_key="sk-x", base_url="https://gw.example/openai/v1/")
+    verify_provider_key(
+        "openai", api_key="sk-x", base_url="https://gw.example/openai/v1/"
+    )
     # trailing slash trimmed, /models appended to the custom endpoint
     assert cap["url"] == "https://gw.example/openai/v1/models"
 


### PR DESCRIPTION

Addresses the first-run review (sign-up -> setup -> first task), focused on easily getting past model setup.

- Fix the "send twice" bug.
- Composer: replace the misleading model picker with a "No model" warning when no provider is configured
- Onboarding: lead with the privacy-first value prop; auto-detect the provider from the key shape; add a "Test" button.
- Backend: POST /v1/providers/verify (transient httpx model-list check) plus provider auto-detect; model_ready flag in settings; filter the model list to configured providers.
- Automations: a "New automation" CTA and one-click templates (morning news briefing, inbox digest, folder cleanup) via a new POST /v1/automations.

Tests: GUI tsc + build clean; backend 351 passed (adds provider-verify and automation-create tests).