### PR TITLE
Support newer OpenAI token limits

### DIFF
--- a/aisuite/providers/openai_provider.py
+++ b/aisuite/providers/openai_provider.py
@@ -49,13 +49,16 @@ def _error_body(error):
 def _is_unsupported_param_error(error, param):
     body = _error_body(error)
     message = str(body.get("message") or error)
+    normalized_message = message.lower()
     reported_param = body.get("param")
     code = body.get("code")
-    return (
-        reported_param == param
-        or (param in message and "unsupported" in message.lower())
-        or (code == "unsupported_parameter" and param in message)
+    param_matches = reported_param == param or param in message
+    unsupported = (
+        code == "unsupported_parameter"
+        or "unsupported" in normalized_message
+        or "not supported" in normalized_message
     )
+    return param_matches and unsupported
 
 
 def _alternate_token_limit_param(param):

--- a/aisuite/providers/openai_provider.py
+++ b/aisuite/providers/openai_provider.py
@@ -10,7 +10,6 @@ from aisuite.framework.message import (
     StreamingTranscriptionChunk,
 )
 
-
 _MAX_TOKENS_PARAM = "max_tokens"
 _MAX_COMPLETION_TOKENS_PARAM = "max_completion_tokens"
 _MAX_COMPLETION_TOKEN_MODEL_PREFIXES = (
@@ -170,28 +169,64 @@ class OpenaiProvider(Provider):
 
     def chat_completions_create_stream(self, model, messages, **kwargs):
         # OpenAI's own chunks already have the unified shape — pass them through.
+        transformed_messages = None
+        request_kwargs = None
         try:
             transformed_messages = self.transformer.convert_request(messages)
+            request_kwargs = _normalize_chat_completion_kwargs(model, kwargs)
             stream = self.client.chat.completions.create(
                 model=model,
                 messages=transformed_messages,
                 stream=True,
-                **kwargs,
+                **request_kwargs,
             )
+        except openai.BadRequestError as e:
+            if request_kwargs is None:
+                raise LLMError(f"An error occurred: {e}")
+            retry_kwargs = _retry_kwargs_for_unsupported_token_param(e, request_kwargs)
+            if retry_kwargs is None:
+                raise LLMError(f"An error occurred: {e}")
+            try:
+                stream = self.client.chat.completions.create(
+                    model=model,
+                    messages=transformed_messages,
+                    stream=True,
+                    **retry_kwargs,
+                )
+            except Exception as retry_error:
+                raise LLMError(f"An error occurred: {retry_error}")
         except Exception as e:
             raise LLMError(f"An error occurred: {e}")
         yield from stream
 
     async def achat_completions_create_stream(self, model, messages, **kwargs):
         # Native async streaming via openai.AsyncOpenAI.
+        transformed_messages = None
+        request_kwargs = None
         try:
             transformed_messages = self.transformer.convert_request(messages)
+            request_kwargs = _normalize_chat_completion_kwargs(model, kwargs)
             stream = await self.aclient.chat.completions.create(
                 model=model,
                 messages=transformed_messages,
                 stream=True,
-                **kwargs,
+                **request_kwargs,
             )
+        except openai.BadRequestError as e:
+            if request_kwargs is None:
+                raise LLMError(f"An error occurred: {e}")
+            retry_kwargs = _retry_kwargs_for_unsupported_token_param(e, request_kwargs)
+            if retry_kwargs is None:
+                raise LLMError(f"An error occurred: {e}")
+            try:
+                stream = await self.aclient.chat.completions.create(
+                    model=model,
+                    messages=transformed_messages,
+                    stream=True,
+                    **retry_kwargs,
+                )
+            except Exception as retry_error:
+                raise LLMError(f"An error occurred: {retry_error}")
         except Exception as e:
             raise LLMError(f"An error occurred: {e}")
         async for chunk in stream:

--- a/aisuite/providers/openai_provider.py
+++ b/aisuite/providers/openai_provider.py
@@ -11,6 +11,72 @@ from aisuite.framework.message import (
 )
 
 
+_MAX_TOKENS_PARAM = "max_tokens"
+_MAX_COMPLETION_TOKENS_PARAM = "max_completion_tokens"
+_MAX_COMPLETION_TOKEN_MODEL_PREFIXES = (
+    "gpt-5",
+    "o1",
+    "o3",
+    "o4",
+)
+
+
+def _prefers_max_completion_tokens(model):
+    """Return True for OpenAI model families that reject max_tokens."""
+    normalized_model = str(model).strip().lower()
+    return normalized_model.startswith(_MAX_COMPLETION_TOKEN_MODEL_PREFIXES)
+
+
+def _normalize_chat_completion_kwargs(model, kwargs):
+    """Map aisuite's max_tokens abstraction to OpenAI's current parameter names."""
+    normalized_kwargs = dict(kwargs)
+    if _prefers_max_completion_tokens(model) and _MAX_TOKENS_PARAM in normalized_kwargs:
+        max_tokens = normalized_kwargs.pop(_MAX_TOKENS_PARAM)
+        normalized_kwargs.setdefault(_MAX_COMPLETION_TOKENS_PARAM, max_tokens)
+    return normalized_kwargs
+
+
+def _error_body(error):
+    body = getattr(error, "body", None)
+    if not isinstance(body, dict):
+        return {}
+    nested_error = body.get("error")
+    if isinstance(nested_error, dict):
+        return nested_error
+    return body
+
+
+def _is_unsupported_param_error(error, param):
+    body = _error_body(error)
+    message = str(body.get("message") or error)
+    reported_param = body.get("param")
+    code = body.get("code")
+    return (
+        reported_param == param
+        or (param in message and "unsupported" in message.lower())
+        or (code == "unsupported_parameter" and param in message)
+    )
+
+
+def _alternate_token_limit_param(param):
+    if param == _MAX_TOKENS_PARAM:
+        return _MAX_COMPLETION_TOKENS_PARAM
+    return _MAX_TOKENS_PARAM
+
+
+def _retry_kwargs_for_unsupported_token_param(error, request_kwargs):
+    for param in (_MAX_TOKENS_PARAM, _MAX_COMPLETION_TOKENS_PARAM):
+        if param not in request_kwargs:
+            continue
+        if not _is_unsupported_param_error(error, param):
+            continue
+        retry_kwargs = dict(request_kwargs)
+        token_limit = retry_kwargs.pop(param)
+        retry_kwargs.setdefault(_alternate_token_limit_param(param), token_limit)
+        return retry_kwargs
+    return None
+
+
 class OpenaiProvider(Provider):
     def __init__(self, **config):
         """
@@ -41,27 +107,61 @@ class OpenaiProvider(Provider):
     def chat_completions_create(self, model, messages, **kwargs):
         # Any exception raised by OpenAI will be returned to the caller.
         # Maybe we should catch them and raise a custom LLMError.
+        transformed_messages = None
+        request_kwargs = None
         try:
             transformed_messages = self.transformer.convert_request(messages)
+            request_kwargs = _normalize_chat_completion_kwargs(model, kwargs)
             response = self.client.chat.completions.create(
                 model=model,
                 messages=transformed_messages,
-                **kwargs,  # Pass any additional arguments to the OpenAI API
+                **request_kwargs,  # Pass any additional arguments to the OpenAI API
             )
             return response
+        except openai.BadRequestError as e:
+            if request_kwargs is None:
+                raise LLMError(f"An error occurred: {e}")
+            retry_kwargs = _retry_kwargs_for_unsupported_token_param(e, request_kwargs)
+            if retry_kwargs is None:
+                raise LLMError(f"An error occurred: {e}")
+            try:
+                return self.client.chat.completions.create(
+                    model=model,
+                    messages=transformed_messages,
+                    **retry_kwargs,
+                )
+            except Exception as retry_error:
+                raise LLMError(f"An error occurred: {retry_error}")
         except Exception as e:
             raise LLMError(f"An error occurred: {e}")
 
     async def achat_completions_create(self, model, messages, **kwargs):
         # Native async path via openai.AsyncOpenAI.
+        transformed_messages = None
+        request_kwargs = None
         try:
             transformed_messages = self.transformer.convert_request(messages)
+            request_kwargs = _normalize_chat_completion_kwargs(model, kwargs)
             response = await self.aclient.chat.completions.create(
                 model=model,
                 messages=transformed_messages,
-                **kwargs,  # Pass any additional arguments to the OpenAI API
+                **request_kwargs,  # Pass any additional arguments to the OpenAI API
             )
             return response
+        except openai.BadRequestError as e:
+            if request_kwargs is None:
+                raise LLMError(f"An error occurred: {e}")
+            retry_kwargs = _retry_kwargs_for_unsupported_token_param(e, request_kwargs)
+            if retry_kwargs is None:
+                raise LLMError(f"An error occurred: {e}")
+            try:
+                return await self.aclient.chat.completions.create(
+                    model=model,
+                    messages=transformed_messages,
+                    **retry_kwargs,
+                )
+            except Exception as retry_error:
+                raise LLMError(f"An error occurred: {retry_error}")
         except Exception as e:
             raise LLMError(f"An error occurred: {e}")
 

--- a/tests/providers/test_async_provider.py
+++ b/tests/providers/test_async_provider.py
@@ -51,3 +51,26 @@ async def test_openai_native_async(monkeypatch):
     )
     assert response.choices[0].message.content == "async hi"
     provider.aclient.chat.completions.create.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_openai_native_async_maps_max_tokens_for_newer_models(monkeypatch):
+    """The native async OpenAI path applies the same token-limit abstraction."""
+    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+    provider = OpenaiProvider()
+
+    mock_response = SimpleNamespace(
+        choices=[SimpleNamespace(message=SimpleNamespace(content="async hi"))]
+    )
+    provider.aclient.chat.completions.create = AsyncMock(return_value=mock_response)
+
+    response = await provider.achat_completions_create(
+        "gpt-5.4-mini",
+        [{"role": "user", "content": "hi"}],
+        max_tokens=100,
+    )
+
+    assert response.choices[0].message.content == "async hi"
+    call_kwargs = provider.aclient.chat.completions.create.await_args.kwargs
+    assert call_kwargs["max_completion_tokens"] == 100
+    assert "max_tokens" not in call_kwargs

--- a/tests/providers/test_openai_provider.py
+++ b/tests/providers/test_openai_provider.py
@@ -9,7 +9,7 @@ from openai import BadRequestError
 import pytest
 
 from aisuite.providers.openai_provider import OpenaiProvider
-from aisuite.provider import ASRError
+from aisuite.provider import ASRError, LLMError
 from aisuite.framework.message import (
     TranscriptionResult,
     TranscriptionOptions,
@@ -41,17 +41,20 @@ def mock_openai_response():
     return mock_response
 
 
-def _bad_request_for_param(param):
+def _bad_request_for_param(param, *, message=None, code="unsupported_parameter"):
+    message = (
+        message or f"Unsupported parameter: '{param}' is not supported with this model."
+    )
     request = httpx.Request("POST", "https://api.openai.test/v1/chat/completions")
     response = httpx.Response(400, request=request)
     return BadRequestError(
-        f"Unsupported parameter: '{param}' is not supported with this model.",
+        message,
         response=response,
         body={
             "error": {
-                "message": f"Unsupported parameter: '{param}' is not supported with this model.",
+                "message": message,
                 "param": param,
-                "code": "unsupported_parameter",
+                "code": code,
             }
         },
     )
@@ -119,6 +122,28 @@ class TestOpenAIProvider:
         assert "max_completion_tokens" not in first_call
         assert second_call["max_completion_tokens"] == 64
         assert "max_tokens" not in second_call
+
+    def test_chat_completion_does_not_retry_non_unsupported_token_error(
+        self, openai_provider
+    ):
+        """Other max_tokens validation errors should not be retried as compatibility issues."""
+        with patch.object(
+            openai_provider.client.chat.completions,
+            "create",
+            side_effect=_bad_request_for_param(
+                "max_tokens",
+                message="Invalid value for max_tokens.",
+                code="invalid_request_error",
+            ),
+        ) as mock_create:
+            with pytest.raises(LLMError, match="Invalid value for max_tokens"):
+                openai_provider.chat_completions_create(
+                    "custom-model",
+                    [{"role": "user", "content": "hi"}],
+                    max_tokens=-1,
+                )
+
+        assert mock_create.call_count == 1
 
 
 class TestOpenAIASR:

--- a/tests/providers/test_openai_provider.py
+++ b/tests/providers/test_openai_provider.py
@@ -1,8 +1,11 @@
 """Tests for OpenAI provider functionality."""
 
 import io
+from types import SimpleNamespace
 from unittest.mock import MagicMock, mock_open, patch
 
+import httpx
+from openai import BadRequestError
 import pytest
 
 from aisuite.providers.openai_provider import OpenaiProvider
@@ -38,6 +41,22 @@ def mock_openai_response():
     return mock_response
 
 
+def _bad_request_for_param(param):
+    request = httpx.Request("POST", "https://api.openai.test/v1/chat/completions")
+    response = httpx.Response(400, request=request)
+    return BadRequestError(
+        f"Unsupported parameter: '{param}' is not supported with this model.",
+        response=response,
+        body={
+            "error": {
+                "message": f"Unsupported parameter: '{param}' is not supported with this model.",
+                "param": param,
+                "code": "unsupported_parameter",
+            }
+        },
+    )
+
+
 class TestOpenAIProvider:
     """Test suite for OpenAI provider functionality."""
 
@@ -47,6 +66,59 @@ class TestOpenAIProvider:
         assert hasattr(openai_provider, "client")
         assert hasattr(openai_provider, "audio")
         assert hasattr(openai_provider.audio, "transcriptions")
+
+    def test_chat_completion_maps_max_tokens_for_newer_openai_models(
+        self, openai_provider
+    ):
+        """OpenAI reasoning/newer model families require max_completion_tokens."""
+        mock_response = SimpleNamespace(
+            choices=[SimpleNamespace(message=SimpleNamespace(content="hi"))]
+        )
+
+        with patch.object(
+            openai_provider.client.chat.completions,
+            "create",
+            return_value=mock_response,
+        ) as mock_create:
+            response = openai_provider.chat_completions_create(
+                "gpt-5.4-mini",
+                [{"role": "user", "content": "hi"}],
+                max_tokens=128,
+                temperature=0,
+            )
+
+        assert response is mock_response
+        call_kwargs = mock_create.call_args.kwargs
+        assert call_kwargs["max_completion_tokens"] == 128
+        assert "max_tokens" not in call_kwargs
+        assert call_kwargs["temperature"] == 0
+
+    def test_chat_completion_retries_token_param_on_unsupported_error(
+        self, openai_provider
+    ):
+        """OpenAI-compatible endpoints can recover by trying the alternate name."""
+        mock_response = SimpleNamespace(
+            choices=[SimpleNamespace(message=SimpleNamespace(content="hi"))]
+        )
+
+        with patch.object(
+            openai_provider.client.chat.completions,
+            "create",
+            side_effect=[_bad_request_for_param("max_tokens"), mock_response],
+        ) as mock_create:
+            response = openai_provider.chat_completions_create(
+                "custom-model",
+                [{"role": "user", "content": "hi"}],
+                max_tokens=64,
+            )
+
+        assert response is mock_response
+        first_call = mock_create.call_args_list[0].kwargs
+        second_call = mock_create.call_args_list[1].kwargs
+        assert first_call["max_tokens"] == 64
+        assert "max_completion_tokens" not in first_call
+        assert second_call["max_completion_tokens"] == 64
+        assert "max_tokens" not in second_call
 
 
 class TestOpenAIASR:

--- a/tests/providers/test_streaming_provider.py
+++ b/tests/providers/test_streaming_provider.py
@@ -4,7 +4,9 @@ import threading
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, Mock
 
+import httpx
 import pytest
+from openai import BadRequestError
 
 from aisuite.provider import Provider, LLMError
 from aisuite.providers.openai_provider import OpenaiProvider
@@ -87,6 +89,23 @@ def openai_provider(monkeypatch):
     return OpenaiProvider()
 
 
+def _bad_request_for_param(param):
+    message = f"Unsupported parameter: '{param}' is not supported with this model."
+    request = httpx.Request("POST", "https://api.openai.test/v1/chat/completions")
+    response = httpx.Response(400, request=request)
+    return BadRequestError(
+        message,
+        response=response,
+        body={
+            "error": {
+                "message": message,
+                "param": param,
+                "code": "unsupported_parameter",
+            }
+        },
+    )
+
+
 def test_openai_sync_stream_passes_through(openai_provider):
     chunks = [SimpleNamespace(id="1"), SimpleNamespace(id="2")]
     openai_provider.client.chat.completions.create = Mock(return_value=iter(chunks))
@@ -102,6 +121,46 @@ def test_openai_sync_stream_passes_through(openai_provider):
     assert call.kwargs["stream"] is True
     assert call.kwargs["temperature"] == 0.1
     assert call.kwargs["model"] == "gpt-4o"
+
+
+def test_openai_sync_stream_maps_max_tokens_for_newer_models(openai_provider):
+    chunks = [SimpleNamespace(id="1")]
+    openai_provider.client.chat.completions.create = Mock(return_value=iter(chunks))
+
+    received = list(
+        openai_provider.chat_completions_create_stream(
+            "gpt-5.4-mini",
+            [{"role": "user", "content": "hi"}],
+            max_tokens=17,
+        )
+    )
+
+    assert received == chunks
+    call = openai_provider.client.chat.completions.create.call_args
+    assert call.kwargs["max_completion_tokens"] == 17
+    assert "max_tokens" not in call.kwargs
+
+
+def test_openai_sync_stream_retries_unsupported_token_param(openai_provider):
+    chunks = [SimpleNamespace(id="1")]
+    openai_provider.client.chat.completions.create = Mock(
+        side_effect=[_bad_request_for_param("max_tokens"), iter(chunks)]
+    )
+
+    received = list(
+        openai_provider.chat_completions_create_stream(
+            "custom-model",
+            [{"role": "user", "content": "hi"}],
+            max_tokens=19,
+        )
+    )
+
+    assert received == chunks
+    calls = openai_provider.client.chat.completions.create.call_args_list
+    assert calls[0].kwargs["max_tokens"] == 19
+    assert "max_completion_tokens" not in calls[0].kwargs
+    assert calls[1].kwargs["max_completion_tokens"] == 19
+    assert "max_tokens" not in calls[1].kwargs
 
 
 def test_openai_sync_stream_wraps_errors(openai_provider):
@@ -146,3 +205,49 @@ async def test_openai_async_stream_passes_through(openai_provider):
     assert received == chunks
     call = openai_provider.aclient.chat.completions.create.await_args
     assert call.kwargs["stream"] is True
+
+
+@pytest.mark.asyncio
+async def test_openai_async_stream_maps_max_tokens_for_newer_models(openai_provider):
+    chunks = [SimpleNamespace(id="1")]
+    openai_provider.aclient.chat.completions.create = AsyncMock(
+        return_value=_AsyncIter(chunks)
+    )
+
+    received = [
+        chunk
+        async for chunk in openai_provider.achat_completions_create_stream(
+            "gpt-5.4-mini",
+            [{"role": "user", "content": "hi"}],
+            max_tokens=23,
+        )
+    ]
+
+    assert received == chunks
+    call = openai_provider.aclient.chat.completions.create.await_args
+    assert call.kwargs["max_completion_tokens"] == 23
+    assert "max_tokens" not in call.kwargs
+
+
+@pytest.mark.asyncio
+async def test_openai_async_stream_retries_unsupported_token_param(openai_provider):
+    chunks = [SimpleNamespace(id="1")]
+    openai_provider.aclient.chat.completions.create = AsyncMock(
+        side_effect=[_bad_request_for_param("max_tokens"), _AsyncIter(chunks)]
+    )
+
+    received = [
+        chunk
+        async for chunk in openai_provider.achat_completions_create_stream(
+            "custom-model",
+            [{"role": "user", "content": "hi"}],
+            max_tokens=29,
+        )
+    ]
+
+    assert received == chunks
+    calls = openai_provider.aclient.chat.completions.create.await_args_list
+    assert calls[0].kwargs["max_tokens"] == 29
+    assert "max_completion_tokens" not in calls[0].kwargs
+    assert calls[1].kwargs["max_completion_tokens"] == 29
+    assert "max_tokens" not in calls[1].kwargs


### PR DESCRIPTION
## Summary

- Map aisuite's provider-agnostic `max_tokens` parameter to OpenAI's `max_completion_tokens` for newer OpenAI model families that reject `max_tokens`.
- Retry once with the alternate token-limit parameter when an OpenAI-compatible endpoint returns an unsupported-parameter error.
- Apply the same behavior to synchronous, native asynchronous, synchronous streaming, and native asynchronous streaming OpenAI provider paths.

## Validation

- `python -m pytest tests/providers/test_openai_provider.py tests/providers/test_async_provider.py tests/providers/test_streaming_provider.py tests/client/test_streaming.py -q` (34 passed)
- `black --check aisuite/providers/openai_provider.py tests/providers/test_openai_provider.py tests/providers/test_async_provider.py tests/providers/test_streaming_provider.py`
