### PR TITLE
Avoid sharing default provider configs across clients

### DIFF
--- a/aisuite/client.py
+++ b/aisuite/client.py
@@ -23,7 +23,7 @@ except ImportError:
 class Client:
     def __init__(
         self,
-        provider_configs: dict = {},
+        provider_configs: dict | None = None,
         extra_param_mode: Literal["strict", "warn", "permissive"] = "warn",
     ):
         """
@@ -49,7 +49,7 @@ class Client:
                 - "permissive": Allow all params without validation (testing)
         """
         self.providers = {}
-        self.provider_configs = provider_configs
+        self.provider_configs = dict(provider_configs or {})
         self.extra_param_mode = extra_param_mode
         self.param_validator = ParamValidator(extra_param_mode)
         self._chat = None

--- a/tests/client/test_client.py
+++ b/tests/client/test_client.py
@@ -110,6 +110,16 @@ def test_invalid_provider_in_client_config():
         client.chat.completions.create("invalid_provider:some-model", messages=messages)
 
 
+def test_default_provider_configs_are_not_shared():
+    first_client = Client()
+    second_client = Client()
+
+    first_client.configure({"openai": {"api_key": "first-key"}})
+
+    assert first_client.provider_configs == {"openai": {"api_key": "first-key"}}
+    assert second_client.provider_configs == {}
+
+
 def test_invalid_model_format_in_create():
     # Valid provider configurations
     provider_configs = {


### PR DESCRIPTION
## What changed

This changes `Client.__init__` to default `provider_configs` to `None` and copy the provided mapping during initialization.

## Why

The previous `{}` default was shared across `Client()` instances. Calling `configure()` on one default client mutated the same dictionary seen by another default client, which can leak provider/API configuration between independent clients in the same process.

## Validation

- `PYTHONPATH=. python -m pytest tests\client\test_client.py::test_default_provider_configs_are_not_shared tests\client\test_client.py::test_invalid_provider_in_client_config tests\client\test_client.py::test_invalid_model_format_in_create -q`
- `python -m black --check aisuite\client.py tests\client\test_client.py`