### PR TITLE
feat(providers): add Eden AI provider

### DIFF
--- a/aisuite/providers/edenai_provider.py
+++ b/aisuite/providers/edenai_provider.py
@@ -1,0 +1,49 @@
+"""Eden AI provider for the aisuite."""
+
+import os
+import openai
+from aisuite.provider import Provider, LLMError
+from aisuite.providers.message_converter import OpenAICompliantMessageConverter
+
+
+# pylint: disable=too-few-public-methods
+class EdenaiProvider(Provider):
+    """Provider for Eden AI.
+
+    Eden AI (https://www.edenai.co) is an EU-hosted, OpenAI-compatible gateway
+    that exposes 100+ models from many providers through a single API key.
+    Models use the ``provider/model`` naming scheme, e.g.
+    ``anthropic/claude-sonnet-4-5`` or ``mistral/codestral-latest``.
+    """
+
+    def __init__(self, **config):
+        """
+        Initialize the Eden AI provider with the given configuration.
+        Pass the entire configuration dictionary to the OpenAI client constructor.
+        """
+        # Ensure API key is provided either in config or via environment variable
+        config.setdefault("api_key", os.getenv("EDENAI_API_KEY"))
+        if not config["api_key"]:
+            raise ValueError(
+                "Eden AI API key is missing. Please provide it in the config or "
+                "set the EDENAI_API_KEY environment variable."
+            )
+        config["base_url"] = "https://api.edenai.run/v3"
+
+        # Pass the entire config to the OpenAI client constructor
+        self.client = openai.OpenAI(**config)
+        # Using OpenAICompliantMessageConverter since Eden AI's response format is
+        # the same as OpenAI's.
+        self.transformer = OpenAICompliantMessageConverter()
+
+    def chat_completions_create(self, model, messages, **kwargs):
+        # Any exception raised by OpenAI will be returned to the caller.
+        try:
+            response = self.client.chat.completions.create(
+                model=model,
+                messages=messages,
+                **kwargs,  # Pass any additional arguments to the OpenAI API
+            )
+            return self.transformer.convert_response(response.model_dump())
+        except Exception as e:
+            raise LLMError(f"An error occurred: {e}") from e

--- a/guides/README.md
+++ b/guides/README.md
@@ -14,6 +14,7 @@ Here are the instructions for:
 - [SambaNova](sambanova.md)
 - [xAI](xai.md)
 - [DeepSeek](deepseek.md)
+- [Eden AI](edenai.md)
 
 For locally hosted models using `Ollama` or `LM Studio`, follow these instructions:
 - [Ollama](ollama.md)

--- a/guides/edenai.md
+++ b/guides/edenai.md
@@ -1,0 +1,48 @@
+# Eden AI
+
+To use [Eden AI](https://www.edenai.co) with `aisuite`, you'll need an [Eden AI account](https://app.edenai.run). After logging in, open your account settings and generate an API key. Once you have your key, add it to your environment as follows:
+
+```shell
+export EDENAI_API_KEY="your-edenai-api-key"
+```
+
+Eden AI is an EU-hosted, OpenAI-compatible gateway that exposes 100+ models from many providers through a single API key. Models use the `provider/model` naming scheme (e.g. `anthropic/claude-sonnet-4-5`, `mistral/codestral-latest`).
+
+## Create a Chat Completion
+
+(Note: Eden AI uses an API format consistent with OpenAI, hence why we need to install `openai`.)
+
+Install the `openai` Python client:
+
+Example with pip:
+```shell
+pip install openai
+```
+
+Example with poetry:
+```shell
+poetry add openai
+```
+
+In your code:
+```python
+import aisuite as ai
+client = ai.Client()
+
+provider = "edenai"
+model_id = "anthropic/claude-sonnet-4-5"
+
+messages = [
+    {"role": "system", "content": "You are a helpful assistant."},
+    {"role": "user", "content": "What's the weather like in San Francisco?"},
+]
+
+response = client.chat.completions.create(
+    model=f"{provider}:{model_id}",
+    messages=messages,
+)
+
+print(response.choices[0].message.content)
+```
+
+Happy coding! If you'd like to contribute, please read our [Contributing Guide](../CONTRIBUTING.md).

--- a/tests/providers/test_edenai_provider.py
+++ b/tests/providers/test_edenai_provider.py
@@ -1,0 +1,103 @@
+"""Tests for the Eden AI provider."""
+
+from unittest.mock import MagicMock, patch
+import pytest
+
+from aisuite.providers.edenai_provider import EdenaiProvider
+from aisuite.framework.chat_completion_response import ChatCompletionResponse
+
+
+@pytest.fixture(autouse=True)
+def set_api_key_env_var(monkeypatch):
+    """Fixture to set the Eden AI API key environment variable for tests."""
+    monkeypatch.setenv("EDENAI_API_KEY", "test-api-key")
+
+
+def test_edenai_provider():
+    """Test that the provider is initialized and chat completions are requested."""
+
+    user_greeting = "Hello!"
+    message_history = [{"role": "user", "content": user_greeting}]
+    selected_model = "anthropic/claude-sonnet-4-5"
+    chosen_temperature = 0.75
+    response_text_content = "mocked-text-response-from-model"
+
+    provider = EdenaiProvider()
+    assert provider.client.base_url.host == "api.edenai.run"
+
+    mock_response = MagicMock()
+    mock_response.model_dump.return_value = {
+        "choices": [
+            {"message": {"content": response_text_content, "role": "assistant"}}
+        ],
+        "model": selected_model,
+        "created": 12345,
+        "id": "chatcmpl-mockid",
+    }
+
+    with patch.object(
+        provider.client.chat.completions, "create", return_value=mock_response
+    ) as mock_create:
+        response = provider.chat_completions_create(
+            messages=message_history,
+            model=selected_model,
+            temperature=chosen_temperature,
+        )
+
+        mock_create.assert_called_once_with(
+            messages=message_history,
+            model=selected_model,
+            temperature=chosen_temperature,
+        )
+
+        assert isinstance(response, ChatCompletionResponse)
+        assert response.choices[0].message.content == response_text_content
+        assert response.usage is None
+
+
+def test_edenai_provider_with_usage():
+    """Tests that usage data is correctly parsed when present in the response."""
+
+    user_greeting = "Hello!"
+    message_history = [{"role": "user", "content": user_greeting}]
+    selected_model = "anthropic/claude-sonnet-4-5"
+    chosen_temperature = 0.75
+    response_text_content = "mocked-text-response-from-model"
+
+    provider = EdenaiProvider()
+    mock_response = MagicMock()
+    mock_response.model_dump.return_value = {
+        "choices": [
+            {"message": {"content": response_text_content, "role": "assistant"}}
+        ],
+        "model": selected_model,
+        "created": 12345,
+        "id": "chatcmpl-mockid",
+        "usage": {
+            "prompt_tokens": 10,
+            "completion_tokens": 20,
+            "total_tokens": 30,
+        },
+    }
+
+    with patch.object(
+        provider.client.chat.completions, "create", return_value=mock_response
+    ) as mock_create:
+        response = provider.chat_completions_create(
+            messages=message_history,
+            model=selected_model,
+            temperature=chosen_temperature,
+        )
+
+        mock_create.assert_called_once_with(
+            messages=message_history,
+            model=selected_model,
+            temperature=chosen_temperature,
+        )
+
+        assert isinstance(response, ChatCompletionResponse)
+        assert response.choices[0].message.content == response_text_content
+        assert response.usage is not None
+        assert response.usage.prompt_tokens == 10
+        assert response.usage.completion_tokens == 20
+        assert response.usage.total_tokens == 30


### PR DESCRIPTION
## Description

Adds **Eden AI** (https://www.edenai.co) as a provider. Eden AI is an EU-hosted, OpenAI-compatible gateway that exposes 100+ models from many providers (OpenAI, Anthropic, Google, Mistral, DeepSeek, …) through a single API key. Models use the `provider/model` naming scheme.

Mirrors the existing DeepSeek provider — Eden AI is OpenAI-compatible, so it reuses the `openai` client with `base_url = https://api.edenai.run/v3` and the `OpenAICompliantMessageConverter`. The provider is auto-discovered by `ProviderFactory` (no extra registration needed).

- `aisuite/providers/edenai_provider.py` — `EdenaiProvider`
- `tests/providers/test_edenai_provider.py` — unit tests (mirrors the DeepSeek tests)
- `guides/edenai.md` + an entry in `guides/README.md`

## Usage

```python
import aisuite as ai
client = ai.Client()

response = client.chat.completions.create(
    model="edenai:anthropic/claude-sonnet-4-5",
    messages=[{"role": "user", "content": "Hello!"}],
)
print(response.choices[0].message.content)
```

## Testing

- `edenai` shows up in `ProviderFactory.get_supported_providers()` and `create_provider("edenai")` returns `EdenaiProvider`.
- `pytest tests/providers/test_edenai_provider.py` passes (mock-based, mirrors DeepSeek).
- Verified live end-to-end through the aisuite client (`edenai:mistral/mistral-small-latest` → real response).
- API key via `EDENAI_API_KEY` env var (or config); never hardcoded.
