### PR TITLE
Add Requesty provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@
 └────────┴───────────┴────────┴────────┴────────┘
 ```
 
-* **[Chat Completions API](#chat-completions)** — a unified, OpenAI-style interface for *OpenAI, Anthropic, Google, Mistral, Hugging Face, AWS, Cohere, Ollama, OpenRouter*, and more. Swap providers by changing one string.
+* **[Chat Completions API](#chat-completions)** — a unified, OpenAI-style interface for *OpenAI, Anthropic, Google, Mistral, Hugging Face, AWS, Cohere, Ollama, OpenRouter, Requesty*, and more. Swap providers by changing one string.
 * **[Agents API · Toolkits · MCP](#agents)** — give models real Python functions as tools, run multi-turn loops, attach ready-made toolkits (files, git, shell) or any MCP server, and govern it all with tool policies.
 * **[OpenCoworker](docs/opencoworker-quickstart.md)** — a desktop AI coworker built using aisuite, shipped as an app for everyday tasks.
 

--- a/aisuite/providers/requesty_provider.py
+++ b/aisuite/providers/requesty_provider.py
@@ -1,0 +1,49 @@
+import openai
+import os
+from aisuite.provider import Provider, LLMError
+from aisuite.providers.message_converter import OpenAICompliantMessageConverter
+
+
+class RequestyProvider(Provider):
+    def __init__(self, **config):
+        """
+        Initialize the Requesty provider with the given configuration.
+        Pass the entire configuration dictionary to the OpenAI client constructor.
+        """
+        # Ensure API key is provided either in config or via environment variable
+        config.setdefault("api_key", os.getenv("REQUESTY_API_KEY"))
+        config.setdefault("base_url", "https://router.requesty.ai/v1")
+
+        # Support optional Requesty attribution headers
+        default_headers = config.get("default_headers", {})
+        if os.getenv("REQUESTY_SITE_URL") and "HTTP-Referer" not in default_headers:
+            default_headers["HTTP-Referer"] = os.getenv("REQUESTY_SITE_URL")
+        if os.getenv("REQUESTY_APP_NAME") and "X-Title" not in default_headers:
+            default_headers["X-Title"] = os.getenv("REQUESTY_APP_NAME")
+
+        if default_headers:
+            config["default_headers"] = default_headers
+
+        if not config["api_key"]:
+            raise ValueError(
+                "Requesty API key is missing. Please provide it in the config or set the REQUESTY_API_KEY environment variable."
+            )
+
+        self.client = openai.OpenAI(**config)
+        self.transformer = OpenAICompliantMessageConverter()
+
+        super().__init__()
+
+    def chat_completions_create(self, model, messages, **kwargs):
+        # Any exception raised by Requesty will be returned to the caller.
+        # Maybe we should catch them and raise a custom LLMError.
+        try:
+            transformed_messages = self.transformer.convert_request(messages)
+            response = self.client.chat.completions.create(
+                model=model,
+                messages=transformed_messages,
+                **kwargs,  # Pass any additional arguments to the Requesty API
+            )
+            return response
+        except Exception as e:
+            raise LLMError(f"An error occurred: {e}")

--- a/tests/providers/test_requesty_provider.py
+++ b/tests/providers/test_requesty_provider.py
@@ -1,0 +1,104 @@
+"""Tests for Requesty provider functionality."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from aisuite.providers.requesty_provider import RequestyProvider
+from aisuite.provider import LLMError
+from aisuite.providers.message_converter import OpenAICompliantMessageConverter
+
+
+@pytest.fixture(autouse=True)
+def set_env_vars(monkeypatch):
+    """Fixture to set environment variables for tests."""
+    monkeypatch.setenv("REQUESTY_API_KEY", "test-requesty-api-key")
+    monkeypatch.setenv("REQUESTY_SITE_URL", "https://my-test-site.com")
+    monkeypatch.setenv("REQUESTY_APP_NAME", "TestApp")
+
+
+@pytest.fixture
+def requesty_provider():
+    """Create a Requesty provider instance for testing."""
+    return RequestyProvider()
+
+
+class TestRequestyProvider:
+    """Test suite for Requesty provider initialization."""
+
+    def test_provider_initialization(self, requesty_provider):
+        """Test that Requesty provider initializes correctly."""
+        assert requesty_provider is not None
+        assert hasattr(requesty_provider, "client")
+        assert hasattr(requesty_provider, "transformer")
+        # Ensure the base URL is properly overridden for Requesty
+        assert (
+            str(requesty_provider.client.base_url) == "https://router.requesty.ai/v1/"
+        )
+
+    def test_provider_missing_api_key(self, monkeypatch):
+        """Test initialization fails when API key is missing."""
+        monkeypatch.delenv("REQUESTY_API_KEY", raising=False)
+        with pytest.raises(ValueError, match="Requesty API key is missing"):
+            RequestyProvider()
+
+
+class TestRequestyChatCompletions:
+    """Test suite for Requesty chat completions functionality."""
+
+    @patch("openai.OpenAI")
+    @patch.object(OpenAICompliantMessageConverter, "convert_request")
+    def test_chat_completions_create_success(
+        self, mock_convert, mock_openai_class, requesty_provider
+    ):
+        """Test successful chat completion request."""
+        # Setup mock client and response
+        mock_client_instance = mock_openai_class.return_value
+        mock_response = MagicMock()
+        mock_client_instance.chat.completions.create.return_value = mock_response
+
+        # Inject the mock client into our provider
+        requesty_provider.client = mock_client_instance
+
+        # Mock the message converter
+        mock_converted_messages = [{"role": "user", "content": "Transformed"}]
+        mock_convert.return_value = mock_converted_messages
+
+        original_messages = [{"role": "user", "content": "Hello"}]
+
+        # Execute the method
+        result = requesty_provider.chat_completions_create(
+            model="requesty:openai/gpt-4o-mini",
+            messages=original_messages,
+            temperature=0.7,
+        )
+
+        # Assertions
+        mock_convert.assert_called_once_with(original_messages)
+        mock_client_instance.chat.completions.create.assert_called_once_with(
+            model="requesty:openai/gpt-4o-mini",
+            messages=mock_converted_messages,
+            temperature=0.7,
+        )
+        assert result == mock_response
+
+    @patch("openai.OpenAI")
+    def test_chat_completions_create_error_handling(
+        self, mock_openai_class, requesty_provider
+    ):
+        """Test error handling for API failures."""
+        # Setup mock client to throw an exception
+        mock_client_instance = mock_openai_class.return_value
+        mock_client_instance.chat.completions.create.side_effect = Exception(
+            "API Error"
+        )
+
+        # Inject the mock client
+        requesty_provider.client = mock_client_instance
+
+        # Execute and assert the custom LLMError is raised
+        with pytest.raises(LLMError, match="An error occurred: API Error"):
+            requesty_provider.chat_completions_create(
+                model="requesty:openai/gpt-4o-mini",
+                messages=[{"role": "user", "content": "Hello"}],
+            )


### PR DESCRIPTION
## Summary

Adds a dedicated `requesty` provider that mirrors the existing OpenRouter provider.

[Requesty](https://requesty.ai) is an OpenAI-compatible LLM router (like OpenRouter). Because the API is OpenAI-compatible, the provider reuses the `openai` client and the shared `OpenAICompliantMessageConverter`, exactly as `openrouter_provider.py` does.

## Details

`aisuite/providers/requesty_provider.py` (`RequestyProvider`):
- Reads `REQUESTY_API_KEY` from the environment (overridable via config), raising a clear `ValueError` when missing.
- Fixed base URL `https://router.requesty.ai/v1`.
- Optional attribution headers `HTTP-Referer` / `X-Title` sourced from `REQUESTY_SITE_URL` / `REQUESTY_APP_NAME`.
- Works with the existing `provider:model` naming, e.g. `requesty:openai/gpt-4o-mini`. The provider is auto-discovered by `ProviderFactory` via the `*_provider.py` filename convention, so no registry change is needed.

Also:
- `tests/providers/test_requesty_provider.py` mirrors the OpenRouter provider tests (initialization, missing-key error, chat-completion success, error handling).
- README provider summary now lists Requesty alongside the other providers.

## Testing

- `ruff check` / `ruff format --check` pass on the new files.
- `pytest tests/providers/test_requesty_provider.py` — 4 passed. Existing `test_openrouter_provider.py` still passes.
- Live-tested end to end through the aisuite code path against the Requesty router:

```python
import aisuite as ai
client = ai.Client()
r = client.chat.completions.create(
    model="requesty:openai/gpt-4o-mini",
    messages=[{"role": "user", "content": "..."}],
    max_tokens=16,
)
# returns a normal OpenAI-shaped completion (model: gpt-4o-mini-2024-07-18)
```

Docs: https://requesty.ai · https://docs.requesty.ai · https://app.requesty.ai/api-keys · https://app.requesty.ai/router/list

I work at Requesty. This mirrors the existing OpenRouter provider as closely as possible. Happy to adjust or close it if it's not a fit.
