### PR TITLE
Feat/add litellm provider

### DIFF
--- a/aisuite/providers/litellm_provider.py
+++ b/aisuite/providers/litellm_provider.py
@@ -1,0 +1,87 @@
+"""LiteLLM provider for aisuite — access 300+ LLM providers through a single interface."""
+
+import os
+from aisuite.provider import Provider, LLMError
+from aisuite.providers.message_converter import OpenAICompliantMessageConverter
+
+
+class LitellmProvider(Provider):
+    """Provider that routes completions through LiteLLM.
+
+    Users can pass any LiteLLM-supported model string as the model name
+    (e.g. ``anthropic/claude-sonnet-4-6``, ``vertex_ai/gemini-2.5-pro``,
+    ``bedrock/anthropic.claude-3-haiku``).
+
+    When running against a self-hosted LiteLLM proxy, set ``base_url``
+    in the provider config and supply the proxy master key via
+    ``api_key`` or the ``LITELLM_API_KEY`` environment variable.
+    """
+
+    def __init__(self, **config):
+        self.api_key = config.pop("api_key", None) or os.getenv("LITELLM_API_KEY")
+        self.base_url = config.pop("base_url", None) or os.getenv("LITELLM_BASE_URL")
+        self.drop_params = config.pop("drop_params", True)
+        self.extra_config = config
+        self.transformer = OpenAICompliantMessageConverter()
+
+    def chat_completions_create(self, model, messages, **kwargs):
+        try:
+            import litellm
+        except ImportError:
+            raise ImportError(
+                "The litellm package is required for the LiteLLM provider. "
+                "Install it with: pip install 'aisuite[litellm]'"
+            )
+
+        try:
+            transformed_messages = self.transformer.convert_request(messages)
+
+            call_kwargs = {
+                "model": model,
+                "messages": transformed_messages,
+                "drop_params": self.drop_params,
+                **self.extra_config,
+                **kwargs,
+            }
+            if self.api_key:
+                call_kwargs["api_key"] = self.api_key
+            if self.base_url:
+                call_kwargs["api_base"] = self.base_url
+
+            response = litellm.completion(**call_kwargs)
+            return self.transformer.convert_response(response.model_dump())
+        except ImportError:
+            raise
+        except Exception as e:
+            raise LLMError(f"An error occurred: {e}") from e
+
+    async def achat_completions_create(self, model, messages, **kwargs):
+        try:
+            import litellm
+        except ImportError:
+            raise ImportError(
+                "The litellm package is required for the LiteLLM provider. "
+                "Install it with: pip install 'aisuite[litellm]'"
+            )
+
+        try:
+            transformed_messages = self.transformer.convert_request(messages)
+
+            call_kwargs = {
+                "model": model,
+                "messages": transformed_messages,
+                "drop_params": self.drop_params,
+                **self.extra_config,
+                **kwargs,
+            }
+            if self.api_key:
+                call_kwargs["api_key"] = self.api_key
+            if self.base_url:
+                call_kwargs["api_base"] = self.base_url
+
+            response = await litellm.acompletion(**call_kwargs)
+            return self.transformer.convert_response(response.model_dump())
+        except ImportError:
+            raise
+        except Exception as e:
+            raise LLMError(f"An error occurred: {e}") from e

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ docstring-parser = { version = ">=0.16,<1.0" }
 pydantic = { version = "^2.10.0" }
 cerebras_cloud_sdk = { version = "^1.19.0", optional = true }
 openai = { version = "^1.107.0", optional = true }
+litellm = { version = ">=1.60,<2.0", optional = true }
 mcp = { version = "^1.1.2", optional = true }
 nest-asyncio = { version = "^1.6.0", optional = true }
 psycopg = { version = "^3.3.4", optional = true }
@@ -47,9 +48,10 @@ ollama = ["openai"]
 lmstudio = ["openai"]
 openai = ["openai"]
 watsonx = ["ibm-watsonx-ai"]
+litellm = ["litellm"]
 mcp = ["mcp", "nest-asyncio"]
 postgres = ["psycopg"]
-all = ["anthropic", "boto3", "cerebras_cloud_sdk", "vertexai", "google-cloud-speech", "groq", "mistralai", "openai", "cohere", "ibm-watsonx-ai", "deepgram-sdk", "soundfile", "scipy", "numpy", "mcp", "nest-asyncio", "psycopg"]  # To install all providers
+all = ["anthropic", "boto3", "cerebras_cloud_sdk", "vertexai", "google-cloud-speech", "groq", "mistralai", "openai", "cohere", "ibm-watsonx-ai", "deepgram-sdk", "soundfile", "scipy", "numpy", "litellm", "mcp", "nest-asyncio", "psycopg"]  # To install all providers
 
 [tool.poetry.group.dev.dependencies]
 pre-commit = "^3.7.1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ docstring-parser = { version = ">=0.16,<1.0" }
 pydantic = { version = "^2.10.0" }
 cerebras_cloud_sdk = { version = "^1.19.0", optional = true }
 openai = { version = "^1.107.0", optional = true }
-litellm = { version = ">=1.60,<2.0", optional = true }
+litellm = { version = ">=1.83.0,<2.0", optional = true }
 mcp = { version = "^1.1.2", optional = true }
 nest-asyncio = { version = "^1.6.0", optional = true }
 psycopg = { version = "^3.3.4", optional = true }

--- a/tests/providers/test_litellm_provider.py
+++ b/tests/providers/test_litellm_provider.py
@@ -1,0 +1,166 @@
+"""Tests for the LiteLLM provider."""
+
+import sys
+import types
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def set_api_key_env_var(monkeypatch):
+    """Fixture to set environment variables for tests."""
+    monkeypatch.setenv("LITELLM_API_KEY", "test-api-key")
+
+
+@pytest.fixture(autouse=True)
+def stub_litellm(monkeypatch):
+    """Stub the litellm module so tests run without the real package."""
+    fake = types.ModuleType("litellm")
+    fake.completion = MagicMock(name="litellm.completion")
+    fake.acompletion = MagicMock(name="litellm.acompletion")
+    monkeypatch.setitem(sys.modules, "litellm", fake)
+    return fake
+
+
+def test_litellm_provider():
+    """Test that the provider initializes and dispatches chat completions."""
+    from aisuite.providers.litellm_provider import LitellmProvider
+
+    message_history = [{"role": "user", "content": "Hello!"}]
+    selected_model = "anthropic/claude-sonnet-4-6"
+    response_text = "mocked-text-response-from-model"
+
+    provider = LitellmProvider()
+
+    mock_response = MagicMock()
+    mock_response.model_dump.return_value = {
+        "choices": [{"message": {"content": response_text, "role": "assistant"}}]
+    }
+
+    with patch("litellm.completion", return_value=mock_response) as mock_completion:
+        response = provider.chat_completions_create(
+            model=selected_model,
+            messages=message_history,
+            temperature=0.7,
+        )
+
+        mock_completion.assert_called_once()
+        call_kwargs = mock_completion.call_args
+        assert call_kwargs.kwargs["model"] == selected_model
+        assert call_kwargs.kwargs["drop_params"] is True
+        assert call_kwargs.kwargs["temperature"] == 0.7
+        assert response.choices[0].message.content == response_text
+
+
+def test_litellm_provider_with_usage():
+    """Test that usage data is correctly parsed when present."""
+    from aisuite.providers.litellm_provider import LitellmProvider
+
+    provider = LitellmProvider()
+
+    mock_response = MagicMock()
+    mock_response.model_dump.return_value = {
+        "choices": [{"message": {"content": "response", "role": "assistant"}}],
+        "usage": {
+            "prompt_tokens": 10,
+            "completion_tokens": 20,
+            "total_tokens": 30,
+        },
+    }
+
+    with patch("litellm.completion", return_value=mock_response):
+        response = provider.chat_completions_create(
+            model="openai/gpt-4o",
+            messages=[{"role": "user", "content": "Hi"}],
+        )
+
+        assert response.usage is not None
+        assert response.usage.prompt_tokens == 10
+        assert response.usage.completion_tokens == 20
+        assert response.usage.total_tokens == 30
+
+
+def test_litellm_provider_forwards_api_key():
+    """Test that api_key is forwarded when set."""
+    from aisuite.providers.litellm_provider import LitellmProvider
+
+    provider = LitellmProvider(api_key="sk-custom-key")
+
+    mock_response = MagicMock()
+    mock_response.model_dump.return_value = {
+        "choices": [{"message": {"content": "ok", "role": "assistant"}}]
+    }
+
+    with patch("litellm.completion", return_value=mock_response) as mock_completion:
+        provider.chat_completions_create(
+            model="openai/gpt-4o",
+            messages=[{"role": "user", "content": "Hi"}],
+        )
+
+        call_kwargs = mock_completion.call_args.kwargs
+        assert call_kwargs["api_key"] == "sk-custom-key"
+
+
+def test_litellm_provider_forwards_base_url():
+    """Test that base_url is forwarded as api_base when set."""
+    from aisuite.providers.litellm_provider import LitellmProvider
+
+    provider = LitellmProvider(base_url="http://localhost:4000")
+
+    mock_response = MagicMock()
+    mock_response.model_dump.return_value = {
+        "choices": [{"message": {"content": "ok", "role": "assistant"}}]
+    }
+
+    with patch("litellm.completion", return_value=mock_response) as mock_completion:
+        provider.chat_completions_create(
+            model="openai/gpt-4o",
+            messages=[{"role": "user", "content": "Hi"}],
+        )
+
+        call_kwargs = mock_completion.call_args.kwargs
+        assert call_kwargs["api_base"] == "http://localhost:4000"
+
+
+def test_litellm_provider_omits_api_key_when_empty():
+    """Test that api_key is omitted when not set, letting litellm read provider env vars."""
+    from aisuite.providers.litellm_provider import LitellmProvider
+
+    provider = LitellmProvider(api_key=None)
+    provider.api_key = None
+
+    mock_response = MagicMock()
+    mock_response.model_dump.return_value = {
+        "choices": [{"message": {"content": "ok", "role": "assistant"}}]
+    }
+
+    with patch("litellm.completion", return_value=mock_response) as mock_completion:
+        provider.chat_completions_create(
+            model="anthropic/claude-haiku",
+            messages=[{"role": "user", "content": "Hi"}],
+        )
+
+        call_kwargs = mock_completion.call_args.kwargs
+        assert "api_key" not in call_kwargs
+
+
+def test_litellm_provider_drop_params_override():
+    """Test that drop_params can be overridden to False."""
+    from aisuite.providers.litellm_provider import LitellmProvider
+
+    provider = LitellmProvider(drop_params=False)
+
+    mock_response = MagicMock()
+    mock_response.model_dump.return_value = {
+        "choices": [{"message": {"content": "ok", "role": "assistant"}}]
+    }
+
+    with patch("litellm.completion", return_value=mock_response) as mock_completion:
+        provider.chat_completions_create(
+            model="openai/gpt-4o",
+            messages=[{"role": "user", "content": "Hi"}],
+        )
+
+        call_kwargs = mock_completion.call_args.kwargs
+        assert call_kwargs["drop_params"] is False


### PR DESCRIPTION
## Summary

- Adds LiteLLM as a new provider, giving aisuite access to 300+ LLM providers (OpenAI, Anthropic, Azure, Bedrock, Vertex, Groq, Together, Mistral, Cohere, and more) through LiteLLM's unified interface
- No hardcoded models - works with any model string LiteLLM supports; users bring whatever models are on their gateway


## Changes

| File | Description |
|------|-------------|
| `aisuite/providers/litellm_provider.py` | New `LitellmProvider` (87 lines) implementing sync `chat_completions_create()` and async `achat_completions_create()` via `litellm.completion` / `litellm.acompletion` |
| `tests/providers/test_litellm_provider.py` | 6 unit tests covering dispatch, drop_params, api_key/base_url forwarding, usage parsing |
| `pyproject.toml` | Added `litellm>=1.83.0,<2.0` as optional dep under `[litellm]` extra, included in `[all]` |

## Design decisions

- **`drop_params=True` by default** - silently drops provider-unsupported kwargs (`seed`, `strict`, `presence_penalty`, etc.) so the same aisuite call works across all providers without 400 errors. Opt-out via `drop_params=False` in provider config
- **Lazy import** - `litellm` is imported inside the method bodies, not at module level. Users who don't install `aisuite[litellm]` get a clear `ImportError` with install instructions
- **Auto-registers via naming convention** - `LitellmProvider` in `litellm_provider.py` matches aisuite's `ProviderFactory` dynamic loading pattern, no explicit registry entry needed
- **Reuses `OpenAICompliantMessageConverter`** - LiteLLM returns OpenAI-compatible responses, so the existing message converter works as-is

## Tests

**1. Unit tests (6/6 pass):**
```
tests/providers/test_litellm_provider.py::test_litellm_provider PASSED
tests/providers/test_litellm_provider.py::test_litellm_provider_with_usage PASSED
tests/providers/test_litellm_provider.py::test_litellm_provider_forwards_api_key PASSED
tests/providers/test_litellm_provider.py::test_litellm_provider_forwards_base_url PASSED
tests/providers/test_litellm_provider.py::test_litellm_provider_omits_api_key_when_empty PASSED
tests/providers/test_litellm_provider.py::test_litellm_provider_drop_params_override PASSED
```

**2. Live E2E via local LiteLLM proxy (localhost:4000):**
```
=== AISUITE via local proxy ===
Response: 8
AISUITE PROXY PASSED
```
Full chain verified: `client.chat.completions.create("litellm:openai/claude-sonnet")` -> `litellm.completion()` -> LiteLLM proxy -> Azure Foundry -> response parsed.

**3. Live E2E direct SDK call:**
```
=== AISUITE E2E ===
Response: The capital of France is **Paris**.
AISUITE E2E PASSED
```

## Risk / Compatibility

- Additive only - no existing providers modified
- `litellm` is an optional extra (`pip install aisuite[litellm]`) - base install unaffected
- Follows the same `Provider` interface as all existing providers

## Example usage

```python
import aisuite as ai

# Direct provider access (litellm reads ANTHROPIC_API_KEY from env)
client = ai.Client()
response = client.chat.completions.create(
    model="litellm:anthropic/claude-sonnet-4-6",
    messages=[{"role": "user", "content": "Hello!"}],
)
print(response.choices[0].message.content)

# Via self-hosted LiteLLM proxy
client = ai.Client(provider_configs={
    "litellm": {
        "api_key": "sk-proxy-key",
        "base_url": "http://localhost:4000",
    }
})
response = client.chat.completions.create(
    model="litellm:openai/my-model",
    messages=[{"role": "user", "content": "Hello!"}],
)
```

```bash
# Install
pip install 'aisuite[litellm]'

# Set provider key (litellm reads it automatically)
export ANTHROPIC_API_KEY="sk-..."
```
