### PR TITLE
OCW/Slack: attribute outbound posts to the workspace's installer

### DIFF
--- a/platform/coworker/connectors/attribution.py
+++ b/platform/coworker/connectors/attribution.py
@@ -1,0 +1,72 @@
+"""Sender attribution for outbound Slack posts (P1, 2026-07-14).
+
+Multiple people can run OpenCoworker into the same channel, and every one of their
+posts arrives as the same @ocw bot. The managed OAuth install already records WHO
+connected each workspace — Slack's `authed_user` — so outbound text carries
+"[<their name>] " per workspace: the member id rides the install form-POST into the
+`slack:team:<id>` profile, and the display name is resolved once via `users.info`
+(scope `users:read`, granted since wave 1) and cached on that profile.
+
+Truthfulness rules: manual Socket-Mode installs have no authed_user, so there is
+nothing to attribute and their posts stay bare; DMs skip the prefix (a 1:1 with the
+bot has no ambiguity); and attribution NEVER blocks a send — any resolution failure
+degrades to no prefix. P2 (chat:write.customize) replaces the text prefix with a
+native username override.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Optional
+
+from ..secrets import SecretStore
+
+_TIMEOUT = 10.0
+
+
+def _api_base() -> str:
+    return os.environ.get("SLACK_API_URL", "https://slack.com/api/")
+
+
+def _fetch_display_name(token: str, user_id: str) -> Optional[str]:
+    """users.info → the human's name (display name, else real name). None on any failure."""
+    import httpx
+
+    try:
+        resp = httpx.get(
+            f"{_api_base()}users.info",
+            params={"user": user_id},
+            headers={"Authorization": f"Bearer {token}"},
+            timeout=_TIMEOUT,
+        )
+        data = resp.json()
+    except Exception:
+        return None
+    if not data.get("ok"):
+        return None
+    user = data.get("user") or {}
+    profile = user.get("profile") or {}
+    name = profile.get("display_name") or profile.get("real_name") or user.get("name")
+    return str(name).strip() or None if name else None
+
+
+def sender_prefix(secrets: SecretStore, chat_id: str) -> str:
+    """'[Rohit] ' for a Slack chat_id whose workspace install knows its human, else ''."""
+    from .slack_addr import split
+
+    team, channel = split(chat_id)
+    if channel.startswith("D"):  # DM with the bot — nothing to disambiguate
+        return ""
+    key = f"slack:team:{team}" if team else "slack:default"
+    profile = secrets.get(key) or {}
+    name = profile.get("sender_name")
+    if not name:
+        user_id, token = profile.get("slack_user_id"), profile.get("bot_token")
+        if not user_id or not token:
+            return ""
+        name = _fetch_display_name(str(token), str(user_id))
+        if not name:
+            return ""
+        profile["sender_name"] = name
+        secrets.put(key, profile)
+    return f"[{name}] "

--- a/platform/coworker/connectors/setup.py
+++ b/platform/coworker/connectors/setup.py
@@ -401,6 +401,9 @@ def managed_connect_slack_install(
             "managed": True,
             "bot_token": bot_token,
             "bot_user_id": form.get("bot_user_id", ""),
+            # The INSTALLER's Slack member id (authed_user) — who this workspace's
+            # outbound posts speak for (attribution.py resolves + caches the name).
+            "slack_user_id": form.get("slack_user_id", ""),
             "team_id": team_id,
             "account": form.get("account", ""),
             # The workspace's slack.com subdomain (broker resolves it via auth.test)

--- a/platform/coworker/connectors/tools.py
+++ b/platform/coworker/connectors/tools.py
@@ -155,6 +155,10 @@ def make_send_message_tool(
         token = _resolve_token(secrets, platform, chat_id)
         if not token:
             return {"error": f"no bot token for {platform} — connect it first"}
+        if platform == "slack":
+            from .attribution import sender_prefix
+
+            text = sender_prefix(secrets, chat_id) + text
         result = sender(token, chat_id, text, thread_id)
         if result.ok:
             return {"ok": True, "message_id": result.message_id, "target": target}
@@ -309,6 +313,10 @@ def make_send_file_tool(
                 return {"error": "file is larger than 50 MB"}
             data = resolved.read_bytes()
             filename = resolved.name
+        if platform == "slack" and comment:
+            from .attribution import sender_prefix
+
+            comment = sender_prefix(secrets, chat_id) + comment
         result = sender(token, chat_id, thread_id, filename, data, title, comment)
         if result.ok:
             return {"ok": True, "file_id": result.message_id, "target": target, "filename": filename}

--- a/platform/tests/test_sender_attribution.py
+++ b/platform/tests/test_sender_attribution.py
@@ -1,0 +1,117 @@
+"""P1 sender attribution (2026-07-14): outbound Slack posts carry "[<installer>] " so
+channels shared by several OpenCoworker users can tell whose coworker is speaking.
+Identity = the managed install's authed_user (plumbed broker → form-POST → team
+profile), name resolved once via users.info and cached. Attribution never blocks a
+send; manual installs (no authed_user) and DMs stay bare."""
+
+from coworker.connectors import attribution
+from coworker.connectors.base import SendResult
+from coworker.connectors.setup import managed_connect_slack_install
+from coworker.connectors.tools import make_send_file_tool, make_send_message_tool
+from coworker.secrets import SecretStore
+
+
+def _secrets(tmp_path, **team_extra) -> SecretStore:
+    s = SecretStore(tmp_path / "secrets.json")
+    s.put("slack:team:T1", {"bot_token": "xoxb-t1", "account": "acme", **team_extra})
+    return s
+
+
+def _sender(record: list):
+    def send(token, chat_id, text, thread_id):
+        record.append(text)
+        return SendResult(True, message_id="1.2")
+
+    return {"slack": send}
+
+
+def test_install_stores_the_installers_member_id(tmp_path):
+    s = SecretStore(tmp_path / "secrets.json")
+    managed_connect_slack_install(
+        s,
+        {"team_id": "T1", "access_token": "xoxb-x", "slack_user_id": "U777"},
+    )
+    assert s.get("slack:team:T1")["slack_user_id"] == "U777"
+
+
+def test_cached_name_prefixes_text_sends(tmp_path):
+    s = _secrets(tmp_path, sender_name="Rohit")
+    record: list = []
+    tool = make_send_message_tool(s, senders=_sender(record))
+
+    assert tool("slack:T1/C9", "shipping the report now")["ok"] is True
+    assert record == ["[Rohit] shipping the report now"]
+
+
+def test_name_is_resolved_once_via_users_info_and_cached(tmp_path, monkeypatch):
+    s = _secrets(tmp_path, slack_user_id="U777")
+    calls: list = []
+
+    def fake_fetch(token, user_id):
+        calls.append((token, user_id))
+        return "Rohit"
+
+    monkeypatch.setattr(attribution, "_fetch_display_name", fake_fetch)
+    record: list = []
+    tool = make_send_message_tool(s, senders=_sender(record))
+
+    tool("slack:T1/C9", "one")
+    tool("slack:T1/C9", "two")
+    assert record == ["[Rohit] one", "[Rohit] two"]
+    assert calls == [("xoxb-t1", "U777")]  # second send hit the cache
+    assert s.get("slack:team:T1")["sender_name"] == "Rohit"
+
+
+def test_no_identity_and_dms_and_failures_stay_bare(tmp_path, monkeypatch):
+    # manual install: no authed_user recorded → nothing truthful to attribute
+    s = _secrets(tmp_path)
+    record: list = []
+    tool = make_send_message_tool(s, senders=_sender(record))
+    tool("slack:T1/C9", "hi")
+    assert record == ["hi"]
+
+    # a DM with the bot has no ambiguity — even with a cached name
+    s2 = _secrets(tmp_path.joinpath("b"), sender_name="Rohit")
+    record2: list = []
+    tool2 = make_send_message_tool(s2, senders=_sender(record2))
+    tool2("slack:T1/D555", "hi")
+    assert record2 == ["hi"]
+
+    # users.info failing must degrade to no prefix, never block the send
+    s3 = _secrets(tmp_path.joinpath("c"), slack_user_id="U777")
+    monkeypatch.setattr(attribution, "_fetch_display_name", lambda t, u: None)
+    record3: list = []
+    tool3 = make_send_message_tool(s3, senders=_sender(record3))
+    assert tool3("slack:T1/C9", "hi")["ok"] is True
+    assert record3 == ["hi"] and "sender_name" not in s3.get("slack:team:T1")
+
+
+def test_telegram_is_never_prefixed(tmp_path):
+    s = SecretStore(tmp_path / "secrets.json")
+    s.put("telegram:default", {"bot_token": "tg-token"})
+    record: list = []
+
+    def send(token, chat_id, text, thread_id):
+        record.append(text)
+        return SendResult(True, message_id="9")
+
+    tool = make_send_message_tool(s, senders={"telegram": send})
+    tool("telegram:12345", "hi")
+    assert record == ["hi"]
+
+
+def test_send_file_comment_is_prefixed_but_absent_comment_stays_absent(tmp_path):
+    s = _secrets(tmp_path, sender_name="Rohit")
+    ws = tmp_path / "ws"
+    ws.mkdir()
+    (ws / "r.pdf").write_bytes(b"%PDF")
+    record: list = []
+
+    def file_sender(token, chat_id, thread_id, filename, data, title, comment):
+        record.append(comment)
+        return SendResult(True, message_id="F1")
+
+    tool = make_send_file_tool(s, workspace=ws, file_senders={"slack": file_sender})
+    assert tool("slack:T1/C9", "r.pdf", comment="the report")["ok"] is True
+    assert tool("slack:T1/C9", "r.pdf")["ok"] is True
+    assert record == ["[Rohit] the report", None]


### PR DESCRIPTION
Outbound Slack posts (send_message text, send_file comments) are now attributed to the human who connected the workspace — "[Name] message" — so channels where several people run their own coworker can tell whose is speaking. The installer's member id is recorded at connect time, the display name is resolved once via users.info and cached; DMs, manual installs, and any resolution failure fall back to an unprefixed send.