### PR TITLE
Apply black formatting repo-wide

### DIFF
--- a/platform/coworker/automation/models.py
+++ b/platform/coworker/automation/models.py
@@ -38,7 +38,8 @@ def grant_entries(permissions: Any) -> list[str]:
     create payload) down to the entries actually grantable. Only `access: "write"` items
     become grants; the tool must declare a target argument (which excludes exec/destructive
     tools by construction) and the target must be non-empty. Reads are disclosure-only —
-    rendered on the consent card, never stored. Anything else is dropped, fail-closed."""
+    rendered on the consent card, never stored. Anything else is dropped, fail-closed.
+    """
     from ..connectors.tool_defs import target_arg_for
 
     entries: list[str] = []

--- a/platform/coworker/catalog.py
+++ b/platform/coworker/catalog.py
@@ -54,7 +54,8 @@ class Capability:
 
 def _code_files(context: AgentContext) -> list:
     """Repo-oriented files: single-root, line-numbered/windowed `read_file`. Our `grep` and
-    windowed `read_file` replace aisuite's slower `search_files` / `read_file`/`read_file_lines`."""
+    windowed `read_file` replace aisuite's slower `search_files` / `read_file`/`read_file_lines`.
+    """
     ws = str(context.workspace)
     replaced = {"search_files", "read_file", "read_file_lines"}
     files = [
@@ -67,7 +68,8 @@ def _code_files(context: AgentContext) -> list:
 
 def _files(context: AgentContext) -> list:
     """Knowledge-work files: multi-root aware (reads/writes across the session's roots), keeps
-    aisuite's `read_file`/`read_file_lines`. Only our `grep` replaces the slow `search_files`."""
+    aisuite's `read_file`/`read_file_lines`. Only our `grep` replaces the slow `search_files`.
+    """
     ws = str(context.workspace)
     file_kwargs = (
         {"roots": context.roots} if context.roots else {"root": ws, "allow_write": True}
@@ -160,7 +162,8 @@ def capability(cap_id: str) -> Capability:
 def expand(ids: list[str], context: AgentContext) -> list:
     """Expand a persona's ``tools:`` id list into concrete tool callables for this context.
     Capabilities whose context prerequisites aren't met are skipped (no shell without an
-    executor, no files without a workspace) — exactly like the old hand-written factories."""
+    executor, no files without a workspace) — exactly like the old hand-written factories.
+    """
     tools: list = []
     for cap_id in ids:
         cap = capability(cap_id)

--- a/platform/coworker/cloud.py
+++ b/platform/coworker/cloud.py
@@ -90,17 +90,20 @@ def begin_login(config: Config) -> dict[str, Any]:
     _pending_logins[state] = {"verifier": verifier, "created": _now()}
 
     redirect_uri = config.cloud_base_url.rstrip("/") + "/v1/auth/callback"
-    authorize_url = f"https://{config.cloud_auth_domain}/authorize?" + urllib.parse.urlencode(
-        {
-            "response_type": "code",
-            "client_id": config.cloud_client_id,
-            "redirect_uri": redirect_uri,
-            "scope": LOGIN_SCOPES,
-            "audience": config.cloud_audience,
-            "state": state,
-            "code_challenge": challenge,
-            "code_challenge_method": "S256",
-        }
+    authorize_url = (
+        f"https://{config.cloud_auth_domain}/authorize?"
+        + urllib.parse.urlencode(
+            {
+                "response_type": "code",
+                "client_id": config.cloud_client_id,
+                "redirect_uri": redirect_uri,
+                "scope": LOGIN_SCOPES,
+                "audience": config.cloud_audience,
+                "state": state,
+                "code_challenge": challenge,
+                "code_challenge_method": "S256",
+            }
+        )
     )
     return {"authorize_url": authorize_url, "state": state}
 
@@ -316,7 +319,8 @@ def emit_session_created(
             sys.platform, _platform.system().lower() or "unknown"
         ),
         "session": {
-            "session_id_hash": "sha256:" + hashlib.sha256(session_id.encode()).hexdigest(),
+            "session_id_hash": "sha256:"
+            + hashlib.sha256(session_id.encode()).hexdigest(),
             "persona_id": persona_id,
             "persona_family": persona_family,
             "workspace_kind": workspace_kind,
@@ -379,7 +383,11 @@ def begin_managed_connect(
         return {"ok": False, "error": f"cloud unreachable: {type(exc).__name__}"}
     if resp.status_code != 200:
         return {"ok": False, "error": f"start failed ({resp.status_code})"}
-    return {"ok": True, "authorize_url": resp.json()["authorize_url"], "app_state": app_state}
+    return {
+        "ok": True,
+        "authorize_url": resp.json()["authorize_url"],
+        "app_state": app_state,
+    }
 
 
 def managed_profile_from_callback(form: dict[str, str]) -> dict[str, Any]:
@@ -490,7 +498,8 @@ def cloud_disconnect(
         return
     try:
         httpx.post(
-            config.cloud_base_url.rstrip("/") + f"/v1/connections/{connection_id}/disconnect",
+            config.cloud_base_url.rstrip("/")
+            + f"/v1/connections/{connection_id}/disconnect",
             headers={"Authorization": f"Bearer {token}"},
             timeout=10,
         )
@@ -631,7 +640,8 @@ def gallery_install_event(secrets: SecretStore, config: Config, slug: str) -> No
         return
     try:
         httpx.post(
-            config.cloud_base_url.rstrip("/") + f"/v1/personas/gallery/{slug}/install-events",
+            config.cloud_base_url.rstrip("/")
+            + f"/v1/personas/gallery/{slug}/install-events",
             json={"platform": __import__("sys").platform},
             headers={"Authorization": f"Bearer {token}"},
             timeout=10,
@@ -661,4 +671,9 @@ def gallery_detail(secrets: SecretStore, config: Config, slug: str) -> Optional[
         ]
     except Exception as exc:  # malformed manifest: surface, don't crash
         return {"ok": False, "error": f"manifest failed local validation: {exc}"}
-    return {"ok": True, "card": card, "capabilities": capabilities, "recommends": recommends}
+    return {
+        "ok": True,
+        "card": card,
+        "capabilities": capabilities,
+        "recommends": recommends,
+    }

--- a/platform/coworker/config.py
+++ b/platform/coworker/config.py
@@ -62,7 +62,9 @@ class Config:
     # default shipped once as "connected but relay OFF" on every machine
     # without a hand-edited config.toml. Empty override ⇒ relay disabled
     # (manual Socket Mode still works); dev/BYO deployments point elsewhere.
-    cloud_relay_ws_url: str = "wss://l4z1paxb83.execute-api.us-east-1.amazonaws.com/ocw-connect"
+    cloud_relay_ws_url: str = (
+        "wss://l4z1paxb83.execute-api.us-east-1.amazonaws.com/ocw-connect"
+    )
 
 
 _FIELDS = {

--- a/platform/coworker/connectors/accounts.py
+++ b/platform/coworker/connectors/accounts.py
@@ -48,7 +48,11 @@ def derive_account_id(d: ConnectorDescriptor, profile: dict[str, Any]) -> str:
     validator identity (stored as `account` at connect time). "default" only
     when neither exists — never fails, so migration can't strand a profile."""
     if d.account_field and d.account_field != IDENTITY:
-        return _norm(profile.get(d.account_field)) or _norm(profile.get("account")) or "default"
+        return (
+            _norm(profile.get(d.account_field))
+            or _norm(profile.get("account"))
+            or "default"
+        )
     return _norm(profile.get("account")) or "default"
 
 
@@ -86,7 +90,7 @@ def list_accounts(
     for meta in secrets.status():
         key = meta.get("profile", "")
         if key.startswith(pre):
-            out.append((key[len(pre):], secrets.get(key) or {}))
+            out.append((key[len(pre) :], secrets.get(key) or {}))
     return sorted(out, key=lambda t: t[0])
 
 
@@ -131,7 +135,9 @@ def add_account(
     return {"ok": True, "account": account_id}
 
 
-def set_default(secrets: SecretStore, connector: str, account_id: str) -> dict[str, Any]:
+def set_default(
+    secrets: SecretStore, connector: str, account_id: str
+) -> dict[str, Any]:
     account_id = _norm(account_id)
     if not secrets.get(prefix(connector) + account_id):
         return {"ok": False, "error": "account not connected"}

--- a/platform/coworker/connectors/adapters.py
+++ b/platform/coworker/connectors/adapters.py
@@ -78,8 +78,7 @@ def slack_event_to_event(
     # Mention detection runs on the RAW text (the `<@U…>` token form, legacy `<@U…|name>`
     # included) — callers rewrite mentions to @display-name only after mapping.
     mentions_me = bool(
-        bot_user_id
-        and re.search(rf"<@{re.escape(bot_user_id)}(?:\|[^>]*)?>", text)
+        bot_user_id and re.search(rf"<@{re.escape(bot_user_id)}(?:\|[^>]*)?>", text)
     )
     return MessageEvent(
         text=text, source=source, message_id=event.get("ts"), mentions_me=mentions_me
@@ -160,9 +159,13 @@ class SlackAdapter(BasePlatformAdapter):
         self._task: Optional[asyncio.Task] = None
         self._watchdog_task: Optional[asyncio.Task] = None
         self._closing = False
-        self._reconnects = 0  # observable: how many times the watchdog revived the connection
+        self._reconnects = (
+            0  # observable: how many times the watchdog revived the connection
+        )
         self._watchdog_interval = (
-            watchdog_interval if watchdog_interval is not None else self._WATCHDOG_INTERVAL
+            watchdog_interval
+            if watchdog_interval is not None
+            else self._WATCHDOG_INTERVAL
         )
         # slack_sdk's own reconnect stays on in production (seamless on Slack's graceful cycling);
         # tests turn it off so the watchdog is the sole, deterministic recovery path.
@@ -274,11 +277,15 @@ class SlackAdapter(BasePlatformAdapter):
                 alive = False
             if alive:
                 continue
-            logger.warning("slack socket mode connection down — reconnecting (watchdog)")
+            logger.warning(
+                "slack socket mode connection down — reconnecting (watchdog)"
+            )
             try:
                 await client.connect_to_new_endpoint(force=True)
                 self._reconnects += 1
-                logger.info("slack socket mode reconnected (watchdog, #%d)", self._reconnects)
+                logger.info(
+                    "slack socket mode reconnected (watchdog, #%d)", self._reconnects
+                )
             except asyncio.CancelledError:
                 break
             except Exception:
@@ -388,7 +395,8 @@ class SlackAdapter(BasePlatformAdapter):
 
 def _load_slack_teams(secrets) -> dict[str, dict]:
     """Per-team bot tokens for managed relay, from `slack:team:<team_id>` profiles
-    (written by the managed OAuth install). Returns {team_id: {bot_token, bot_user_id}}."""
+    (written by the managed OAuth install). Returns {team_id: {bot_token, bot_user_id}}.
+    """
     teams: dict[str, dict] = {}
     if secrets is None:
         return teams
@@ -461,7 +469,9 @@ def make_adapter(
         from .relay_client import RelayHub
 
         hub = relay_hub or RelayHub(relay_url, token_provider)
-        installs = {iid: prof for iid, prof in list_installs(secrets)} if secrets else {}
+        installs = (
+            {iid: prof for iid, prof in list_installs(secrets)} if secrets else {}
+        )
         return GitHubRelayAdapter(
             hub, installs=installs, token_client=github_token_client
         )

--- a/platform/coworker/connectors/descriptors.py
+++ b/platform/coworker/connectors/descriptors.py
@@ -1034,7 +1034,9 @@ DESCRIPTORS: list[ConnectorDescriptor] = [
         auth="api_token",
         two_way=False,
         fields=[
-            Field("api_key", "API key", secret=True, help="Project Settings → API Keys."),
+            Field(
+                "api_key", "API key", secret=True, help="Project Settings → API Keys."
+            ),
             Field("secret_key", "Secret key", secret=True),
         ],
         instructions=[
@@ -1053,7 +1055,9 @@ DESCRIPTORS: list[ConnectorDescriptor] = [
         auth="api_token",
         two_way=False,
         fields=[
-            Field("api_key", "API key", secret=True, help="Settings → Integrations → API."),
+            Field(
+                "api_key", "API key", secret=True, help="Settings → Integrations → API."
+            ),
             Field(
                 "label",
                 "Account label",
@@ -1078,7 +1082,9 @@ DESCRIPTORS: list[ConnectorDescriptor] = [
         auth="api_token",
         two_way=False,
         fields=[
-            Field("api_key", "API key", secret=True, help="hunter.io → API → API keys."),
+            Field(
+                "api_key", "API key", secret=True, help="hunter.io → API → API keys."
+            ),
         ],
         instructions=[
             "In Hunter, open API → API keys and copy your key.",

--- a/platform/coworker/connectors/gateway.py
+++ b/platform/coworker/connectors/gateway.py
@@ -157,9 +157,13 @@ class Gateway:
         adapter = self._adapters.get(platform)
         if adapter is None:
             return SendResult(False, error=f"no adapter for {platform}")
-        return await adapter.send_interactive(chat_id, text, buttons, thread_id=thread_id)
+        return await adapter.send_interactive(
+            chat_id, text, buttons, thread_id=thread_id
+        )
 
-    async def update_message(self, platform: str, chat_id: str, message_id: str, text: str) -> None:
+    async def update_message(
+        self, platform: str, chat_id: str, message_id: str, text: str
+    ) -> None:
         """Replace a resolved prompt's buttons with a plain-text outcome, if the adapter supports it."""
         adapter = self._adapters.get(platform)
         fn = getattr(adapter, "update_message", None)

--- a/platform/coworker/connectors/gcal_accounts.py
+++ b/platform/coworker/connectors/gcal_accounts.py
@@ -53,7 +53,7 @@ def list_accounts(secrets: SecretStore) -> list[tuple[str, dict[str, Any]]]:
     for meta in secrets.status():
         key = meta.get("profile", "")
         if key.startswith(PREFIX):
-            out.append((key[len(PREFIX):], secrets.get(key) or {}))
+            out.append((key[len(PREFIX) :], secrets.get(key) or {}))
     return sorted(out, key=lambda t: t[0])
 
 

--- a/platform/coworker/connectors/github_installs.py
+++ b/platform/coworker/connectors/github_installs.py
@@ -32,7 +32,7 @@ def list_installs(secrets: SecretStore) -> list[tuple[str, dict[str, Any]]]:
     for meta in secrets.status():
         key = meta.get("profile", "")
         if key.startswith(PREFIX):
-            out.append((key[len(PREFIX):], secrets.get(key) or {}))
+            out.append((key[len(PREFIX) :], secrets.get(key) or {}))
     return sorted(out, key=lambda t: t[0])
 
 
@@ -44,7 +44,9 @@ def default_install(secrets: SecretStore) -> str:
     return next(iter(installs), "")
 
 
-def resolve(secrets: SecretStore, install: str = "") -> tuple[str, dict[str, Any] | None]:
+def resolve(
+    secrets: SecretStore, install: str = ""
+) -> tuple[str, dict[str, Any] | None]:
     """(installation_id, profile) for the requested — or default — installation.
     Accepts the id or the account login (what agents see in results)."""
     installs = list_installs(secrets)

--- a/platform/coworker/connectors/github_relay.py
+++ b/platform/coworker/connectors/github_relay.py
@@ -107,8 +107,12 @@ class GitHubRelayAdapter(BasePlatformAdapter):
         kind = frame.get("kind")
         if kind == "missed":
             repo = frame.get("channel", "")
-            self.missed[repo] = self.missed.get(repo, 0) + int(frame.get("count", 0) or 1)
-            logger.info("github relay: %s event(s) missed in %s", frame.get("count"), repo)
+            self.missed[repo] = self.missed.get(repo, 0) + int(
+                frame.get("count", 0) or 1
+            )
+            logger.info(
+                "github relay: %s event(s) missed in %s", frame.get("count"), repo
+            )
             return
         if kind == "revoked":
             self._installs.pop(str(frame.get("installation_id", "")), None)
@@ -191,6 +195,8 @@ class GitHubRelayAdapter(BasePlatformAdapter):
             self._note_token_health(installation_id, False)
             return SendResult(False, error="installation token rejected")
         if resp.status_code not in (200, 201):
-            return SendResult(False, error=f"github comment failed ({resp.status_code})")
+            return SendResult(
+                False, error=f"github comment failed ({resp.status_code})"
+            )
         self._note_token_health(installation_id, True)
         return SendResult(True, message_id=str((resp.json() or {}).get("id", "")))

--- a/platform/coworker/connectors/gmail_accounts.py
+++ b/platform/coworker/connectors/gmail_accounts.py
@@ -58,7 +58,7 @@ def list_accounts(secrets: SecretStore) -> list[tuple[str, dict[str, Any]]]:
     for meta in secrets.status():
         key = meta.get("profile", "")
         if key.startswith(PREFIX):
-            out.append((key[len(PREFIX):], secrets.get(key) or {}))
+            out.append((key[len(PREFIX) :], secrets.get(key) or {}))
     return sorted(out, key=lambda t: t[0])
 
 

--- a/platform/coworker/connectors/hubspot_portals.py
+++ b/platform/coworker/connectors/hubspot_portals.py
@@ -60,7 +60,7 @@ def list_portals(secrets: SecretStore) -> list[tuple[str, dict[str, Any]]]:
     for meta in secrets.status():
         key = meta.get("profile", "")
         if key.startswith(PREFIX):
-            out.append((key[len(PREFIX):], secrets.get(key) or {}))
+            out.append((key[len(PREFIX) :], secrets.get(key) or {}))
     return sorted(out, key=lambda t: t[0])
 
 

--- a/platform/coworker/connectors/integration_tools.py
+++ b/platform/coworker/connectors/integration_tools.py
@@ -112,9 +112,11 @@ def _account_profile(
         profile = secrets.get(key) or profile
     missing = [k for k in keys if not profile.get(k)]
     if missing:
-        return account_id, None, {
-            "error": f"{connector} is not connected; missing {', '.join(missing)}"
-        }
+        return (
+            account_id,
+            None,
+            {"error": f"{connector} is not connected; missing {', '.join(missing)}"},
+        )
     return account_id, profile, None
 
 
@@ -183,7 +185,11 @@ def _gcal_profile(
         )
         profile = secrets.get(key) or profile
     if not profile.get("access_token"):
-        return "", None, {"error": f"google calendar account {email} has no usable token"}
+        return (
+            "",
+            None,
+            {"error": f"google calendar account {email} has no usable token"},
+        )
     return email, profile, None
 
 
@@ -289,7 +295,10 @@ def _gmail_is_hidden(
     if filters["labels"]:
         wanted = {name.lower() for name in filters["labels"]}
         for lid in message.get("labelIds") or []:
-            if label_map.get(str(lid), "").lower() in wanted or str(lid).lower() in wanted:
+            if (
+                label_map.get(str(lid), "").lower() in wanted
+                or str(lid).lower() in wanted
+            ):
                 return True
     return False
 
@@ -405,12 +414,16 @@ def _github_git_auth_args(secrets: SecretStore, owner: str) -> list[str]:
     token = headers["Authorization"].split(" ", 1)[1]
     basic = base64.b64encode(f"x-access-token:{token}".encode()).decode()
     return [
-        "-c", f"http.extraHeader=AUTHORIZATION: basic {basic}",
-        "-c", "credential.helper=",
+        "-c",
+        f"http.extraHeader=AUTHORIZATION: basic {basic}",
+        "-c",
+        "credential.helper=",
     ]
 
 
-def _run_git(args: list[str], *, cwd: Any = None, timeout: int = 600) -> tuple[str, str]:
+def _run_git(
+    args: list[str], *, cwd: Any = None, timeout: int = 600
+) -> tuple[str, str]:
     """(stdout, error). Never raises; the error string is capped and carries no
     auth material (git never echoes header values)."""
     import subprocess
@@ -716,7 +729,11 @@ def make_integration_tools(
         if author:
             params["author"] = author
         out = _github_call(
-            secrets, "GET", f"/repos/{owner}/{repo}/commits", install=owner, params=params
+            secrets,
+            "GET",
+            f"/repos/{owner}/{repo}/commits",
+            install=owner,
+            params=params,
         )
         if "error" in out:
             return out
@@ -744,7 +761,10 @@ def make_integration_tools(
                 {
                     "owner": {"type": "string"},
                     "repo": {"type": "string"},
-                    "since": {"type": "string", "description": "ISO-8601, e.g. 2026-07-06T00:00:00Z"},
+                    "since": {
+                        "type": "string",
+                        "description": "ISO-8601, e.g. 2026-07-06T00:00:00Z",
+                    },
                     "until": {"type": "string"},
                     "author": {"type": "string", "description": "GitHub login"},
                     "max_results": {"type": "integer"},
@@ -756,7 +776,9 @@ def make_integration_tools(
         )
     )
 
-    def _writable_target(raw: str, *, default_name: str = "") -> tuple[Any, dict[str, Any] | None]:
+    def _writable_target(
+        raw: str, *, default_name: str = ""
+    ) -> tuple[Any, dict[str, Any] | None]:
         """Resolve a directory inside a WRITABLE granted root — clones and pulls
         never touch anything the user hasn't shared with the session."""
         from pathlib import Path as _Path
@@ -770,7 +792,9 @@ def make_integration_tools(
             else (writable[0] / default_name).resolve()
         )
         if not any(path.is_relative_to(root) for root in writable):
-            return None, {"error": f"{path} is outside the session's writable directories"}
+            return None, {
+                "error": f"{path} is outside the session's writable directories"
+            }
         return path, None
 
     def github_clone(owner: str, repo: str, directory: str = "") -> dict[str, Any]:
@@ -778,7 +802,9 @@ def make_integration_tools(
         if err:
             return err
         if target.exists() and any(target.iterdir()):
-            return {"error": f"{target} already exists and is not empty (use github_pull?)"}
+            return {
+                "error": f"{target} already exists and is not empty (use github_pull?)"
+            }
         url = f"{_github_git_base()}/{owner}/{repo}.git"
         _out, git_err = _run_git(
             [*_github_git_auth_args(secrets, owner), "clone", url, str(target)]
@@ -808,7 +834,10 @@ def make_integration_tools(
                 {
                     "owner": {"type": "string"},
                     "repo": {"type": "string"},
-                    "directory": {"type": "string", "description": "target path inside a granted folder (default: <primary>/<repo>)"},
+                    "directory": {
+                        "type": "string",
+                        "description": "target path inside a granted folder (default: <primary>/<repo>)",
+                    },
                 },
                 ["owner", "repo"],
             ),
@@ -829,7 +858,13 @@ def make_integration_tools(
         m = re.search(r"[:/]([^/:]+)/([^/]+?)(?:\.git)?/?$", remote)
         owner = m.group(1) if m else ""
         _out, git_err = _run_git(
-            [*_github_git_auth_args(secrets, owner), "-C", str(target), "pull", "--ff-only"]
+            [
+                *_github_git_auth_args(secrets, owner),
+                "-C",
+                str(target),
+                "pull",
+                "--ff-only",
+            ]
         )
         if git_err:
             return {"error": f"pull failed: {git_err}"}
@@ -888,14 +923,18 @@ def make_integration_tools(
                 detail = meta.get("data") if meta.get("ok") else None
                 # Fail-open on a metadata miss: ids alone reveal nothing, and
                 # gmail_get_message re-enforces before any content flows.
-                if isinstance(detail, dict) and _gmail_is_hidden(detail, filters, label_map):
+                if isinstance(detail, dict) and _gmail_is_hidden(
+                    detail, filters, label_map
+                ):
                     hidden += 1
                 else:
                     kept.append(m)
             if hidden:
                 data["messages"] = kept
                 if isinstance(data.get("resultSizeEstimate"), int):
-                    data["resultSizeEstimate"] = max(0, data["resultSizeEstimate"] - hidden)
+                    data["resultSizeEstimate"] = max(
+                        0, data["resultSizeEstimate"] - hidden
+                    )
                 result = {
                     "ok": True,
                     "data": data,
@@ -1080,7 +1119,9 @@ def make_integration_tools(
         if err:
             return err
         items = [
-            {"id": c.strip()} for c in str(calendars or "primary").split(",") if c.strip()
+            {"id": c.strip()}
+            for c in str(calendars or "primary").split(",")
+            if c.strip()
         ]
         return _gcal_result(
             email,
@@ -1193,7 +1234,9 @@ def make_integration_tools(
         if end:
             payload["end"] = {"dateTime": end, "timeZone": timezone}
         if not payload:
-            return {"error": "nothing to update — pass summary, description, start, or end"}
+            return {
+                "error": "nothing to update — pass summary, description, start, or end"
+            }
         return _gcal_result(
             email,
             _request(
@@ -2848,7 +2891,9 @@ def make_integration_tools(
         for b in blocks:
             content = b.get(b.get("type", ""), {})
             texts = content.get("rich_text") or content.get("title") or []
-            line = "".join(t.get("plain_text", "") for t in texts if isinstance(t, dict))
+            line = "".join(
+                t.get("plain_text", "") for t in texts if isinstance(t, dict)
+            )
             if line:
                 lines.append(line)
         return "\n".join(lines)
@@ -2932,7 +2977,10 @@ def make_integration_tools(
     )
 
     def notion_query_database(
-        database_id: str, filter_json: str = "", max_results: int = 10, account: str = ""
+        database_id: str,
+        filter_json: str = "",
+        max_results: int = 10,
+        account: str = "",
     ) -> dict[str, Any]:
         aid, profile, err = _account_profile(secrets, "notion", account, "access_token")
         if err:
@@ -3045,7 +3093,10 @@ def make_integration_tools(
     )
 
     def attio_query_records(
-        object_type: str, filter_json: str = "", max_results: int = 10, account: str = ""
+        object_type: str,
+        filter_json: str = "",
+        max_results: int = 10,
+        account: str = "",
     ) -> dict[str, Any]:
         aid, profile, err = _account_profile(secrets, "attio", account, "access_token")
         if err:
@@ -3252,7 +3303,9 @@ def make_integration_tools(
             "event": event,
             "from_date": from_date,
             "to_date": to_date,
-            "unit": unit if unit in ("minute", "hour", "day", "week", "month") else "day",
+            "unit": (
+                unit if unit in ("minute", "hour", "day", "week", "month") else "day"
+            ),
         }
         if where:
             params["where"] = where
@@ -3582,7 +3635,9 @@ def make_integration_tools(
         aid, profile, err = _account_profile(secrets, "hunter", account, "api_key")
         if err:
             return err
-        return _acct_result(aid, _hunter_get(profile, "email-verifier", {"email": email}))
+        return _acct_result(
+            aid, _hunter_get(profile, "email-verifier", {"email": email})
+        )
 
     hunter_verify_email.__name__ = "hunter_verify_email"
     tools.append(

--- a/platform/coworker/connectors/relay_client.py
+++ b/platform/coworker/connectors/relay_client.py
@@ -45,6 +45,7 @@ class RelayTransport(Protocol):
     async def recv(self) -> Optional[dict]:
         """Next frame, or None when the connection has closed."""
         ...
+
     async def close(self) -> None: ...
 
 
@@ -93,7 +94,9 @@ class RelayHub:
         self.last_error: str = ""  # last connect/reconnect failure ("" once healthy)
         self._progress = asyncio.Event()
 
-    def register(self, provider: str, handler: Callable[[dict], Awaitable[None]]) -> None:
+    def register(
+        self, provider: str, handler: Callable[[dict], Awaitable[None]]
+    ) -> None:
         self._handlers[provider] = handler
 
     async def release(self, provider: str) -> None:
@@ -196,11 +199,15 @@ class RelayHub:
             self._progress.clear()
             remaining = deadline - loop.time()
             if remaining <= 0:
-                raise TimeoutError(f"only {self._dispatched} frames dispatched (< {at_least})")
+                raise TimeoutError(
+                    f"only {self._dispatched} frames dispatched (< {at_least})"
+                )
             try:
                 await asyncio.wait_for(self._progress.wait(), timeout=remaining)
             except asyncio.TimeoutError:
-                raise TimeoutError(f"only {self._dispatched} frames dispatched (< {at_least})")
+                raise TimeoutError(
+                    f"only {self._dispatched} frames dispatched (< {at_least})"
+                )
 
     # -- default transport ---------------------------------------------------
     def _default_transport_factory(self) -> RelayTransport:
@@ -281,7 +288,9 @@ class SlackRelayAdapter(BasePlatformAdapter):
         await self._hub.wait_dispatched(at_least, timeout)
 
     # -- team registry -------------------------------------------------------
-    def set_team(self, team_id: str, bot_token: str, bot_user_id: Optional[str] = None) -> None:
+    def set_team(
+        self, team_id: str, bot_token: str, bot_user_id: Optional[str] = None
+    ) -> None:
         self._teams[team_id] = {"bot_token": bot_token, "bot_user_id": bot_user_id}
 
     def _bot_user_id(self, team_id: str) -> Optional[str]:
@@ -307,7 +316,9 @@ class SlackRelayAdapter(BasePlatformAdapter):
         await self._on_event(frame)
 
     async def _on_event(self, frame: dict) -> None:
-        await self._dispatch_slack_event(frame.get("team_id", ""), frame.get("event") or {})
+        await self._dispatch_slack_event(
+            frame.get("team_id", ""), frame.get("event") or {}
+        )
 
     async def _dispatch_slack_event(self, team_id: str, event: dict) -> None:
         """Map a raw Slack event → MessageEvent, resolve display names via the
@@ -321,7 +332,9 @@ class SlackRelayAdapter(BasePlatformAdapter):
         # mirroring the Socket-Mode adapter — so cards read "@ocw"/"Rohit"/"#ocw-test"
         # not raw U…/C… ids. Best-effort: ids fall through on failure.
         if not mapped.source.user_name:
-            mapped.source.user_name = await self._display_name(team_id, mapped.source.user_id)
+            mapped.source.user_name = await self._display_name(
+                team_id, mapped.source.user_id
+            )
         if not mapped.source.chat_name:
             mapped.source.chat_name = await self._channel_name(team_id, channel)
         mapped.text = await self._resolve_mentions(team_id, mapped.text)
@@ -379,7 +392,9 @@ class SlackRelayAdapter(BasePlatformAdapter):
             info["token_ok"] = False
 
     # -- name resolution (per workspace, via that team's bot token) ----------
-    async def _slack_get(self, team_id: str, method: str, params: dict) -> Optional[dict]:
+    async def _slack_get(
+        self, team_id: str, method: str, params: dict
+    ) -> Optional[dict]:
         """Call a Slack Web API read method with the team's bot token. Best-effort
         (None on any failure). `SLACK_API_URL` redirects to the fake in tests."""
         import httpx
@@ -391,7 +406,8 @@ class SlackRelayAdapter(BasePlatformAdapter):
         try:
             async with httpx.AsyncClient(timeout=15) as http:
                 resp = await http.get(
-                    base + method, params=params,
+                    base + method,
+                    params=params,
                     headers={"Authorization": f"Bearer {token}"},
                 )
             data = resp.json()
@@ -409,7 +425,12 @@ class SlackRelayAdapter(BasePlatformAdapter):
         data = await self._slack_get(team_id, "users.info", {"user": uid})
         u = (data or {}).get("user") or {}
         prof = u.get("profile") or {}
-        name = prof.get("display_name") or prof.get("real_name") or u.get("real_name") or u.get("name")
+        name = (
+            prof.get("display_name")
+            or prof.get("real_name")
+            or u.get("real_name")
+            or u.get("name")
+        )
         if name:
             cache[uid] = name
         return name

--- a/platform/coworker/connectors/senders.py
+++ b/platform/coworker/connectors/senders.py
@@ -162,7 +162,8 @@ def _send_slack_file(
 ) -> SendResult:
     """files_upload_v2 (the only non-deprecated path): reserve an upload URL, PUT the
     bytes, then complete into the channel/thread. Slack renders its own previews for
-    pdf/csv/images — that's the whole point of sending the file instead of a thumbnail."""
+    pdf/csv/images — that's the whole point of sending the file instead of a thumbnail.
+    """
     import httpx
 
     from .slack_addr import split
@@ -178,9 +179,13 @@ def _send_slack_file(
         )
         got = resp.json()
         if not got.get("ok"):
-            return SendResult(False, error=got.get("error") or "slack upload-url failed")
+            return SendResult(
+                False, error=got.get("error") or "slack upload-url failed"
+            )
         up = httpx.post(
-            got["upload_url"], files={"file": (filename, data)}, timeout=max(_TIMEOUT, 120.0)
+            got["upload_url"],
+            files={"file": (filename, data)},
+            timeout=max(_TIMEOUT, 120.0),
         )
         if up.status_code != 200:
             return SendResult(False, error=f"slack upload failed ({up.status_code})")

--- a/platform/coworker/connectors/setup.py
+++ b/platform/coworker/connectors/setup.py
@@ -54,32 +54,32 @@ def connector_list(secrets: SecretStore) -> list[dict[str, Any]]:
         profile = secrets.get(f"{d.name}:default") or {}
         connected = _profile_connected(d, profile)
         entry = {
-                "name": d.name,
-                "title": d.title,
-                "icon": d.icon,
-                "blurb": d.blurb,
-                "auth": d.auth,
-                "two_way": d.two_way,
-                "channels": d.channels,
-                "available": d.available,
-                "brand_color": d.brand_color,
-                "logo": d.logo,
-                "fields": [f.to_dict() for f in d.fields],
-                "instructions": d.instructions,
-                "connected": connected,
-                "account": profile.get("account"),
-                "enabled": bool(profile.get("enabled", True)) and connected,
-                # The actual allow-list (the GUI manages it inline); was a bare count.
-                "allowed_users": list(profile.get("allowed_users") or []),
-                "tools": tool_dicts(secrets, d.name),
-                "experimental": d.experimental,
-                "risk_notice": d.risk_notice,
-                "managed": d.managed,
-                # Whether THIS profile came from managed OAuth (vs manual paste).
-                "managed_profile": bool(profile.get("managed")),
-                # "relay" for the managed cloud path; empty for manual/token connect.
-                "mode": profile.get("mode") or "",
-            }
+            "name": d.name,
+            "title": d.title,
+            "icon": d.icon,
+            "blurb": d.blurb,
+            "auth": d.auth,
+            "two_way": d.two_way,
+            "channels": d.channels,
+            "available": d.available,
+            "brand_color": d.brand_color,
+            "logo": d.logo,
+            "fields": [f.to_dict() for f in d.fields],
+            "instructions": d.instructions,
+            "connected": connected,
+            "account": profile.get("account"),
+            "enabled": bool(profile.get("enabled", True)) and connected,
+            # The actual allow-list (the GUI manages it inline); was a bare count.
+            "allowed_users": list(profile.get("allowed_users") or []),
+            "tools": tool_dicts(secrets, d.name),
+            "experimental": d.experimental,
+            "risk_notice": d.risk_notice,
+            "managed": d.managed,
+            # Whether THIS profile came from managed OAuth (vs manual paste).
+            "managed_profile": bool(profile.get("managed")),
+            # "relay" for the managed cloud path; empty for manual/token connect.
+            "mode": profile.get("mode") or "",
+        }
         if d.name == "slack":
             # Managed relay is multi-workspace: each `slack:team:*` profile is one
             # connected workspace with its OWN allow-list (ids are workspace-scoped).
@@ -250,9 +250,7 @@ def _hubspot_portal_list(secrets: SecretStore) -> list[dict[str, Any]]:
                 "managed": bool(profile.get("managed")),
                 # Consent tier granted at connect: managed profiles reveal it in
                 # their scope grant; a manual private-app token doesn't say.
-                "access": (".write" in scope and "write")
-                or (scope and "read")
-                or "",
+                "access": (".write" in scope and "write") or (scope and "read") or "",
             }
         )
     return out
@@ -434,7 +432,9 @@ def disconnect_connector(secrets: SecretStore, name: str) -> dict[str, Any]:
         from . import gmail_accounts
 
         for email, _profile in gmail_accounts.list_accounts(secrets):
-            dropped_accounts = secrets.delete(gmail_accounts.PREFIX + email) or dropped_accounts
+            dropped_accounts = (
+                secrets.delete(gmail_accounts.PREFIX + email) or dropped_accounts
+            )
     if name == "google_calendar":
         from . import gcal_accounts
 

--- a/platform/coworker/connectors/slack_directory.py
+++ b/platform/coworker/connectors/slack_directory.py
@@ -48,7 +48,11 @@ def _bot_token(secrets: SecretStore, team_id: str) -> str:
 
 
 def _get_pages(
-    token: str, method: str, params: dict[str, Any], key: str, page_limit: int = _PAGE_LIMIT
+    token: str,
+    method: str,
+    params: dict[str, Any],
+    key: str,
+    page_limit: int = _PAGE_LIMIT,
 ) -> list[dict]:
     """Cursor-paginated GET; raises RuntimeError with Slack's error string."""
     import httpx
@@ -89,8 +93,12 @@ def _rank(rows: list[dict], query: str, key: str, limit: int) -> list[dict]:
     """Case-insensitive substring filter; prefix matches first, then alpha."""
     q = query.strip().lower()
     if q:
-        rows = [r for r in rows if q in r[key].lower() or q in r.get("handle", "").lower()]
-    rows = sorted(rows, key=lambda r: (not r[key].lower().startswith(q), r[key].lower()))
+        rows = [
+            r for r in rows if q in r[key].lower() or q in r.get("handle", "").lower()
+        ]
+    rows = sorted(
+        rows, key=lambda r: (not r[key].lower().startswith(q), r[key].lower())
+    )
     return rows[: max(1, min(int(limit or 25), 100))]
 
 
@@ -115,13 +123,20 @@ def list_members(
             if m.get("deleted") or m.get("is_bot") or m.get("id") == "USLACKBOT":
                 continue
             profile = m.get("profile") or {}
-            name = profile.get("display_name") or profile.get("real_name") or m.get("name") or ""
+            name = (
+                profile.get("display_name")
+                or profile.get("real_name")
+                or m.get("name")
+                or ""
+            )
             out.append(
                 {
                     "id": m.get("id", ""),
                     "name": name,
                     "handle": m.get("name") or "",
-                    "guest": bool(m.get("is_restricted") or m.get("is_ultra_restricted")),
+                    "guest": bool(
+                        m.get("is_restricted") or m.get("is_ultra_restricted")
+                    ),
                 }
             )
         return out

--- a/platform/coworker/connectors/tool_defs.py
+++ b/platform/coworker/connectors/tool_defs.py
@@ -694,9 +694,7 @@ for _def in TOOL_DEFS:
 # always-available messaging tool `send_message` (its `target` is the reply handle
 # "platform:chat_id" — exactly the address a rule pins). This dict is the single source of
 # which tools can EVER carry a standing rule: exec/destructive tools must never appear here.
-TARGET_ARGS: dict[str, str] = {
-    d.name: d.target_arg for d in TOOL_DEFS if d.target_arg
-}
+TARGET_ARGS: dict[str, str] = {d.name: d.target_arg for d in TOOL_DEFS if d.target_arg}
 TARGET_ARGS["send_message"] = "target"
 
 

--- a/platform/coworker/connectors/tools.py
+++ b/platform/coworker/connectors/tools.py
@@ -202,8 +202,14 @@ _FILE_SCHEMA = {
                     "type": "string",
                     "description": "The file to send — workspace-relative, or absolute within an allowed folder.",
                 },
-                "title": {"type": "string", "description": "Display title (defaults to the filename)."},
-                "comment": {"type": "string", "description": "Short message posted with the file."},
+                "title": {
+                    "type": "string",
+                    "description": "Display title (defaults to the filename).",
+                },
+                "comment": {
+                    "type": "string",
+                    "description": "Short message posted with the file.",
+                },
                 "as_screenshot": {
                     "type": "boolean",
                     "description": "HTML only: render the page headless and send a PNG preview instead of the raw file.",
@@ -296,7 +302,9 @@ def make_send_file_tool(
             return {"error": "no workspace folders available to read from"}
         resolved = _resolve_within(path, bases)
         if resolved is None or not resolved.is_file():
-            return {"error": "path is outside the folders this session can access (or missing)"}
+            return {
+                "error": "path is outside the folders this session can access (or missing)"
+            }
         token = _resolve_token(secrets, platform, chat_id)
         if not token:
             return {"error": f"no bot token for {platform} — connect it first"}
@@ -319,7 +327,12 @@ def make_send_file_tool(
             comment = sender_prefix(secrets, chat_id) + comment
         result = sender(token, chat_id, thread_id, filename, data, title, comment)
         if result.ok:
-            return {"ok": True, "file_id": result.message_id, "target": target, "filename": filename}
+            return {
+                "ok": True,
+                "file_id": result.message_id,
+                "target": target,
+                "filename": filename,
+            }
         return {"error": result.error or "file send failed"}
 
     send_file.__name__ = "send_file"

--- a/platform/coworker/conversations.py
+++ b/platform/coworker/conversations.py
@@ -355,7 +355,8 @@ class ConversationStore:
 
     def set_origin(self, session_id: str, origin: str, origin_label: str = "") -> bool:
         """Mark where a spawned session came from (§31). Set once at spawn; `save()` never
-        names these columns, so per-turn saves can't clobber them (the pinned mechanism)."""
+        names these columns, so per-turn saves can't clobber them (the pinned mechanism).
+        """
         with self._lock:
             cur = self._conn.execute(
                 "UPDATE sessions SET origin = ?, origin_label = ? WHERE session_id = ?",

--- a/platform/coworker/engine.py
+++ b/platform/coworker/engine.py
@@ -206,7 +206,10 @@ class TurnEngine:
                         turn = chunk.turn
             except Exception as exc:  # provider failure
                 friendly = friendly_model_error(self.model, exc)
-                payload = {"error": friendly or str(exc), "error_type": type(exc).__name__}
+                payload = {
+                    "error": friendly or str(exc),
+                    "error_type": type(exc).__name__,
+                }
                 if friendly:
                     payload["raw"] = str(exc)
                 yield Event(EventType.ERROR, payload)
@@ -692,9 +695,11 @@ class TurnEngine:
         # (e.g. filter-hidden counts) — copying only messages that carry one.
         _SIDECARS = ("source", "_display")
         out = [
-            {k: v for k, v in msg.items() if k not in _SIDECARS}
-            if any(s in msg for s in _SIDECARS)
-            else msg
+            (
+                {k: v for k, v in msg.items() if k not in _SIDECARS}
+                if any(s in msg for s in _SIDECARS)
+                else msg
+            )
             for msg in self.messages
         ]
         context = (

--- a/platform/coworker/events.py
+++ b/platform/coworker/events.py
@@ -18,7 +18,9 @@ class EventType(str, Enum):
     TOOL_PROPOSED = "tool_proposed"
     PERMISSION_REQUIRED = "permission_required"
     DIRECTORY_REQUESTED = "directory_requested"  # agent asks the user to grant a folder
-    QUESTION_REQUESTED = "question_requested"  # agent asks the user a free-text/multiple-choice question
+    QUESTION_REQUESTED = (
+        "question_requested"  # agent asks the user a free-text/multiple-choice question
+    )
     PLAN_PROPOSED = (
         "plan_proposed"  # agent presents a plan for approval (plan mode exit)
     )

--- a/platform/coworker/inbox.py
+++ b/platform/coworker/inbox.py
@@ -45,7 +45,8 @@ def _now() -> str:
 
 def args_preview(arguments: Optional[dict], *, limit: int = 240) -> str:
     """A compact one-line summary of a tool call's arguments, for an approval card body (so a
-    mirrored 'Run `write_file`?' shows *what* — path/content — not just the tool name)."""
+    mirrored 'Run `write_file`?' shows *what* — path/content — not just the tool name).
+    """
     parts: list[str] = []
     for k, v in (arguments or {}).items():
         s = v if isinstance(v, str) else json.dumps(v, default=str, ensure_ascii=False)
@@ -65,7 +66,9 @@ class InboxItem:
     title: str
     body: str = ""
     state: str = STATE_PENDING
-    resolution: Optional[str] = None  # approval: "allow"/"deny"/"always"; question: answer text
+    resolution: Optional[str] = (
+        None  # approval: "allow"/"deny"/"always"; question: answer text
+    )
     inbox: str = "default"  # named inbox / delivery binding (Phase 3 routing)
     created_at: str = field(default_factory=_now)
     resolved_at: Optional[str] = None
@@ -76,7 +79,9 @@ class InboxItem:
     # Question metadata (ask_user): optional quick-reply choices + a free-text escape, mirroring
     # the structured-but-always-answerable shape of Claude Code's AskUserQuestion.
     options: list[str] = field(default_factory=list)
-    allow_text: bool = True  # accept a typed answer even when options exist (the "Other" escape)
+    allow_text: bool = (
+        True  # accept a typed answer even when options exist (the "Other" escape)
+    )
     multi: bool = False  # allow choosing more than one option
     # Kind-specific payload (directory: suggested path/writable; plan: the plan text; …).
     data: dict[str, Any] = field(default_factory=dict)
@@ -109,9 +114,18 @@ class InboxStore:
 
     # -- adding -----------------------------------------------------------------
     def add(
-        self, session_id: str, kind: str, title: str, *, body: str = "", inbox: str = "default",
-        visibility: str = VIS_INBOX, data: Optional[dict[str, Any]] = None,
-        options=None, allow_text: bool = True, multi: bool = False,
+        self,
+        session_id: str,
+        kind: str,
+        title: str,
+        *,
+        body: str = "",
+        inbox: str = "default",
+        visibility: str = VIS_INBOX,
+        data: Optional[dict[str, Any]] = None,
+        options=None,
+        allow_text: bool = True,
+        multi: bool = False,
         tool_call_id: Optional[str] = None,
     ) -> InboxItem:
         # Idempotent by (session_id, tool_call_id): a durable resume re-raises the same prompt, and
@@ -121,9 +135,17 @@ class InboxStore:
             if existing is not None:
                 return existing
         item = InboxItem(
-            id=uuid.uuid4().hex, session_id=session_id, kind=kind, title=title,
-            body=body, inbox=inbox, visibility=visibility, data=dict(data or {}),
-            options=list(options or []), allow_text=bool(allow_text), multi=bool(multi),
+            id=uuid.uuid4().hex,
+            session_id=session_id,
+            kind=kind,
+            title=title,
+            body=body,
+            inbox=inbox,
+            visibility=visibility,
+            data=dict(data or {}),
+            options=list(options or []),
+            allow_text=bool(allow_text),
+            multi=bool(multi),
             tool_call_id=tool_call_id,
         )
         with self._lock:
@@ -137,36 +159,123 @@ class InboxStore:
                 return i
         return None
 
-    def add_approval(self, session_id, title, *, body="", inbox="default", visibility=VIS_INBOX, data=None, tool_call_id=None) -> InboxItem:
+    def add_approval(
+        self,
+        session_id,
+        title,
+        *,
+        body="",
+        inbox="default",
+        visibility=VIS_INBOX,
+        data=None,
+        tool_call_id=None,
+    ) -> InboxItem:
         # `data` carries the automation-run context for standing scoped approvals (§25):
         # {task_id, task_title, standing_target?} — the in-app card's "Allow every time" gate.
-        return self.add(session_id, KIND_APPROVAL, title, body=body, inbox=inbox, visibility=visibility, data=data, tool_call_id=tool_call_id)
-
-    def add_question(
-        self, session_id, title, *, body="", inbox="default", visibility=VIS_INBOX,
-        options=None, allow_text=True, multi=False, tool_call_id=None,
-    ) -> InboxItem:
         return self.add(
-            session_id, KIND_QUESTION, title, body=body, inbox=inbox, visibility=visibility,
-            options=options, allow_text=allow_text, multi=multi, tool_call_id=tool_call_id,
+            session_id,
+            KIND_APPROVAL,
+            title,
+            body=body,
+            inbox=inbox,
+            visibility=visibility,
+            data=data,
+            tool_call_id=tool_call_id,
         )
 
-    def add_directory(self, session_id, title, *, body="", inbox="default", visibility=VIS_INBOX, data=None, tool_call_id=None) -> InboxItem:
-        return self.add(session_id, KIND_DIRECTORY, title, body=body, inbox=inbox, visibility=visibility, data=data, tool_call_id=tool_call_id)
+    def add_question(
+        self,
+        session_id,
+        title,
+        *,
+        body="",
+        inbox="default",
+        visibility=VIS_INBOX,
+        options=None,
+        allow_text=True,
+        multi=False,
+        tool_call_id=None,
+    ) -> InboxItem:
+        return self.add(
+            session_id,
+            KIND_QUESTION,
+            title,
+            body=body,
+            inbox=inbox,
+            visibility=visibility,
+            options=options,
+            allow_text=allow_text,
+            multi=multi,
+            tool_call_id=tool_call_id,
+        )
 
-    def add_plan(self, session_id, title, *, body="", inbox="default", visibility=VIS_INBOX, data=None, tool_call_id=None) -> InboxItem:
-        return self.add(session_id, KIND_PLAN, title, body=body, inbox=inbox, visibility=visibility, data=data, tool_call_id=tool_call_id)
+    def add_directory(
+        self,
+        session_id,
+        title,
+        *,
+        body="",
+        inbox="default",
+        visibility=VIS_INBOX,
+        data=None,
+        tool_call_id=None,
+    ) -> InboxItem:
+        return self.add(
+            session_id,
+            KIND_DIRECTORY,
+            title,
+            body=body,
+            inbox=inbox,
+            visibility=visibility,
+            data=data,
+            tool_call_id=tool_call_id,
+        )
 
-    def add_notification(self, session_id, title, *, body="", inbox="default", visibility=VIS_INBOX) -> InboxItem:
-        return self.add(session_id, KIND_NOTIFICATION, title, body=body, inbox=inbox, visibility=visibility)
+    def add_plan(
+        self,
+        session_id,
+        title,
+        *,
+        body="",
+        inbox="default",
+        visibility=VIS_INBOX,
+        data=None,
+        tool_call_id=None,
+    ) -> InboxItem:
+        return self.add(
+            session_id,
+            KIND_PLAN,
+            title,
+            body=body,
+            inbox=inbox,
+            visibility=visibility,
+            data=data,
+            tool_call_id=tool_call_id,
+        )
+
+    def add_notification(
+        self, session_id, title, *, body="", inbox="default", visibility=VIS_INBOX
+    ) -> InboxItem:
+        return self.add(
+            session_id,
+            KIND_NOTIFICATION,
+            title,
+            body=body,
+            inbox=inbox,
+            visibility=visibility,
+        )
 
     # -- queries ----------------------------------------------------------------
     def get(self, item_id: str) -> Optional[InboxItem]:
         return self._items.get(item_id)
 
     def list(
-        self, *, session_id: Optional[str] = None, state: Optional[str] = None,
-        inbox: Optional[str] = None, visibility: Optional[str] = None,
+        self,
+        *,
+        session_id: Optional[str] = None,
+        state: Optional[str] = None,
+        inbox: Optional[str] = None,
+        visibility: Optional[str] = None,
     ) -> list[InboxItem]:
         out = list(self._items.values())
         if session_id is not None:
@@ -199,7 +308,9 @@ class InboxStore:
             waiter.set()
         return True
 
-    def resolve_session(self, session_id: str, resolution: str = "session deleted") -> int:
+    def resolve_session(
+        self, session_id: str, resolution: str = "session deleted"
+    ) -> int:
         """Resolve every still-pending item of a session (called when the session is deleted —
         an orphaned approval/question can never be meaningfully answered). Releases any waiter
         the usual way; returns how many items were closed."""
@@ -236,7 +347,8 @@ class InboxStore:
 # -- approver routing -----------------------------------------------------------
 def inbox_approver(store: InboxStore, session_id: str, *, inbox: str = "default"):
     """An Approver that routes a permission request to the Inbox and suspends until resolved.
-    Maps the resolution to an ApprovalOutcome (allow → ONCE, always → ALWAYS_TOOL, else DENY)."""
+    Maps the resolution to an ApprovalOutcome (allow → ONCE, always → ALWAYS_TOOL, else DENY).
+    """
     from .engine import ApprovalOutcome, PermissionRequest
 
     async def approve(request: "PermissionRequest") -> "ApprovalOutcome":

--- a/platform/coworker/inbox_routing.py
+++ b/platform/coworker/inbox_routing.py
@@ -19,7 +19,9 @@ from pathlib import Path
 from typing import Callable, Optional
 
 DEFAULT_INBOX = "default"
-_ID_TOKEN = re.compile(r"\[ocw:([0-9a-f]{6,})\]")  # embeds the item id in a delivered message
+_ID_TOKEN = re.compile(
+    r"\[ocw:([0-9a-f]{6,})\]"
+)  # embeds the item id in a delivered message
 
 
 @dataclass
@@ -33,7 +35,9 @@ class InboxRouting:
     def __init__(self, path: Optional[str | Path] = None) -> None:
         self.path = Path(path) if path else None
         self._lock = threading.Lock()
-        self._bindings: dict[str, InboxBinding] = {DEFAULT_INBOX: InboxBinding(DEFAULT_INBOX)}
+        self._bindings: dict[str, InboxBinding] = {
+            DEFAULT_INBOX: InboxBinding(DEFAULT_INBOX)
+        }
         self._persona_default: dict[str, str] = {}
         self._session_override: dict[str, str] = {}
         self._load()
@@ -64,7 +68,9 @@ class InboxRouting:
         )
 
     # -- config -----------------------------------------------------------------
-    def set_binding(self, name: str, *, channel: Optional[str] = None, target: str = "") -> None:
+    def set_binding(
+        self, name: str, *, channel: Optional[str] = None, target: str = ""
+    ) -> None:
         with self._lock:
             self._bindings[name] = InboxBinding(name, channel, target)
             self._save()
@@ -110,7 +116,9 @@ def deliver(item, binding: InboxBinding, sender: Optional[Sender]) -> bool:
     return True
 
 
-def resolve_from_reply(reply: str, resolve: Callable[[str, str], bool]) -> Optional[bool]:
+def resolve_from_reply(
+    reply: str, resolve: Callable[[str, str], bool]
+) -> Optional[bool]:
     """Correlate an inbound channel reply to its item (by the embedded id) and resolve it.
 
     Looks for the ``[ocw:<id>]`` token and an allow/deny intent; falls back to treating the whole

--- a/platform/coworker/overrides.py
+++ b/platform/coworker/overrides.py
@@ -56,7 +56,12 @@ class RiskOverrideStore:
         self.path.parent.mkdir(parents=True, exist_ok=True)
         self.path.write_text(
             json.dumps(
-                {"rules": [{"pattern": r.pattern, "risk": r.risk.value} for r in self._rules]},
+                {
+                    "rules": [
+                        {"pattern": r.pattern, "risk": r.risk.value}
+                        for r in self._rules
+                    ]
+                },
                 indent=2,
             ),
             encoding="utf-8",

--- a/platform/coworker/personas/loading.py
+++ b/platform/coworker/personas/loading.py
@@ -36,7 +36,9 @@ def consent_summary(m: PersonaManifest) -> dict:
     }
 
 
-def git_clone(url: str, dest: Path) -> None:  # pragma: no cover - exercised via injection
+def git_clone(
+    url: str, dest: Path
+) -> None:  # pragma: no cover - exercised via injection
     """Shallow-clone a persona repo. Injectable so tests don't touch the network."""
     dest.parent.mkdir(parents=True, exist_ok=True)
     subprocess.run(

--- a/platform/coworker/providers/matrix.py
+++ b/platform/coworker/providers/matrix.py
@@ -47,10 +47,18 @@ MATRIX: dict[str, ModelEntry] = {
     "gpt-5.5": ModelEntry("GPT-5.5 · OpenAI", _AGENTIC_VISION),
     # Fable 5 (2026-06-09) is GA; its Mythos 5 sibling is approved-orgs-only, so it
     # stays out of a picker meant for the public.
-    "anthropic:claude-fable-5": ModelEntry("Claude Fable 5 · Anthropic", _AGENTIC_VISION),
-    "anthropic:claude-opus-4-8": ModelEntry("Claude Opus 4.8 · Anthropic", _AGENTIC_VISION),
-    "anthropic:claude-sonnet-4-6": ModelEntry("Claude Sonnet 4.6 · Anthropic", _AGENTIC_VISION),
-    "anthropic:claude-haiku-4-5": ModelEntry("Claude Haiku 4.5 · Anthropic", _AGENTIC_VISION),
+    "anthropic:claude-fable-5": ModelEntry(
+        "Claude Fable 5 · Anthropic", _AGENTIC_VISION
+    ),
+    "anthropic:claude-opus-4-8": ModelEntry(
+        "Claude Opus 4.8 · Anthropic", _AGENTIC_VISION
+    ),
+    "anthropic:claude-sonnet-4-6": ModelEntry(
+        "Claude Sonnet 4.6 · Anthropic", _AGENTIC_VISION
+    ),
+    "anthropic:claude-haiku-4-5": ModelEntry(
+        "Claude Haiku 4.5 · Anthropic", _AGENTIC_VISION
+    ),
     "gemini:gemini-2.5-pro": ModelEntry("Gemini 2.5 Pro · Google", _AGENTIC_VISION),
     "gemini:gemini-2.5-flash": ModelEntry("Gemini 2.5 Flash · Google", _AGENTIC_VISION),
     # -- direct OpenAI-compatible vendors ----------------------------------------
@@ -65,12 +73,18 @@ MATRIX: dict[str, ModelEntry] = {
     # -- resellers (their model namespaces, verbatim) -----------------------------
     "together:zai-org/GLM-5.2": ModelEntry("GLM-5.2 · via Together"),
     "together:moonshotai/Kimi-K2.6": ModelEntry("Kimi K2.6 · via Together"),
-    "together:deepseek-ai/DeepSeek-V4-Pro": ModelEntry("DeepSeek V4 Pro · via Together"),
+    "together:deepseek-ai/DeepSeek-V4-Pro": ModelEntry(
+        "DeepSeek V4 Pro · via Together"
+    ),
     "together:meta-llama/Llama-4-Maverick-17B-128E-Instruct-FP8": ModelEntry(
         "Llama 4 Maverick · via Together"
     ),
-    "fireworks:accounts/fireworks/models/glm-5p2": ModelEntry("GLM-5.2 · via Fireworks"),
-    "fireworks:accounts/fireworks/models/kimi-k2p6": ModelEntry("Kimi K2.6 · via Fireworks"),
+    "fireworks:accounts/fireworks/models/glm-5p2": ModelEntry(
+        "GLM-5.2 · via Fireworks"
+    ),
+    "fireworks:accounts/fireworks/models/kimi-k2p6": ModelEntry(
+        "Kimi K2.6 · via Fireworks"
+    ),
     "fireworks:accounts/fireworks/models/deepseek-v4-pro": ModelEntry(
         "DeepSeek V4 Pro · via Fireworks"
     ),

--- a/platform/coworker/providers/openai_provider.py
+++ b/platform/coworker/providers/openai_provider.py
@@ -53,7 +53,10 @@ def _pin_reasoning_effort(kwargs: dict[str, Any]) -> None:
 
 def _effort_none_retry(kwargs: dict[str, Any], exc: Exception) -> dict[str, Any]:
     """Kwargs for the one retry this error earns, or re-raise anything else."""
-    if kwargs.get("reasoning_effort") == "none" or _EFFORT_ERROR not in str(exc).lower():
+    if (
+        kwargs.get("reasoning_effort") == "none"
+        or _EFFORT_ERROR not in str(exc).lower()
+    ):
         raise exc
     return {**kwargs, "reasoning_effort": "none"}
 

--- a/platform/coworker/providers/registry.py
+++ b/platform/coworker/providers/registry.py
@@ -128,7 +128,8 @@ def _openai_compat(vendor: str, default_base_url: str, env_key: Optional[str] = 
     Kimi, MiniMax, Qwen, xAI, Mistral). The key is resolved from the vendor's OWN profile (or its
     env var) — deliberately NOT from the OpenAI env/SecretStore fallback, so a configured OpenAI
     key is never silently sent to a different vendor's endpoint. Missing key ⇒ fail fast with a
-    vendor-named error (these are only built on demand, when one of their models is selected)."""
+    vendor-named error (these are only built on demand, when one of their models is selected).
+    """
 
     def build(profile: dict[str, Any], secrets: Any) -> ProviderClient:
         base_url = ((profile or {}).get("base_url") or "").strip() or default_base_url

--- a/platform/coworker/selfwake.py
+++ b/platform/coworker/selfwake.py
@@ -50,7 +50,9 @@ class WakeStore:
         self._lock = threading.Lock()
         self._wakes: dict[str, Wake] = {}
         if self.path and self.path.is_file():
-            for raw in json.loads(self.path.read_text(encoding="utf-8")).get("wakes", []):
+            for raw in json.loads(self.path.read_text(encoding="utf-8")).get(
+                "wakes", []
+            ):
                 w = Wake(**raw)
                 self._wakes[w.id] = w
 
@@ -64,21 +66,31 @@ class WakeStore:
         )
 
     def add_timer(self, session_id: str, fire_at: datetime, *, note: str = "") -> Wake:
-        w = Wake(uuid.uuid4().hex, session_id, KIND_TIMER, fire_at=fire_at.isoformat(), note=note)
+        w = Wake(
+            uuid.uuid4().hex,
+            session_id,
+            KIND_TIMER,
+            fire_at=fire_at.isoformat(),
+            note=note,
+        )
         with self._lock:
             self._wakes[w.id] = w
             self._save()
         return w
 
     def add_completion(self, session_id: str, job_id: str, *, note: str = "") -> Wake:
-        w = Wake(uuid.uuid4().hex, session_id, KIND_COMPLETION, job_id=job_id, note=note)
+        w = Wake(
+            uuid.uuid4().hex, session_id, KIND_COMPLETION, job_id=job_id, note=note
+        )
         with self._lock:
             self._wakes[w.id] = w
             self._save()
         return w
 
     def add_event(self, session_id: str, event_key: str, *, note: str = "") -> Wake:
-        w = Wake(uuid.uuid4().hex, session_id, KIND_EVENT, event_key=event_key, note=note)
+        w = Wake(
+            uuid.uuid4().hex, session_id, KIND_EVENT, event_key=event_key, note=note
+        )
         with self._lock:
             self._wakes[w.id] = w
             self._save()
@@ -91,7 +103,11 @@ class WakeStore:
         for w in self._wakes.values():
             if w.state != STATE_PENDING and w.state != STATE_DUE:
                 continue
-            if w.kind == KIND_TIMER and w.fire_at and datetime.fromisoformat(w.fire_at) <= now:
+            if (
+                w.kind == KIND_TIMER
+                and w.fire_at
+                and datetime.fromisoformat(w.fire_at) <= now
+            ):
                 out.append(w)
             elif w.kind in (KIND_COMPLETION, KIND_EVENT) and w.state == STATE_DUE:
                 out.append(w)
@@ -99,11 +115,15 @@ class WakeStore:
 
     def complete_job(self, job_id: str) -> list[Wake]:
         """Mark completion wakes for ``job_id`` as due (the job exited). Returns them."""
-        return self._mark_due(lambda w: w.kind == KIND_COMPLETION and w.job_id == job_id)
+        return self._mark_due(
+            lambda w: w.kind == KIND_COMPLETION and w.job_id == job_id
+        )
 
     def fire_event(self, event_key: str) -> list[Wake]:
         """Mark on-event wakes for ``event_key`` as due (a connector/webhook fired). Returns them."""
-        return self._mark_due(lambda w: w.kind == KIND_EVENT and w.event_key == event_key)
+        return self._mark_due(
+            lambda w: w.kind == KIND_EVENT and w.event_key == event_key
+        )
 
     def _mark_due(self, pred) -> list[Wake]:
         fired = []
@@ -127,7 +147,8 @@ class WakeStore:
         return [
             w
             for w in self._wakes.values()
-            if w.state != STATE_FIRED and (session_id is None or w.session_id == session_id)
+            if w.state != STATE_FIRED
+            and (session_id is None or w.session_id == session_id)
         ]
 
 
@@ -137,7 +158,9 @@ def selfwake_tools(store: WakeStore, session_id: str) -> list:
     def sleep_for(seconds: int, note: str = "") -> dict:
         """Suspend and wake this session after `seconds`. Use for polling/waiting without
         burning context while idle."""
-        w = store.add_timer(session_id, _now() + timedelta(seconds=int(seconds)), note=note)
+        w = store.add_timer(
+            session_id, _now() + timedelta(seconds=int(seconds)), note=note
+        )
         return {"ok": True, "wake_id": w.id, "fire_at": w.fire_at}
 
     def sleep_until(when_iso: str, note: str = "") -> dict:

--- a/platform/coworker/server/app.py
+++ b/platform/coworker/server/app.py
@@ -65,7 +65,9 @@ def _browser_page(
         color = _BRAND_COLORS.get(connector, "#3670b2")
         initial = _html.escape((connector[:1] or "?").upper())
         badge = f'<span class="mini" style="background:{color}">{initial}</span>'
-    icon = f'<div class="ico ok">✓{badge}</div>' if ok else '<div class="ico bad">✕</div>'
+    icon = (
+        f'<div class="ico ok">✓{badge}</div>' if ok else '<div class="ico bad">✕</div>'
+    )
     err = f'<div class="err">{_html.escape(error)}</div>' if error else ""
     return (
         "<!doctype html><html><head><meta charset='utf-8'>"
@@ -371,14 +373,20 @@ def create_app(manager: SessionManager) -> FastAPI:
                     }
                 markdown = manifest.get("manifest_markdown", "")
                 digest = "sha256:" + hashlib.sha256(markdown.encode()).hexdigest()
-                if manifest.get("manifest_hash") and manifest["manifest_hash"] != digest:
+                if (
+                    manifest.get("manifest_hash")
+                    and manifest["manifest_hash"] != digest
+                ):
                     return {"ok": False, "error": "manifest hash mismatch"}
                 with tempfile.TemporaryDirectory() as td:
                     (Path(td) / f"{slug}.md").write_text(markdown)
                     summaries = reg.install_from_dir(td)
                 cloud.gallery_install_event(manager.secrets, load_config(), slug)
             else:
-                return {"ok": False, "error": "provide a `dir`, `git_url`, or `gallery_slug`"}
+                return {
+                    "ok": False,
+                    "error": "provide a `dir`, `git_url`, or `gallery_slug`",
+                }
         except Exception as e:  # surface manifest/clone errors to the caller
             return {"ok": False, "error": str(e)}
         return {"ok": True, "consent": summaries, "personas": reg.list_all()}
@@ -404,7 +412,11 @@ def create_app(manager: SessionManager) -> FastAPI:
 
         body = cloud.gallery_list(manager.secrets, load_config())
         if body is None:
-            return {"ok": False, "error": "gallery requires cloud sign-in", "personas": []}
+            return {
+                "ok": False,
+                "error": "gallery requires cloud sign-in",
+                "personas": [],
+            }
         return {"ok": True, "personas": body.get("personas", [])}
 
     @app.post("/v1/personas/{persona_id}")
@@ -415,9 +427,9 @@ def create_app(manager: SessionManager) -> FastAPI:
             if "enabled" in body:
                 # Disable archives the persona's sessions atomically (server-side, one
                 # request) so any client gets the same semantic. See set_persona_enabled.
-                archived = manager.set_persona_enabled(persona_id, bool(body["enabled"]))[
-                    "archived_sessions"
-                ]
+                archived = manager.set_persona_enabled(
+                    persona_id, bool(body["enabled"])
+                )["archived_sessions"]
             if "surfaced" in body:
                 reg.set_surfaced(persona_id, bool(body["surfaced"]))
             if body.get("default"):
@@ -451,7 +463,9 @@ def create_app(manager: SessionManager) -> FastAPI:
         # Dedicated §5/§8 route; delegates to the same manager toggle as POST /v1/personas/{id}
         # (so disable archives the persona's sessions here too).
         try:
-            manager.set_persona_enabled(persona_id, bool((body or {}).get("enabled", True)))
+            manager.set_persona_enabled(
+                persona_id, bool((body or {}).get("enabled", True))
+            )
         except KeyError:
             return {"ok": False, "error": f"unknown persona: {persona_id}"}
         return {"ok": True, "personas": manager.personas.list_all()}
@@ -703,7 +717,10 @@ def create_app(manager: SessionManager) -> FastAPI:
         profile_key = gcal_accounts.PREFIX + email.strip().lower()
         await asyncio.to_thread(
             lambda: cloud.cloud_disconnect(
-                manager.secrets, load_config(), "google_calendar", profile_key=profile_key
+                manager.secrets,
+                load_config(),
+                "google_calendar",
+                profile_key=profile_key,
             )
         )
         return gcal_accounts.disconnect_account(manager.secrets, email)
@@ -829,10 +846,14 @@ def create_app(manager: SessionManager) -> FastAPI:
         from .. import cloud
         from ..config import load_config
 
-        signin_failed_detail = "Close this tab and try signing in again from OpenCoworker."
+        signin_failed_detail = (
+            "Close this tab and try signing in again from OpenCoworker."
+        )
         if error:
             return HTMLResponse(
-                _browser_page("Sign-in failed", signin_failed_detail, ok=False, error=error),
+                _browser_page(
+                    "Sign-in failed", signin_failed_detail, ok=False, error=error
+                ),
                 status_code=400,
             )
         result = await asyncio.to_thread(
@@ -861,7 +882,9 @@ def create_app(manager: SessionManager) -> FastAPI:
         )
 
     @app.post("/v1/connectors/{name}/connect-managed")
-    async def connector_connect_managed(name: str, body: Optional[dict] = None) -> dict[str, Any]:
+    async def connector_connect_managed(
+        name: str, body: Optional[dict] = None
+    ) -> dict[str, Any]:
         """One-click managed OAuth (requires cloud sign-in). Opens the provider
         consent page in the system browser; the broker's callback page will
         form-POST the tokens to /oauth/callback below. `access` picks a consent
@@ -898,7 +921,10 @@ def create_app(manager: SessionManager) -> FastAPI:
         if data.get("error"):
             return HTMLResponse(
                 _browser_page(
-                    "Connection failed", _CONNECT_FAILED_DETAIL, ok=False, error=data["error"]
+                    "Connection failed",
+                    _CONNECT_FAILED_DETAIL,
+                    ok=False,
+                    error=data["error"],
                 ),
                 status_code=400,
             )
@@ -931,7 +957,10 @@ def create_app(manager: SessionManager) -> FastAPI:
         if not connector or not data.get("access_token"):
             return HTMLResponse(
                 _browser_page(
-                    "Connection failed", _CONNECT_FAILED_DETAIL, ok=False, error="missing fields"
+                    "Connection failed",
+                    _CONNECT_FAILED_DETAIL,
+                    ok=False,
+                    error="missing fields",
                 ),
                 status_code=400,
             )
@@ -1009,7 +1038,9 @@ def create_app(manager: SessionManager) -> FastAPI:
         )
 
     @app.get("/v1/connectors/slack/workspaces/{team_id}/directory")
-    async def slack_directory(team_id: str, q: str = "", limit: int = 25) -> dict[str, Any]:
+    async def slack_directory(
+        team_id: str, q: str = "", limit: int = 25
+    ) -> dict[str, Any]:
         """Workspace member roster for the people picker (team_id "default" =
         the manual Socket-Mode workspace). Cached locally; never leaves this machine."""
         from ..connectors import slack_directory as roster
@@ -1019,7 +1050,9 @@ def create_app(manager: SessionManager) -> FastAPI:
         )
 
     @app.get("/v1/connectors/slack/workspaces/{team_id}/channels")
-    async def slack_channels(team_id: str, q: str = "", limit: int = 25) -> dict[str, Any]:
+    async def slack_channels(
+        team_id: str, q: str = "", limit: int = 25
+    ) -> dict[str, Any]:
         """Channel roster for the channel typeahead: all public channels, private
         ones only where the bot is a member (Slack API constraint)."""
         from ..connectors import slack_directory as roster

--- a/platform/coworker/server/manager.py
+++ b/platform/coworker/server/manager.py
@@ -544,7 +544,8 @@ class SessionManager:
         non-internal) sessions — disable means "put this coworker and its history away", so
         the persona's sidebar section disappears with it (owner call, 2026-07-04). Re-enabling
         never unarchives: that would overwrite the user's archive state; history returns one
-        click at a time via the Show-archived disclosure. Raises KeyError for unknown ids."""
+        click at a time via the Show-archived disclosure. Raises KeyError for unknown ids.
+        """
         self.personas.set_enabled(persona_id, enabled)
         archived = 0
         if not enabled:
@@ -588,7 +589,8 @@ class SessionManager:
         ``persona_id`` is the caller's hint (the GUI knows the active persona). It matters for a
         brand-new session: no SessionRecord exists until the first turn persists, so without the
         hint the view would resolve to the DEFAULT persona and show its defaults/recommends —
-        the owner's 2026-07-03 finding (a fresh Project Manager session rendered cowork's view)."""
+        the owner's 2026-07-03 finding (a fresh Project Manager session rendered cowork's view).
+        """
         persona = self._persona_of(session_id, persona_id)
         entry = self.personas.get(persona)
         manifest = entry.manifest if entry else None
@@ -1187,7 +1189,8 @@ class SessionManager:
     def pick_native_folder(self) -> dict[str, Any]:
         """Open the OS folder picker FROM THE SIDECAR — the browser GUI can't obtain absolute
         paths from web file dialogs, but the sidecar is local and can (the desktop shell uses
-        Tauri's own picker instead). Blocking until pick/cancel; callers run it off-thread."""
+        Tauri's own picker instead). Blocking until pick/cancel; callers run it off-thread.
+        """
         import subprocess
         import sys
 
@@ -1406,7 +1409,8 @@ class SessionManager:
         (`get_settings` culls the ones whose provider has no key) plus custom ids the user
         added, minus matrix models they removed. Deliberately NO built-in seed list — a
         fresh install offers nothing until a provider key exists, and then exactly that
-        provider's matrix models appear. The active default is always kept selectable."""
+        provider's matrix models appear. The active default is always kept selectable.
+        """
         from ..providers.matrix import MATRIX
 
         user = self._prefs.get("models")
@@ -1628,7 +1632,9 @@ class SessionManager:
         if not profile:
             return {
                 "ok": False,
-                "error": "workspace not connected" if team_id else "connector not connected",
+                "error": (
+                    "workspace not connected" if team_id else "connector not connected"
+                ),
             }
         allowed = set(profile.get("allowed_users") or [])
         allowed.add(user_id) if add else allowed.discard(user_id)
@@ -1709,8 +1715,12 @@ class SessionManager:
             "last_error": "",
         }
         teams: dict[str, Any] = {}
-        adapter = self.gateway._adapters.get("slack") if self.gateway is not None else None
-        snapshot = getattr(adapter, "status", None)  # relay adapter only; Socket Mode has none
+        adapter = (
+            self.gateway._adapters.get("slack") if self.gateway is not None else None
+        )
+        snapshot = getattr(
+            adapter, "status", None
+        )  # relay adapter only; Socket Mode has none
         if callable(snapshot):
             relay = snapshot()
             teams = relay.pop("teams", {})
@@ -1722,7 +1732,9 @@ class SessionManager:
             "teams": teams,
         }
 
-    async def disconnect_github_installation(self, installation_id: str) -> dict[str, Any]:
+    async def disconnect_github_installation(
+        self, installation_id: str
+    ) -> dict[str, Any]:
         """Stop relaying ONE GitHub installation: delete the cloud routing rows
         (best-effort), drop the local profile, hot-reload the gateway. The Slack
         per-workspace disconnect, GitHub flavour — a manual PAT stays untouched."""
@@ -1759,7 +1771,9 @@ class SessionManager:
         }
         installs: dict[str, Any] = {}
         missed: dict[str, Any] = {}
-        adapter = self.gateway._adapters.get("github") if self.gateway is not None else None
+        adapter = (
+            self.gateway._adapters.get("github") if self.gateway is not None else None
+        )
         snapshot = getattr(adapter, "status", None)
         if callable(snapshot):
             relay = snapshot()
@@ -1851,9 +1865,12 @@ class SessionManager:
             self.gateway = None
 
     # -- unauthorized inbound (parked, §19) --------------------------------------
-    def _note_person(self, platform: str, user_id: Optional[str], name: Optional[str]) -> None:
+    def _note_person(
+        self, platform: str, user_id: Optional[str], name: Optional[str]
+    ) -> None:
         """Remember a sender's display name (persisted) so ID-keyed surfaces — the allow-list
-        chips above all — can show who a U07JK… actually is. Best-effort, newest name wins."""
+        chips above all — can show who a U07JK… actually is. Best-effort, newest name wins.
+        """
         if not user_id or not name:
             return
         key = f"{platform}:{user_id}"
@@ -1886,7 +1903,8 @@ class SessionManager:
     ) -> dict[str, Any]:
         """Resolve one parked message: "dismiss" throws it away; "allow" adds the sender to the
         allow-list (future messages flow); "allow_deliver" also re-injects the parked message
-        through the NORMAL inbound path — buffer + subscriptions — as if it just arrived."""
+        through the NORMAL inbound path — buffer + subscriptions — as if it just arrived.
+        """
         item = self.parked.pop(item_id)
         if item is None or item.platform != name:
             return {"ok": False, "error": "unknown item"}
@@ -2006,7 +2024,8 @@ class SessionManager:
 
     def approval_outcome(self, resolution: str, request, session_id: str):
         """Map an approval resolution (from any surface) to an ApprovalOutcome, handling
-        the task-persistent "always_task" vocabulary alongside the session-scoped ones."""
+        the task-persistent "always_task" vocabulary alongside the session-scoped ones.
+        """
         from ..engine import ApprovalOutcome
 
         if resolution == "always_task":
@@ -2330,7 +2349,9 @@ class SessionManager:
                 if not self._inbound_connector_allowed(sub.session_id, src.platform):
                     continue
                 try:
-                    await self.deliver_to_session(sub.session_id, msg, source=ms.to_dict())
+                    await self.deliver_to_session(
+                        sub.session_id, msg, source=ms.to_dict()
+                    )
                 except Exception:
                     pass
             return
@@ -2370,7 +2391,9 @@ class SessionManager:
         self.mention_sessions.set(
             thread_target, sid, channel=f"{src.platform}:{src.chat_id}"
         )
-        engine.permissions.task_rules.setdefault("send_message", set()).add(thread_target)
+        engine.permissions.task_rules.setdefault("send_message", set()).add(
+            thread_target
+        )
         self.save(sid, engine)  # the sessions row must exist before rename/set_origin
         # Title = the ASK first, channel last (owner call 2026-07-14): the text is what
         # varies between sessions, so it gets the truncation budget; the mention token is

--- a/platform/coworker/server/run.py
+++ b/platform/coworker/server/run.py
@@ -112,7 +112,8 @@ def _ensure_ca_bundle() -> None:
     """Point SSL at certifi's CA bundle if the interpreter has none configured. macOS framework
     Python ships without a usable system trust store for `aiohttp` (it builds an `ssl` context with
     no CAs), so the Slack Socket-Mode client fails with CERTIFICATE_VERIFY_FAILED. `httpx`/`requests`
-    bundle certifi already; aiohttp honours the SSL_CERT_FILE env var, so set it once at startup."""
+    bundle certifi already; aiohttp honours the SSL_CERT_FILE env var, so set it once at startup.
+    """
     if os.environ.get("SSL_CERT_FILE"):
         return
     try:

--- a/platform/coworker/subscriptions.py
+++ b/platform/coworker/subscriptions.py
@@ -56,7 +56,9 @@ class SubscriptionStore:
         )
 
     # -- mutations --------------------------------------------------------------
-    def subscribe(self, session_id: str, channel: str, *, filter: str = "all") -> Subscription:
+    def subscribe(
+        self, session_id: str, channel: str, *, filter: str = "all"
+    ) -> Subscription:
         with self._lock:
             for s in self._subs:
                 if s.session_id == session_id and s.channel == channel:
@@ -72,7 +74,9 @@ class SubscriptionStore:
         with self._lock:
             before = len(self._subs)
             self._subs = [
-                s for s in self._subs if not (s.session_id == session_id and s.channel == channel)
+                s
+                for s in self._subs
+                if not (s.session_id == session_id and s.channel == channel)
             ]
             changed = len(self._subs) != before
             if changed:
@@ -144,8 +148,12 @@ class ChannelBuffer:
                 data = json.loads(self._path.read_text())
                 # Current format: {"messages": {...}, "names": {...}}; the first shipped
                 # format was the bare messages dict — accept both.
-                msgs_by_chan = data.get("messages", data) if isinstance(data, dict) else {}
-                self._names = dict(data.get("names") or {}) if isinstance(data, dict) else {}
+                msgs_by_chan = (
+                    data.get("messages", data) if isinstance(data, dict) else {}
+                )
+                self._names = (
+                    dict(data.get("names") or {}) if isinstance(data, dict) else {}
+                )
                 for chan, msgs in msgs_by_chan.items():
                     if isinstance(msgs, list):
                         self._by_channel[chan] = deque(msgs[-cap:], maxlen=cap)
@@ -181,7 +189,7 @@ class ChannelBuffer:
 
     def recent(self, channel: str, n: int = 10) -> list[dict]:
         msgs = list(self._by_channel.get(channel, ()))
-        return msgs[-max(1, min(n, self._cap)):]
+        return msgs[-max(1, min(n, self._cap)) :]
 
     def name_for(self, channel: str) -> Optional[str]:
         """The channel's resolved display name, if any inbound message carried one."""
@@ -222,7 +230,10 @@ def subscription_tools(
         or a channel id."""
         addr = resolve_channel(channel, default_platform=default_platform)
         if not addr or ":" not in addr:
-            return {"ok": False, "error": f"could not resolve a channel from {channel!r}"}
+            return {
+                "ok": False,
+                "error": f"could not resolve a channel from {channel!r}",
+            }
         store.subscribe(session_id, addr)
         warn = None
         if routing_targets and addr in routing_targets:
@@ -249,4 +260,9 @@ def subscription_tools(
         addr = resolve_channel(channel, default_platform=default_platform)
         return {"channel": addr, "messages": buffer.recent(addr, n)}
 
-    return [subscribe_channel, unsubscribe_channel, list_subscriptions, get_channel_messages]
+    return [
+        subscribe_channel,
+        unsubscribe_channel,
+        list_subscriptions,
+        get_channel_messages,
+    ]

--- a/platform/coworker/testing/fake_slack/server.py
+++ b/platform/coworker/testing/fake_slack/server.py
@@ -172,7 +172,9 @@ class FakeSlack:
         """Total Socket Mode connects so far — a reconnect bumps this."""
         return self._socket_connections
 
-    async def wait_socket_connections(self, at_least: int, timeout: float = 5.0) -> None:
+    async def wait_socket_connections(
+        self, at_least: int, timeout: float = 5.0
+    ) -> None:
         """Block until the client has connected `at_least` times (used to await a reconnect)."""
         deadline = asyncio.get_event_loop().time() + timeout
         while self._socket_connections < at_least:
@@ -184,7 +186,8 @@ class FakeSlack:
 
     async def close_sockets(self) -> None:
         """Drop every live Socket Mode connection from the server side — simulates Slack cycling
-        the connection so a reconnect (slack_sdk's or our watchdog's) has to re-establish it."""
+        the connection so a reconnect (slack_sdk's or our watchdog's) has to re-establish it.
+        """
         for ws in list(self._sockets):
             try:
                 await ws.close()

--- a/platform/coworker/tools/ask.py
+++ b/platform/coworker/tools/ask.py
@@ -39,7 +39,10 @@ def ask_user_tool() -> object:
         """
         # Real handling lives in the engine (it needs the out-of-band Inbox round-trip). This body
         # only runs if no question_asker is wired (e.g. a headless surface).
-        return {"answer": "", "error": "asking the user isn't available in this surface"}
+        return {
+            "answer": "",
+            "error": "asking the user isn't available in this surface",
+        }
 
     return tool(
         ask_user,

--- a/platform/coworker/unrouted.py
+++ b/platform/coworker/unrouted.py
@@ -51,11 +51,13 @@ class UnroutedStore:
         )
 
     def record(self, source: str, sender: str, text: str, reason: str) -> UnroutedItem:
-        item = UnroutedItem(source=source or "?", sender=sender or "-", text=text or "", reason=reason)
+        item = UnroutedItem(
+            source=source or "?", sender=sender or "-", text=text or "", reason=reason
+        )
         with self._lock:
             self._items.append(item)
             if len(self._items) > self._cap:
-                self._items = self._items[-self._cap:]
+                self._items = self._items[-self._cap :]
             self._save()
         return item
 

--- a/platform/tests/test_accounts.py
+++ b/platform/tests/test_accounts.py
@@ -9,7 +9,11 @@ import pytest
 
 from coworker.connectors import accounts, descriptors
 from coworker.connectors.descriptors import ConnectorDescriptor, Field, ValidationResult
-from coworker.connectors.setup import connect_connector, connector_list, disconnect_connector
+from coworker.connectors.setup import (
+    connect_connector,
+    connector_list,
+    disconnect_connector,
+)
 from coworker.secrets import SecretStore
 
 

--- a/platform/tests/test_cloud.py
+++ b/platform/tests/test_cloud.py
@@ -87,7 +87,9 @@ def test_complete_login_stores_tokens_and_account(secrets, config, monkeypatch):
         assert url == "https://tenant.auth0.test/oauth/token"
         assert kwargs["data"]["code_verifier"]
         assert kwargs["data"]["redirect_uri"] == authorize_redirect
-        return FakeResponse(200, {"access_token": "at1", "refresh_token": "rt1", "expires_in": 3600})
+        return FakeResponse(
+            200, {"access_token": "at1", "refresh_token": "rt1", "expires_in": 3600}
+        )
 
     def fake_get(url, **kwargs):
         if url == "https://cloud.test/v1/me":
@@ -158,9 +160,16 @@ def test_sync_connections_restores_github_installs(secrets, config, monkeypatch)
     _signed_in(secrets)
     rows = [
         _github_connection_row(),
-        {"connector": "slack", "status": "connected", "tenant_metadata": {"team_id": "T1"}},
-        {"connector": "github", "status": "disconnected",
-         "tenant_metadata": {"installation_id": "999", "github_login": "octocat"}},
+        {
+            "connector": "slack",
+            "status": "connected",
+            "tenant_metadata": {"team_id": "T1"},
+        },
+        {
+            "connector": "github",
+            "status": "disconnected",
+            "tenant_metadata": {"installation_id": "999", "github_login": "octocat"},
+        },
     ]
     monkeypatch.setattr(
         cloud.httpx, "get", lambda url, **k: FakeResponse(200, {"connections": rows})
@@ -178,7 +187,9 @@ def test_sync_connections_restores_github_installs(secrets, config, monkeypatch)
     assert default["mode"] == "relay" and default["default_install"] == "101"
 
 
-def test_sync_connections_pre_restore_rows_fall_back_to_primary(secrets, config, monkeypatch):
+def test_sync_connections_pre_restore_rows_fall_back_to_primary(
+    secrets, config, monkeypatch
+):
     """Rows written before the broker stored the installations list carry only
     the primary install in tenant_metadata — restore that one."""
     _signed_in(secrets)
@@ -192,7 +203,9 @@ def test_sync_connections_pre_restore_rows_fall_back_to_primary(secrets, config,
     assert secrets.get("github:install:101")["account_login"] == "acme"
 
 
-def test_sync_connections_requires_sign_in_and_survives_errors(secrets, config, monkeypatch):
+def test_sync_connections_requires_sign_in_and_survives_errors(
+    secrets, config, monkeypatch
+):
     assert not cloud.sync_connections(secrets, config)["ok"]  # signed out
     _signed_in(secrets)
     monkeypatch.setattr(cloud.httpx, "get", lambda url, **k: FakeResponse(503, {}))
@@ -357,10 +370,17 @@ def test_emit_sends_nothing_signed_out(secrets, config, monkeypatch):
         raise AssertionError("signed-out users must send no telemetry")
 
     monkeypatch.setattr(cloud.httpx, "post", boom)
-    assert cloud.emit_session_created(
-        secrets, config, session_id="s1", persona_id="sales",
-        persona_family="knowledge", workspace_kind="deliverable",
-    ) is False
+    assert (
+        cloud.emit_session_created(
+            secrets,
+            config,
+            session_id="s1",
+            persona_id="sales",
+            persona_family="knowledge",
+            workspace_kind="deliverable",
+        )
+        is False
+    )
 
 
 def test_emit_sends_nothing_when_opted_out(secrets, config, monkeypatch):
@@ -370,8 +390,12 @@ def test_emit_sends_nothing_when_opted_out(secrets, config, monkeypatch):
         cloud.httpx, "post", lambda *a, **k: (_ for _ in ()).throw(AssertionError())
     )
     assert not cloud.emit_session_created(
-        secrets, config, session_id="s1", persona_id="sales",
-        persona_family="knowledge", workspace_kind="deliverable",
+        secrets,
+        config,
+        session_id="s1",
+        persona_id="sales",
+        persona_family="knowledge",
+        workspace_kind="deliverable",
     )
 
 
@@ -386,8 +410,12 @@ def test_emit_is_content_free_and_hashes_session_id(secrets, config, monkeypatch
 
     monkeypatch.setattr(cloud.httpx, "post", fake_post)
     ok = cloud.emit_session_created(
-        secrets, config, session_id="sess-secret-id", persona_id="sales",
-        persona_family="knowledge", workspace_kind="deliverable",
+        secrets,
+        config,
+        session_id="sess-secret-id",
+        persona_id="sales",
+        persona_family="knowledge",
+        workspace_kind="deliverable",
     )
     assert ok
     assert sent["url"] == "https://cloud.test/v1/telemetry/events"
@@ -397,7 +425,10 @@ def test_emit_is_content_free_and_hashes_session_id(secrets, config, monkeypatch
     assert "sess-secret-id" not in str(body)  # raw id never leaves the device
     assert body["session"]["session_id_hash"].startswith("sha256:")
     assert set(body["session"]) == {
-        "session_id_hash", "persona_id", "persona_family", "workspace_kind",
+        "session_id_hash",
+        "persona_id",
+        "persona_family",
+        "workspace_kind",
     }
 
 
@@ -421,8 +452,16 @@ You are the Sales Coworker."""
 
     def fake_get(s, c, path):
         if path.endswith("/manifest"):
-            return {"slug": "sales", "manifest_markdown": manifest_md, "manifest_hash": ""}
-        return {"slug": "sales", "name": "Sales Coworker", "pitch_markdown": "**pitch**"}
+            return {
+                "slug": "sales",
+                "manifest_markdown": manifest_md,
+                "manifest_hash": "",
+            }
+        return {
+            "slug": "sales",
+            "name": "Sales Coworker",
+            "pitch_markdown": "**pitch**",
+        }
 
     monkeypatch.setattr(cloud, "_gallery_get", fake_get)
     out = cloud.gallery_detail(secrets, config, "sales")

--- a/platform/tests/test_cloud_server.py
+++ b/platform/tests/test_cloud_server.py
@@ -171,7 +171,9 @@ def test_cloud_gallery_endpoint_signed_out(client):
 
 def test_delete_persona_after_gallery_install(client, monkeypatch):
     _stub_gallery(monkeypatch)
-    assert client.post("/v1/personas/install", json={"gallery_slug": "sales"}).json()["ok"]
+    assert client.post("/v1/personas/install", json={"gallery_slug": "sales"}).json()[
+        "ok"
+    ]
     body = client.delete("/v1/personas/sales").json()
     assert body["ok"]
     assert "sales" not in {p["id"] for p in body["personas"]}

--- a/platform/tests/test_connectors.py
+++ b/platform/tests/test_connectors.py
@@ -284,7 +284,9 @@ def test_engine_connector_tools_are_cowork_scoped(tmp_path):
         is False
     )
     assert (
-        cowork_with_github.registry.get("github_create_issue").metadata.requires_approval
+        cowork_with_github.registry.get(
+            "github_create_issue"
+        ).metadata.requires_approval
         is True
     )
 
@@ -304,7 +306,9 @@ def test_connector_list_descriptors(tmp_path):
     # relay (inbound mentions) but sessions can't subscribe to "GitHub channels".
     assert by_name["telegram"]["channels"] is True
     assert by_name["slack"]["channels"] is True
-    assert by_name["github"]["two_way"] is True and by_name["github"]["channels"] is False
+    assert (
+        by_name["github"]["two_way"] is True and by_name["github"]["channels"] is False
+    )
     assert (
         by_name["gmail"]["available"] is True and by_name["gmail"]["connected"] is False
     )
@@ -740,7 +744,10 @@ def test_new_tools_error_when_not_connected(tmp_path):
     assert "not connected" in tools["hubspot_search"]("acme")["error"]
     assert "not connected" in tools["posthog_query"]("SELECT 1")["error"]
     assert "not connected" in tools["mixpanel_top_events"]()["error"]
-    assert "not connected" in tools["amplitude_active_users"]("20260701", "20260707")["error"]
+    assert (
+        "not connected"
+        in tools["amplitude_active_users"]("20260701", "20260707")["error"]
+    )
     assert "not connected" in tools["apollo_enrich_company"]("acme.io")["error"]
     assert "not connected" in tools["hunter_verify_email"]("a@b.co")["error"]
     assert "not connected" in tools["dropbox_list_folder"]()["error"]
@@ -913,7 +920,10 @@ def test_batch2_tools_request_routing(tmp_path, monkeypatch):
 
     tools["notion_query_database"]("db1")
     assert calls[-1]["url"].endswith("/v1/databases/db1/query")
-    assert "must be a Notion filter" in tools["notion_query_database"]("db1", "nope")["error"]
+    assert (
+        "must be a Notion filter"
+        in tools["notion_query_database"]("db1", "nope")["error"]
+    )
 
     tools["notion_create_page"]("pg1", "Weekly notes", "line one\n\nline two")
     assert calls[-1]["json"]["parent"] == {"page_id": "pg1"}

--- a/platform/tests/test_connectors_allowlist.py
+++ b/platform/tests/test_connectors_allowlist.py
@@ -1,5 +1,7 @@
 """Allow-list surfacing on the Connectors tab: GET /v1/connectors carries the allow-list as a list
-plus the gateway's recently-seen senders (each flagged authorized), and allow/disallow mutate it."""
+plus the gateway's recently-seen senders (each flagged authorized), and allow/disallow mutate it.
+"""
+
 from fastapi.testclient import TestClient
 
 from coworker.providers import ModelCapabilities, ProviderClient
@@ -29,7 +31,12 @@ class _Gateway:
 def _connected_slack(mgr, allowed=()):
     mgr.secrets.put(
         "slack:default",
-        {"type": "token", "bot_token": "xoxb-1", "app_token": "xapp-1", "allowed_users": list(allowed)},
+        {
+            "type": "token",
+            "bot_token": "xoxb-1",
+            "app_token": "xapp-1",
+            "allowed_users": list(allowed),
+        },
     )
 
 
@@ -42,8 +49,20 @@ def test_connectors_carry_allowlist_and_recent(tmp_path):
     _connected_slack(mgr, allowed=["U_OK"])
     mgr.gateway = _Gateway(
         recent=[
-            {"user_id": "U_OK", "user_name": "Ann", "chat_id": "D1", "chat_type": "dm", "target": "slack:D1"},
-            {"user_id": "U_NEW", "user_name": "Bob", "chat_id": "D2", "chat_type": "dm", "target": "slack:D2"},
+            {
+                "user_id": "U_OK",
+                "user_name": "Ann",
+                "chat_id": "D1",
+                "chat_type": "dm",
+                "target": "slack:D1",
+            },
+            {
+                "user_id": "U_NEW",
+                "user_name": "Bob",
+                "chat_id": "D2",
+                "chat_type": "dm",
+                "target": "slack:D2",
+            },
         ]
     )
     client = TestClient(create_app(mgr))
@@ -63,10 +82,14 @@ def test_allow_then_disallow_mutates_list(tmp_path):
     client = TestClient(create_app(mgr))
 
     client.post("/v1/connectors/slack/allow", json={"user_id": "U_NEW"})
-    assert _slack(client.get("/v1/connectors").json()["connectors"])["allowed_users"] == ["U_NEW"]
+    assert _slack(client.get("/v1/connectors").json()["connectors"])[
+        "allowed_users"
+    ] == ["U_NEW"]
 
     client.post("/v1/connectors/slack/disallow", json={"user_id": "U_NEW"})
-    assert _slack(client.get("/v1/connectors").json()["connectors"])["allowed_users"] == []
+    assert (
+        _slack(client.get("/v1/connectors").json()["connectors"])["allowed_users"] == []
+    )
 
 
 def test_recent_absent_when_no_gateway(tmp_path):

--- a/platform/tests/test_dm_routing.py
+++ b/platform/tests/test_dm_routing.py
@@ -33,7 +33,10 @@ def _connect_slack(mgr):
     """Inbound delivery is gated on the connector being CONNECTED (§4.3). Tests used to pass
     by riding the developer's real Slack profile; with the isolated state dir (conftest) each
     test must connect its own."""
-    mgr.secrets.put("slack:default", {"bot_token": "xoxb-test", "app_token": "xapp-test", "enabled": True})
+    mgr.secrets.put(
+        "slack:default",
+        {"bot_token": "xoxb-test", "app_token": "xapp-test", "enabled": True},
+    )
 
 
 def test_dm_with_designated_session_delivers(tmp_path, monkeypatch):

--- a/platform/tests/test_durable_resume.py
+++ b/platform/tests/test_durable_resume.py
@@ -1,8 +1,14 @@
 """Durable resume: a prompt pending when the process 'restarts' is answered later and the turn
 continues — rebuilt from the persisted thread, with no live await."""
+
 import asyncio
 
-from coworker.providers import AssistantTurn, ModelCapabilities, ProviderClient, ToolCall
+from coworker.providers import (
+    AssistantTurn,
+    ModelCapabilities,
+    ProviderClient,
+    ToolCall,
+)
 from coworker.server.manager import SessionManager
 
 
@@ -51,14 +57,30 @@ async def _run_until_pending(mgr, sid, engine):
 
 def _final_assistant_texts(mgr, sid):
     rec = mgr.session_store.load(sid)
-    return [m.get("content") for m in rec.messages if m.get("role") == "assistant" and m.get("content")]
+    return [
+        m.get("content")
+        for m in rec.messages
+        if m.get("role") == "assistant" and m.get("content")
+    ]
 
 
 def test_durable_resume_question(tmp_path):
-    mgr = SessionManager(workspace=tmp_path, provider=ScriptedProvider([
-        _tool("ask_user", {"question": "Which region?", "options": ["us-east-1", "us-west-2"]}, "call_q"),
-        _text("You chose us-west-2."),
-    ]))
+    mgr = SessionManager(
+        workspace=tmp_path,
+        provider=ScriptedProvider(
+            [
+                _tool(
+                    "ask_user",
+                    {
+                        "question": "Which region?",
+                        "options": ["us-east-1", "us-west-2"],
+                    },
+                    "call_q",
+                ),
+                _text("You chose us-west-2."),
+            ]
+        ),
+    )
     sid = "dur-q"
 
     async def scenario():
@@ -75,10 +97,15 @@ def test_durable_resume_question(tmp_path):
 def test_durable_resume_approval_executes_tool(tmp_path):
     # The model wants a write (needs approval); on durable resume "allow" must RE-EXECUTE the tool.
     target = tmp_path / "scratch_marker.txt"
-    mgr = SessionManager(workspace=tmp_path, provider=ScriptedProvider([
-        _tool("write_file", {"path": str(target), "content": "ok"}, "call_w"),
-        _text("Done — file written."),
-    ]))
+    mgr = SessionManager(
+        workspace=tmp_path,
+        provider=ScriptedProvider(
+            [
+                _tool("write_file", {"path": str(target), "content": "ok"}, "call_w"),
+                _text("Done — file written."),
+            ]
+        ),
+    )
     sid = "dur-a"
 
     async def scenario():
@@ -86,8 +113,12 @@ def test_durable_resume_approval_executes_tool(tmp_path):
         item = await _run_until_pending(mgr, sid, engine)
         assert item.kind == "approval" and item.tool_call_id == "call_w"
         assert not target.exists()  # not executed before approval
-        await mgr.resolve_inbox(item.id, "allow")  # restart-style resume → re-execute the tool
+        await mgr.resolve_inbox(
+            item.id, "allow"
+        )  # restart-style resume → re-execute the tool
 
     asyncio.run(scenario())
-    assert target.exists() and target.read_text() == "ok"  # the approved write actually ran
+    assert (
+        target.exists() and target.read_text() == "ok"
+    )  # the approved write actually ran
     assert any("Done" in (t or "") for t in _final_assistant_texts(mgr, sid))

--- a/platform/tests/test_gateway_inbox_reply.py
+++ b/platform/tests/test_gateway_inbox_reply.py
@@ -53,7 +53,8 @@ async def test_freetext_answer_to_question_is_consumed(tmp_path):
     gw = Gateway(
         settings=settings,
         handler=handler,
-        reply_resolver=lambda ev: resolve_from_reply(ev.text, inbox.resolve) is not None,
+        reply_resolver=lambda ev: resolve_from_reply(ev.text, inbox.resolve)
+        is not None,
     )
     fake = FakeAdapter()
     gw.register(fake)

--- a/platform/tests/test_gcal_accounts.py
+++ b/platform/tests/test_gcal_accounts.py
@@ -64,7 +64,12 @@ def _fake_gcal(monkeypatch, responses: dict[str, dict]):
 def test_legacy_default_migrates_to_one_account(secrets):
     secrets.put(
         "google_calendar:default",
-        {"type": "oauth", "enabled": True, "access_token": "ya29", "account": "Old@X.com"},
+        {
+            "type": "oauth",
+            "enabled": True,
+            "access_token": "ya29",
+            "account": "Old@X.com",
+        },
     )
     accounts = gcal_accounts.list_accounts(secrets)
     assert [e for e, _ in accounts] == ["old@x.com"]
@@ -128,7 +133,10 @@ def test_tools_pick_the_requested_account_token(secrets, monkeypatch):
     assert out["ok"] and out["account"] == "one@x.com"
     out = listing(account="two@y.com")
     assert out["ok"] and out["account"] == "two@y.com"
-    assert [t for _, _, t, _ in calls] == ["Bearer tok-one@x.com", "Bearer tok-two@y.com"]
+    assert [t for _, _, t, _ in calls] == [
+        "Bearer tok-one@x.com",
+        "Bearer tok-two@y.com",
+    ]
 
     out = listing(account="nobody@z.com")
     assert "no google calendar account" in out["error"]
@@ -150,7 +158,9 @@ def test_legacy_single_account_still_works_via_tools(secrets, monkeypatch):
 
 def test_update_event_patches_only_provided_fields(secrets, monkeypatch):
     gcal_accounts.managed_connect_account(secrets, _account("me@x.com"))
-    calls = _fake_gcal(monkeypatch, {"/events/ev1": {"ok": True, "data": {"id": "ev1"}}})
+    calls = _fake_gcal(
+        monkeypatch, {"/events/ev1": {"ok": True, "data": {"id": "ev1"}}}
+    )
     out = _tool(secrets, "gcal_update_event")(
         "ev1", summary="Moved", start="2026-07-10T10:00:00Z"
     )
@@ -173,7 +183,9 @@ def test_update_event_with_nothing_to_change_refuses(secrets, monkeypatch):
 def test_delete_event_targets_the_calendar(secrets, monkeypatch):
     gcal_accounts.managed_connect_account(secrets, _account("me@x.com"))
     calls = _fake_gcal(monkeypatch, {"/events/ev9": {"ok": True, "data": ""}})
-    out = _tool(secrets, "gcal_delete_event")("ev9", calendar_id="team@group.calendar.google.com")
+    out = _tool(secrets, "gcal_delete_event")(
+        "ev9", calendar_id="team@group.calendar.google.com"
+    )
     assert out["ok"]
     method, url, _, _ = calls[0]
     assert method == "DELETE"
@@ -213,7 +225,9 @@ def test_write_tools_require_approval(secrets):
 def test_account_profile_refreshes_in_place(secrets, monkeypatch):
     from coworker import cloud
 
-    secrets.put(cloud.CLOUD_AUTH_PROFILE, {"access_token": "jwt", "expires": time.time() + 3600})
+    secrets.put(
+        cloud.CLOUD_AUTH_PROFILE, {"access_token": "jwt", "expires": time.time() + 3600}
+    )
     gcal_accounts.managed_connect_account(
         secrets,
         _account(

--- a/platform/tests/test_github_installs.py
+++ b/platform/tests/test_github_installs.py
@@ -113,9 +113,7 @@ def test_disconnect_one_installation_keeps_the_other(client, monkeypatch):
     assert cloud_calls == ["101"]
     assert client.manager.secrets.get("github:install:101") is None
     assert client.manager.secrets.get("github:install:202") is not None
-    gh = next(
-        c for c in client.manager.list_connectors() if c["name"] == "github"
-    )
+    gh = next(c for c in client.manager.list_connectors() if c["name"] == "github")
     assert gh["connected"] is True
     assert [i["installation_id"] for i in gh["installations"]] == ["202"]
 
@@ -263,7 +261,12 @@ async def test_adapter_missed_and_revoked_frames():
         lambda: "jwt",
         transport_factory=lambda: FakeTransport(
             [
-                {"provider": "github", "kind": "missed", "channel": "acme/site", "count": 3},
+                {
+                    "provider": "github",
+                    "kind": "missed",
+                    "channel": "acme/site",
+                    "count": 3,
+                },
                 {"provider": "github", "kind": "revoked", "installation_id": "101"},
             ]
         ),
@@ -285,7 +288,9 @@ def test_addressing_roundtrip():
 
 async def test_send_posts_comment_with_minted_token(monkeypatch):
     """Replies mint the right installation's token and post as the bot."""
-    hub = RelayHub("wss://x", lambda: "jwt", transport_factory=lambda: FakeTransport([]))
+    hub = RelayHub(
+        "wss://x", lambda: "jwt", transport_factory=lambda: FakeTransport([])
+    )
     minted: list[str] = []
 
     async def token_client(installation_id: str) -> str:
@@ -445,9 +450,7 @@ def test_managed_401_reminted_once(tmp_path, monkeypatch):
         lambda s, c, iid, *, force=False: minted.append(force) or "ghs_x",
     )
     responses = iter([{"error": "HTTP 401"}, {"ok": True, "data": {}}])
-    monkeypatch.setattr(
-        integration_tools, "_request", lambda *a, **k: next(responses)
-    )
+    monkeypatch.setattr(integration_tools, "_request", lambda *a, **k: next(responses))
 
     out = _tool(secrets, "github_review")("acme", "site", 5, "APPROVE")
     assert out["ok"] is True
@@ -490,7 +493,11 @@ def test_list_commits_filters_and_trims(tmp_path, monkeypatch):
 
     monkeypatch.setattr(integration_tools, "_request", fake_request)
     out = _tool(secrets, "github_list_commits")(
-        "acme", "site", since="2026-07-06T00:00:00Z", author="rohit-dev", max_results=200
+        "acme",
+        "site",
+        since="2026-07-06T00:00:00Z",
+        author="rohit-dev",
+        max_results=200,
     )
     assert seen["url"].endswith("/repos/acme/site/commits")
     assert seen["params"]["since"] == "2026-07-06T00:00:00Z"
@@ -506,7 +513,10 @@ def _git(args, cwd):
 
     return subprocess.run(
         ["git", "-c", "user.name=t", "-c", "user.email=t@t", *args],
-        cwd=cwd, check=True, capture_output=True, text=True,
+        cwd=cwd,
+        check=True,
+        capture_output=True,
+        text=True,
     )
 
 

--- a/platform/tests/test_gmail_accounts.py
+++ b/platform/tests/test_gmail_accounts.py
@@ -48,7 +48,12 @@ def _tool(secrets, name: str):
 def test_legacy_default_migrates_to_one_account(secrets):
     secrets.put(
         "gmail:default",
-        {"type": "oauth", "enabled": True, "access_token": "ya29", "account": "Old@X.com"},
+        {
+            "type": "oauth",
+            "enabled": True,
+            "access_token": "ya29",
+            "account": "Old@X.com",
+        },
     )
     accounts = gmail_accounts.list_accounts(secrets)
     assert [e for e, _ in accounts] == ["old@x.com"]
@@ -62,7 +67,11 @@ def test_legacy_default_migrates_to_one_account(secrets):
 def test_migration_preserves_filters_and_is_idempotent(secrets):
     secrets.put(
         "gmail:default",
-        {"access_token": "t", "account": "a@x.com", "filters": {"senders": ["ceo@x.com"]}},
+        {
+            "access_token": "t",
+            "account": "a@x.com",
+            "filters": {"senders": ["ceo@x.com"]},
+        },
     )
     gmail_accounts.migrate_legacy_default(secrets)
     gmail_accounts.migrate_legacy_default(secrets)
@@ -96,7 +105,9 @@ def test_last_disconnect_keeps_filters_only(secrets):
     gmail_accounts.disconnect_account(secrets, "one@x.com")
     listed = {c["name"]: c for c in connector_list(secrets)}
     assert not listed["gmail"]["connected"]
-    assert gmail_accounts.get_filters(secrets)["senders"] == ["@spam.com"]  # policy survives
+    assert gmail_accounts.get_filters(secrets)["senders"] == [
+        "@spam.com"
+    ]  # policy survives
 
 
 def test_full_disconnect_drops_every_account(secrets):
@@ -203,7 +214,10 @@ def test_get_filtered_message_reads_like_a_real_404(secrets, monkeypatch):
     out = _tool(secrets, "gmail_get_message")("m1")
     assert out["error"] == "HTTP 404"
     assert out["_display"] == {"hidden_by_filters": 1, "connector": "gmail"}
-    assert "filter" not in json.dumps({k: v for k, v in out.items() if k != "_display"}).lower()
+    assert (
+        "filter"
+        not in json.dumps({k: v for k, v in out.items() if k != "_display"}).lower()
+    )
 
 
 def test_label_filter_uses_label_names(secrets, monkeypatch):
@@ -254,7 +268,9 @@ def test_sender_rule_matching():
 def test_account_profile_refreshes_in_place(secrets, monkeypatch):
     from coworker import cloud
 
-    secrets.put(cloud.CLOUD_AUTH_PROFILE, {"access_token": "jwt", "expires": time.time() + 3600})
+    secrets.put(
+        cloud.CLOUD_AUTH_PROFILE, {"access_token": "jwt", "expires": time.time() + 3600}
+    )
     gmail_accounts.managed_connect_account(
         secrets,
         _account(

--- a/platform/tests/test_hubspot_portals.py
+++ b/platform/tests/test_hubspot_portals.py
@@ -48,7 +48,12 @@ def _tool(secrets, name: str):
 def test_legacy_private_app_default_migrates_to_one_portal(secrets):
     secrets.put(
         "hubspot:default",
-        {"type": "token", "enabled": True, "token": "pat-x", "account": "portal 424242"},
+        {
+            "type": "token",
+            "enabled": True,
+            "token": "pat-x",
+            "account": "portal 424242",
+        },
     )
     portals = hubspot_portals.list_portals(secrets)
     assert [h for h, _ in portals] == ["424242"]
@@ -60,7 +65,8 @@ def test_legacy_private_app_default_migrates_to_one_portal(secrets):
 def test_managed_portals_list_with_access_and_sandbox(secrets):
     hubspot_portals.managed_connect_portal(secrets, _portal("111", sandbox=True))
     hubspot_portals.managed_connect_portal(
-        secrets, _portal("222", scope="crm.objects.contacts.read crm.objects.deals.write")
+        secrets,
+        _portal("222", scope="crm.objects.contacts.read crm.objects.deals.write"),
     )
     listed = {c["name"]: c for c in connector_list(secrets)}
     hs = listed["hubspot"]
@@ -107,7 +113,9 @@ def _fake_hubspot(monkeypatch, responses: dict[str, dict]):
 def test_tools_pick_the_requested_portal_by_id_or_name(secrets, monkeypatch):
     hubspot_portals.managed_connect_portal(secrets, _portal("111"))
     hubspot_portals.managed_connect_portal(secrets, _portal("222"))
-    calls = _fake_hubspot(monkeypatch, {"/search": {"ok": True, "data": {"results": []}}})
+    calls = _fake_hubspot(
+        monkeypatch, {"/search": {"ok": True, "data": {"results": []}}}
+    )
     search = _tool(secrets, "hubspot_search")
 
     out = search("acme")  # default portal
@@ -117,7 +125,9 @@ def test_tools_pick_the_requested_portal_by_id_or_name(secrets, monkeypatch):
     out = search("acme", portal="acme-222")  # by name too
     assert out["portal"] == "acme-222"
     assert [t for _, t, _ in calls] == [
-        "Bearer tok-111", "Bearer tok-222", "Bearer tok-222",
+        "Bearer tok-111",
+        "Bearer tok-222",
+        "Bearer tok-222",
     ]
     out = search("acme", portal="999")
     assert "no hubspot portal" in out["error"]
@@ -159,7 +169,9 @@ def test_no_delete_tool_exists(secrets):
     assert not any("delete" in n for n in names if n.startswith("hubspot"))
     # the write surface is exactly: create contact, update, note, task
     assert {
-        "hubspot_update_object", "hubspot_log_note", "hubspot_create_task",
+        "hubspot_update_object",
+        "hubspot_log_note",
+        "hubspot_create_task",
         "hubspot_create_contact",
     } <= names
 
@@ -211,8 +223,12 @@ def test_managed_callback_lands_in_portal_profile(client):
     listed = {c["name"]: c for c in client.manager.list_connectors()}
     row = listed["hubspot"]["portals"][0]
     assert row == {
-        "hub_id": "424242", "name": "Acme Inc", "sandbox": True,
-        "default": True, "managed": True, "access": "read",
+        "hub_id": "424242",
+        "name": "Acme Inc",
+        "sandbox": True,
+        "default": True,
+        "managed": True,
+        "access": "read",
     }
 
 
@@ -228,6 +244,7 @@ def test_portal_routes_default_and_disconnect(client, monkeypatch):
     assert r["ok"] and r["remaining_portals"] == 1
 
     r = client.patch(
-        "/v1/connectors/hubspot/hidden-fields", json={"hidden_fields": ["Salary", "ssn "]}
+        "/v1/connectors/hubspot/hidden-fields",
+        json={"hidden_fields": ["Salary", "ssn "]},
     ).json()
     assert r["hidden_fields"] == ["salary", "ssn"]  # normalized

--- a/platform/tests/test_inbox.py
+++ b/platform/tests/test_inbox.py
@@ -106,7 +106,10 @@ def test_inbox_approver_deny(tmp_path):
 def test_args_preview():
     from coworker.inbox import args_preview
 
-    assert args_preview({"path": "g.txt", "content": "buy milk"}) == "path: g.txt · content: buy milk"
+    assert (
+        args_preview({"path": "g.txt", "content": "buy milk"})
+        == "path: g.txt · content: buy milk"
+    )
     assert args_preview(None) == "" and args_preview({}) == ""
     assert "\n" not in args_preview({"x": "a\nb\nc"})  # newlines collapsed
     assert args_preview({"content": "z" * 300}).endswith("…")  # long values truncated
@@ -116,7 +119,9 @@ def test_approval_body_includes_tool_args():
     from coworker.engine import PermissionRequest
     from coworker.server.manager import _approval_body
 
-    req = PermissionRequest("write_file", {"path": "groceries.txt", "content": "buy milk"}, None, "")
+    req = PermissionRequest(
+        "write_file", {"path": "groceries.txt", "content": "buy milk"}, None, ""
+    )
     body = _approval_body(req)
     assert "groceries.txt" in body and "buy milk" in body  # the card now shows *what*
 

--- a/platform/tests/test_inbox_routing.py
+++ b/platform/tests/test_inbox_routing.py
@@ -54,7 +54,10 @@ def test_in_app_only_binding_delivers_nothing(tmp_path):
     routing = InboxRouting(tmp_path / "routing.json")
     item = store.add_approval("s1", "x", inbox=DEFAULT_INBOX)
     calls = []
-    assert deliver(item, routing.binding_for(DEFAULT_INBOX), lambda *a: calls.append(a)) is False
+    assert (
+        deliver(item, routing.binding_for(DEFAULT_INBOX), lambda *a: calls.append(a))
+        is False
+    )
     assert calls == []
 
 

--- a/platform/tests/test_interactions.py
+++ b/platform/tests/test_interactions.py
@@ -1,4 +1,5 @@
 """Interactive prompts over messaging: button encoding, block rendering, and the click→resolve path."""
+
 import asyncio
 import json
 
@@ -73,8 +74,13 @@ def test_interaction_click_resolves_item(tmp_path):
         waiter = asyncio.create_task(fake_wait(item.id))
         await asyncio.sleep(0)  # let the waiter register
         await mgr._on_interaction(
-            InteractionEvent(platform="slack", chat_id="C1", message_id="111.2",
-                             value=encode(item.id, "allow"), user_name="bob")
+            InteractionEvent(
+                platform="slack",
+                chat_id="C1",
+                message_id="111.2",
+                value=encode(item.id, "allow"),
+                user_name="bob",
+            )
         )
         await asyncio.wait_for(waiter, timeout=2)
 

--- a/platform/tests/test_mention_router.py
+++ b/platform/tests/test_mention_router.py
@@ -25,7 +25,11 @@ class CapturingProvider(ProviderClient):
 
     def complete(self, *, model, messages, tools=None, **settings):
         self.calls.append([dict(m) for m in messages])
-        return self._turns.pop(0) if self._turns else AssistantTurn(text="ok", finish_reason="stop")
+        return (
+            self._turns.pop(0)
+            if self._turns
+            else AssistantTurn(text="ok", finish_reason="stop")
+        )
 
     def capabilities(self, model):
         return ModelCapabilities()
@@ -33,12 +37,19 @@ class CapturingProvider(ProviderClient):
 
 def _connect_slack(mgr):
     mgr.secrets.put(
-        "slack:default", {"bot_token": "xoxb-test", "app_token": "xapp-test", "enabled": True}
+        "slack:default",
+        {"bot_token": "xoxb-test", "app_token": "xapp-test", "enabled": True},
     )
 
 
-def _mention_event(text="<@UBOT> check the deploy?", *, chat_id="C1", ts="1700000010.000100",
-                   thread_ts=None, team_id=None):
+def _mention_event(
+    text="<@UBOT> check the deploy?",
+    *,
+    chat_id="C1",
+    ts="1700000010.000100",
+    thread_ts=None,
+    team_id=None
+):
     return MessageEvent(
         text=text,
         source=SessionSource(
@@ -84,8 +95,12 @@ def _capture_deliveries(mgr, monkeypatch):
 def test_slack_mapper_computes_mentions_me():
     base = {"channel": "C1", "user": "U1", "ts": "1.2", "channel_type": "channel"}
     assert slack_event_to_event({**base, "text": "<@UBOT> hi"}, "UBOT").mentions_me
-    assert slack_event_to_event({**base, "text": "hey <@UBOT|ocw> hi"}, "UBOT").mentions_me
-    assert not slack_event_to_event({**base, "text": "<@UOTHER> hi"}, "UBOT").mentions_me
+    assert slack_event_to_event(
+        {**base, "text": "hey <@UBOT|ocw> hi"}, "UBOT"
+    ).mentions_me
+    assert not slack_event_to_event(
+        {**base, "text": "<@UOTHER> hi"}, "UBOT"
+    ).mentions_me
     # No bot id known (misconfigured) → never flags.
     assert not slack_event_to_event({**base, "text": "<@UBOT> hi"}, None).mentions_me
 
@@ -114,7 +129,7 @@ def test_mention_spawns_visible_session_with_thread_grant(tmp_path, monkeypatch)
     assert target in mgr._engines[sid].permissions.task_rules["send_message"]
 
     # The opening turn carries the reply contract and went to the new session.
-    (got_sid, opening, source) = captured[-1]
+    got_sid, opening, source = captured[-1]
     assert got_sid == sid
     assert target in opening and "pre-approved" in opening
     assert source["connector"] == "slack" and source["kind"] == "channel"
@@ -129,8 +144,11 @@ def test_followup_tag_steers_same_session(tmp_path, monkeypatch):
     # The follow-up arrives IN the thread (thread_ts = the first message's ts).
     asyncio.run(
         mgr._dispatch_inbound(
-            _mention_event("<@UBOT> and staging too", ts="1700000012.000300",
-                           thread_ts="1700000010.000100")
+            _mention_event(
+                "<@UBOT> and staging too",
+                ts="1700000012.000300",
+                thread_ts="1700000010.000100",
+            )
         )
     )
 
@@ -145,7 +163,11 @@ def test_distinct_thread_spawns_distinct_session(tmp_path, monkeypatch):
     _capture_deliveries(mgr, monkeypatch)
 
     asyncio.run(mgr._dispatch_inbound(_mention_event()))
-    asyncio.run(mgr._dispatch_inbound(_mention_event("<@UBOT> other thing", ts="1700000099.000900")))
+    asyncio.run(
+        mgr._dispatch_inbound(
+            _mention_event("<@UBOT> other thing", ts="1700000099.000900")
+        )
+    )
 
     sids = {t.session_id for t in mgr.mention_sessions.all()}
     assert len(sids) == 2
@@ -218,7 +240,7 @@ def test_untagged_channel_traffic_stays_judgement_only(tmp_path, monkeypatch):
 
     asyncio.run(mgr._dispatch_inbound(_plain_event()))
 
-    (_, message, _) = captured[0]
+    _, message, _ = captured[0]
     assert "subscribed" in message and "stay silent" in message
     # …and with NO subscriber, an untagged message never spawns anything (buffered only).
     captured.clear()
@@ -232,7 +254,9 @@ def test_untagged_channel_traffic_stays_judgement_only(tmp_path, monkeypatch):
 
 def test_set_origin_round_trips_and_survives_saves(tmp_path):
     store = ConversationStore(tmp_path)
-    rec = SessionRecord(session_id="s1", workspace=str(tmp_path), model="m", mode="interactive")
+    rec = SessionRecord(
+        session_id="s1", workspace=str(tmp_path), model="m", mode="interactive"
+    )
     store.save(rec)
     assert store.set_origin("s1", "slack", "#general · T1")
     loaded = store.load("s1")

--- a/platform/tests/test_message_source.py
+++ b/platform/tests/test_message_source.py
@@ -72,7 +72,10 @@ def _connect_slack(mgr):
     """Inbound delivery is gated on the connector being CONNECTED (§4.3). Tests used to pass
     by riding the developer's real Slack profile; with the isolated state dir (conftest) each
     test must connect its own."""
-    mgr.secrets.put("slack:default", {"bot_token": "xoxb-test", "app_token": "xapp-test", "enabled": True})
+    mgr.secrets.put(
+        "slack:default",
+        {"bot_token": "xoxb-test", "app_token": "xapp-test", "enabled": True},
+    )
 
 
 def test_inbound_builds_message_source(tmp_path, monkeypatch):
@@ -191,8 +194,11 @@ def test_tool_display_sidecar_is_agent_invisible(tmp_path):
     tc = ToolCall(id="t1", name="gmail_search_messages", arguments={"query": "q"})
     engine._record_result(
         tc,
-        {"ok": True, "data": {"messages": [{"id": "m2"}]},
-         "_display": {"hidden_by_filters": 2, "connector": "gmail"}},
+        {
+            "ok": True,
+            "data": {"messages": [{"id": "m2"}]},
+            "_display": {"hidden_by_filters": 2, "connector": "gmail"},
+        },
         "ok",
     )
 

--- a/platform/tests/test_model_errors.py
+++ b/platform/tests/test_model_errors.py
@@ -1,6 +1,7 @@
 """New-flagship rollout (2026-07-14): GPT-5.6 Sol/Terra/Luna + Claude Fable 5 in the
 matrix, both families' flagships as defaults, and friendly errors when an account can't
-use them (GPT-5.6 rolls out per-organization; quota/credits can run out on any model)."""
+use them (GPT-5.6 rolls out per-organization; quota/credits can run out on any model).
+"""
 
 from coworker.config import Config
 from coworker.providers.errors import friendly_model_error
@@ -65,7 +66,21 @@ def test_quota_errors_are_translated():
 
 def test_unrelated_errors_pass_through_raw():
     # a plain rate-limit (429 without a quota code) must NOT be dressed up
-    assert friendly_model_error("gpt-5.6-sol", RuntimeError("Error code: 429 - rate_limit_exceeded, retry after 2s")) is None
+    assert (
+        friendly_model_error(
+            "gpt-5.6-sol",
+            RuntimeError("Error code: 429 - rate_limit_exceeded, retry after 2s"),
+        )
+        is None
+    )
     # a 404 from a wrong base_url isn't an access problem
-    assert friendly_model_error("gpt-5.6-sol", RuntimeError("Error code: 404 - no route /v2/chat")) is None
-    assert friendly_model_error("gpt-5.6-sol", RuntimeError("connection reset by peer")) is None
+    assert (
+        friendly_model_error(
+            "gpt-5.6-sol", RuntimeError("Error code: 404 - no route /v2/chat")
+        )
+        is None
+    )
+    assert (
+        friendly_model_error("gpt-5.6-sol", RuntimeError("connection reset by peer"))
+        is None
+    )

--- a/platform/tests/test_persona_connections.py
+++ b/platform/tests/test_persona_connections.py
@@ -66,7 +66,9 @@ def test_persona_detail_endpoint(tmp_path, monkeypatch):
     assert detail["id"] == "ops"
     assert detail["name"] == "Ops Coworker"
     assert detail["enabled"] is False  # non-default personas ship disabled (opt-in)
-    assert detail["workspace"] == "deliverable"  # §16 collapse: ops is a scratch persona now
+    assert (
+        detail["workspace"] == "deliverable"
+    )  # §16 collapse: ops is a scratch persona now
     assert detail["default_permission_mode"] == "interactive"
     assert "anthropic:claude-opus-4-8" in detail["recommended_models"]
     assert set(detail["tools"]) == {"files", "search", "shell", "todo"}
@@ -200,7 +202,9 @@ def test_fresh_session_view_uses_persona_hint(tmp_path, monkeypatch):
 
     # without the hint the same fresh session would fall back to the default persona
     fallback = client.get("/v1/sessions/brand-new/connections").json()
-    assert {c["connector"]: c for c in fallback["connected"]}["slack"]["enabled"] is True
+    assert {c["connector"]: c for c in fallback["connected"]}["slack"][
+        "enabled"
+    ] is True
 
 
 def test_session_set_override(tmp_path, monkeypatch):

--- a/platform/tests/test_provider_router.py
+++ b/platform/tests/test_provider_router.py
@@ -312,7 +312,8 @@ def test_manager_provider_config(tmp_path, monkeypatch):
 
 def test_manager_curated_models(tmp_path, monkeypatch):
     """No seed list: the picker is the curated matrix filtered to key-holding providers,
-    plus user-added custom ids. A fresh install shows only the (not-yet-usable) default."""
+    plus user-added custom ids. A fresh install shows only the (not-yet-usable) default.
+    """
     monkeypatch.setenv("COWORKER_STATE_DIR", str(tmp_path / "state"))
     from coworker.providers.registry import provider_descriptors
 

--- a/platform/tests/test_providers.py
+++ b/platform/tests/test_providers.py
@@ -143,7 +143,9 @@ def test_gpt56_tools_pin_reasoning_effort_none():
     assert [c["reasoning_effort"] for c in calls] == ["none"] * 3
 
     # an explicit caller choice is respected on the first attempt
-    provider.complete(model="gpt-5.6-sol", messages=[], tools=_TOOLS, reasoning_effort="low")
+    provider.complete(
+        model="gpt-5.6-sol", messages=[], tools=_TOOLS, reasoning_effort="low"
+    )
     assert calls[3]["reasoning_effort"] == "low"
 
     # no tools, or another model → the request is untouched
@@ -309,7 +311,9 @@ def test_compat_builder_never_leaks_the_openai_key(monkeypatch):
 def test_compat_models_route_and_get_tool_capabilities():
     from coworker.providers.router import ProviderRouter
 
-    router = ProviderRouter.__new__(ProviderRouter)  # only using _provider_name (stateless)
+    router = ProviderRouter.__new__(
+        ProviderRouter
+    )  # only using _provider_name (stateless)
     for model in (
         "zai:glm-5.2",
         "deepseek:deepseek-v4-flash",

--- a/platform/tests/test_send_file.py
+++ b/platform/tests/test_send_file.py
@@ -50,7 +50,12 @@ def test_send_file_success_within_workspace(tmp_path):
     )
 
     out = tool("slack:C9:1700.1", "report.pdf", comment="here you go")
-    assert out == {"ok": True, "file_id": "F123", "target": "slack:C9:1700.1", "filename": "report.pdf"}
+    assert out == {
+        "ok": True,
+        "file_id": "F123",
+        "target": "slack:C9:1700.1",
+        "filename": "report.pdf",
+    }
     sent = record[0]
     assert sent["chat_id"] == "C9" and sent["thread_id"] == "1700.1"
     assert sent["data"] == b"%PDF-fake" and sent["comment"] == "here you go"
@@ -97,7 +102,9 @@ def test_send_file_unsupported_platform_and_missing_token(tmp_path):
     assert "not supported" in tool("telegram:123", "a.txt")["error"]
 
     no_token = make_send_file_tool(
-        _secrets(tmp_path / "nt", token=None), workspace=ws, file_senders=_fake_sender([])
+        _secrets(tmp_path / "nt", token=None),
+        workspace=ws,
+        file_senders=_fake_sender([]),
     )
     assert "no bot token" in no_token("slack:C9", "a.txt")["error"]
 
@@ -115,7 +122,10 @@ def test_send_file_screenshot_is_html_only_and_renames_to_png(tmp_path):
         render_html=lambda p: b"PNG-bytes-for-" + Path(p).name.encode(),
     )
 
-    assert "only applies to .html" in tool("slack:C9", "notes.md", as_screenshot=True)["error"]
+    assert (
+        "only applies to .html"
+        in tool("slack:C9", "notes.md", as_screenshot=True)["error"]
+    )
 
     out = tool("slack:C9", "dash.html", as_screenshot=True)
     assert out["ok"] and out["filename"] == "dash.png"
@@ -132,10 +142,16 @@ def test_thread_send_message_grant_never_covers_send_file(tmp_path):
     from coworker.connectors.tools import make_send_file_tool, make_send_message_tool
 
     msg_meta = make_send_message_tool(_secrets(tmp_path)).__aisuite_tool_metadata__
-    file_meta = make_send_file_tool(_secrets(tmp_path), workspace=tmp_path).__aisuite_tool_metadata__
+    file_meta = make_send_file_tool(
+        _secrets(tmp_path), workspace=tmp_path
+    ).__aisuite_tool_metadata__
 
-    allowed = engine.evaluate("send_message", {"target": target, "text": "hi"}, msg_meta)
+    allowed = engine.evaluate(
+        "send_message", {"target": target, "text": "hi"}, msg_meta
+    )
     assert allowed.allowed and "standing rule" in allowed.reason
 
-    asked = engine.evaluate("send_file", {"target": target, "path": "report.pdf"}, file_meta)
+    asked = engine.evaluate(
+        "send_file", {"target": target, "path": "report.pdf"}, file_meta
+    )
     assert not asked.allowed and asked.needs_user

--- a/platform/tests/test_send_target_resolution.py
+++ b/platform/tests/test_send_target_resolution.py
@@ -26,17 +26,28 @@ def test_integration_tools_reads_are_free_writes_gate(tmp_path):
         for t in make_integration_tools(SecretStore(tmp_path / "secrets.json"))
     }
     assert tools["github_search"].__aisuite_tool_metadata__.requires_approval is False
-    assert tools["github_list_commits"].__aisuite_tool_metadata__.requires_approval is False
-    assert tools["browser_read_url"].__aisuite_tool_metadata__.requires_approval is False
-    assert tools["github_create_issue"].__aisuite_tool_metadata__.requires_approval is True
+    assert (
+        tools["github_list_commits"].__aisuite_tool_metadata__.requires_approval
+        is False
+    )
+    assert (
+        tools["browser_read_url"].__aisuite_tool_metadata__.requires_approval is False
+    )
+    assert (
+        tools["github_create_issue"].__aisuite_tool_metadata__.requires_approval is True
+    )
 
 
 def test_browser_automation_reads_are_free_interactions_gate():
     from coworker.connectors.browser_automation import make_browser_automation_tools
 
     tools = {t.__name__: t for t in make_browser_automation_tools()}
-    assert tools["browser_snapshot"].__aisuite_tool_metadata__.requires_approval is False
-    assert tools["browser_open_url"].__aisuite_tool_metadata__.requires_approval is False
+    assert (
+        tools["browser_snapshot"].__aisuite_tool_metadata__.requires_approval is False
+    )
+    assert (
+        tools["browser_open_url"].__aisuite_tool_metadata__.requires_approval is False
+    )
     assert tools["browser_click"].__aisuite_tool_metadata__.requires_approval is True
     assert tools["browser_type"].__aisuite_tool_metadata__.requires_approval is True
 
@@ -77,7 +88,16 @@ def test_channel_name_resolves_to_team_qualified_address(tmp_path, monkeypatch):
     secrets = _secrets_with_team(tmp_path)
     _fake_roster(
         monkeypatch,
-        {"T1": [{"id": "C9", "name": "all-opencoworker", "is_private": False, "is_member": True}]},
+        {
+            "T1": [
+                {
+                    "id": "C9",
+                    "name": "all-opencoworker",
+                    "is_private": False,
+                    "is_member": True,
+                }
+            ]
+        },
     )
     record: list = []
     tool = make_send_message_tool(secrets, senders=_record_sender(record))
@@ -85,7 +105,9 @@ def test_channel_name_resolves_to_team_qualified_address(tmp_path, monkeypatch):
     out = tool("slack:#all-opencoworker", "Hi")
     assert out["ok"] is True
     assert record[0]["chat_id"] == "T1/C9"
-    assert record[0]["token"] == "xoxb-t1"  # the resolved team's token, not slack:default
+    assert (
+        record[0]["token"] == "xoxb-t1"
+    )  # the resolved team's token, not slack:default
 
 
 def test_bare_channel_names_coerce_to_slack(tmp_path, monkeypatch):
@@ -95,7 +117,16 @@ def test_bare_channel_names_coerce_to_slack(tmp_path, monkeypatch):
     secrets = _secrets_with_team(tmp_path)
     _fake_roster(
         monkeypatch,
-        {"T1": [{"id": "C9", "name": "all-opencoworker", "is_private": False, "is_member": True}]},
+        {
+            "T1": [
+                {
+                    "id": "C9",
+                    "name": "all-opencoworker",
+                    "is_private": False,
+                    "is_member": True,
+                }
+            ]
+        },
     )
     record: list = []
     tool = make_send_message_tool(secrets, senders=_record_sender(record))
@@ -130,7 +161,16 @@ def test_unknown_ambiguous_and_not_member_names_error_actionably(tmp_path, monke
 
     _fake_roster(
         monkeypatch,
-        {"T1": [{"id": "C3", "name": "private-ops", "is_private": True, "is_member": False}]},
+        {
+            "T1": [
+                {
+                    "id": "C3",
+                    "name": "private-ops",
+                    "is_private": True,
+                    "is_member": False,
+                }
+            ]
+        },
     )
     secrets.delete("slack:team:T2")
     assert "invite @ocw" in tool("slack:#private-ops", "Hi")["error"]
@@ -143,7 +183,11 @@ def test_send_file_resolves_names_too(tmp_path, monkeypatch):
     (ws / "r.pdf").write_bytes(b"%PDF")
     _fake_roster(
         monkeypatch,
-        {"T1": [{"id": "C9", "name": "general", "is_private": False, "is_member": True}]},
+        {
+            "T1": [
+                {"id": "C9", "name": "general", "is_private": False, "is_member": True}
+            ]
+        },
     )
     record: list = []
 
@@ -151,6 +195,8 @@ def test_send_file_resolves_names_too(tmp_path, monkeypatch):
         record.append({"chat_id": chat_id, "filename": filename})
         return SendResult(True, message_id="F1")
 
-    tool = make_send_file_tool(secrets, workspace=ws, file_senders={"slack": file_sender})
+    tool = make_send_file_tool(
+        secrets, workspace=ws, file_senders={"slack": file_sender}
+    )
     out = tool("slack:#general", "r.pdf")
     assert out["ok"] is True and record[0]["chat_id"] == "T1/C9"

--- a/platform/tests/test_server.py
+++ b/platform/tests/test_server.py
@@ -84,15 +84,20 @@ def test_disable_persona_archives_its_sessions(tmp_path):
     def mk(sid, agent):
         store.save(
             SessionRecord(
-                session_id=sid, workspace=str(tmp_path), model="m",
-                mode="interactive", agent=agent,
+                session_id=sid,
+                workspace=str(tmp_path),
+                model="m",
+                mode="interactive",
+                agent=agent,
             )
         )
 
     mk("chat-a", "chat")
     mk("chat-b", "chat")
     mk("chat-old", "chat")
-    store.set_flags("chat-old", archived=True)  # already archived — must not be re-counted
+    store.set_flags(
+        "chat-old", archived=True
+    )  # already archived — must not be re-counted
     mk("cowork-a", "cowork")
     mk("__run__r1", "chat")  # internal automation thread — never touched
 
@@ -456,7 +461,12 @@ def test_delete_session_removes_its_scratch_dir_only(tmp_path):
 
     scratch = Path(mgr._provision_scratch("sess-scratch"))
     mgr.session_store.save(
-        SessionRecord(session_id="sess-scratch", workspace=str(scratch), model="m", mode="interactive")
+        SessionRecord(
+            session_id="sess-scratch",
+            workspace=str(scratch),
+            model="m",
+            mode="interactive",
+        )
     )
     assert mgr.delete_session("sess-scratch")["ok"]
     assert not scratch.exists()
@@ -464,7 +474,9 @@ def test_delete_session_removes_its_scratch_dir_only(tmp_path):
     proj = tmp_path / "real-project"
     proj.mkdir()
     mgr.session_store.save(
-        SessionRecord(session_id="sess-proj", workspace=str(proj), model="m", mode="interactive")
+        SessionRecord(
+            session_id="sess-proj", workspace=str(proj), model="m", mode="interactive"
+        )
     )
     assert mgr.delete_session("sess-proj")["ok"]
     assert proj.is_dir()  # user folders are sacred
@@ -575,15 +587,14 @@ def test_ws_first_message_binds_the_session_model_then_locks(tmp_path):
     2026-07-04: a new cowork session reconnects to adopt its scratch dir, which could drop a
     queued set_model and leave the engine on a stale/resumed model). After the first turn the
     model is FIXED for the session's life: later message models and set_model are ignored
-    (owner call, 2026-07-04 — mixed-model transcripts invite provider-quirk breakage)."""
+    (owner call, 2026-07-04 — mixed-model transcripts invite provider-quirk breakage).
+    """
     client = _client(tmp_path, [_text("ok"), _text("ok again"), _text("still ok")])
     with client.websocket_connect("/ws/session/model-per-msg") as ws:
         ready = ws.receive_json()
         assert ready["type"] == "ready"
         default_model = ready["data"]["model"]
-        ws.send_json(
-            {"type": "user_message", "text": "hi", "model": "zai:glm-5.2"}
-        )
+        ws.send_json({"type": "user_message", "text": "hi", "model": "zai:glm-5.2"})
         _drain(ws)
         # message WITHOUT a model keeps the bound one (no silent reset to default)
         ws.send_json({"type": "user_message", "text": "again"})
@@ -625,14 +636,21 @@ def test_pick_native_folder_paths(tmp_path, monkeypatch):
     monkeypatch.setattr(
         subprocess,
         "run",
-        lambda *a, **k: SimpleNamespace(returncode=0, stdout="/tmp/picked\n", stderr=""),
+        lambda *a, **k: SimpleNamespace(
+            returncode=0, stdout="/tmp/picked\n", stderr=""
+        ),
     )
-    assert client.post("/v1/workspaces/pick").json() == {"ok": True, "path": "/tmp/picked"}
+    assert client.post("/v1/workspaces/pick").json() == {
+        "ok": True,
+        "path": "/tmp/picked",
+    }
 
     monkeypatch.setattr(
         subprocess,
         "run",
-        lambda *a, **k: SimpleNamespace(returncode=1, stdout="", stderr="User canceled."),
+        lambda *a, **k: SimpleNamespace(
+            returncode=1, stdout="", stderr="User canceled."
+        ),
     )
     assert client.post("/v1/workspaces/pick").json()["ok"] is False
 

--- a/platform/tests/test_session_events.py
+++ b/platform/tests/test_session_events.py
@@ -1,5 +1,7 @@
 """Per-session event bus: a background turn (channel delivery, self-wake, durable resume) streams
-its events to every socket viewing that session — delivery itself stays socket-independent."""
+its events to every socket viewing that session — delivery itself stays socket-independent.
+"""
+
 import asyncio
 
 from coworker.providers import AssistantTurn, ModelCapabilities, ProviderClient
@@ -43,7 +45,9 @@ def _types(events):
 
 
 def test_deliver_broadcasts_turn_events(tmp_path):
-    mgr = SessionManager(workspace=tmp_path, provider=ScriptedProvider([_text("hello")]))
+    mgr = SessionManager(
+        workspace=tmp_path, provider=ScriptedProvider([_text("hello")])
+    )
     mgr.get_engine("S", agent="chat")  # materialize a durable, workspace-free session
     events, cb = _collector()
     mgr.register_session_client("S", cb)
@@ -52,7 +56,9 @@ def test_deliver_broadcasts_turn_events(tmp_path):
 
     types = _types(events)
     assert types[0] == "turn_start"
-    assert events[0]["data"]["input"] == "hi"  # the inbound message surfaces as a user item
+    assert (
+        events[0]["data"]["input"] == "hi"
+    )  # the inbound message surfaces as a user item
     assert "assistant_message" in types
     assert types[-1] == "turn_done"
 
@@ -71,7 +77,9 @@ def test_deliver_broadcasts_to_multiple_clients(tmp_path):
 
 
 def test_unregister_stops_delivery(tmp_path):
-    mgr = SessionManager(workspace=tmp_path, provider=ScriptedProvider([_text("a"), _text("b")]))
+    mgr = SessionManager(
+        workspace=tmp_path, provider=ScriptedProvider([_text("a"), _text("b")])
+    )
     mgr.get_engine("S", agent="chat")
     events, cb = _collector()
     mgr.register_session_client("S", cb)
@@ -121,4 +129,7 @@ def test_unrouted_endpoint(tmp_path):
     client = TestClient(create_app(mgr))
     items = client.get("/v1/unrouted").json()["items"]
     assert len(items) == 1
-    assert items[0]["source"] == "slack:D1" and items[0]["reason"] == "no DM session designated"
+    assert (
+        items[0]["source"] == "slack:D1"
+        and items[0]["reason"] == "no DM session designated"
+    )

--- a/platform/tests/test_session_persona.py
+++ b/platform/tests/test_session_persona.py
@@ -1,7 +1,8 @@
 """Phase 1 gate — a session is born from exactly one persona; pin + rename persist.
 
 The persona binding rides on the existing ``SessionRecord.agent`` column (immutable in
-practice — ``get_engine`` always rebuilds from it). Pin = ``pinned`` flag; rename = ``title``."""
+practice — ``get_engine`` always rebuilds from it). Pin = ``pinned`` flag; rename = ``title``.
+"""
 
 from __future__ import annotations
 
@@ -17,8 +18,11 @@ def test_session_records_its_persona(tmp_path):
     store = _store(tmp_path)
     store.save(
         SessionRecord(
-            session_id="s1", workspace=str(tmp_path), model="gpt-5.5",
-            mode="interactive", agent="ops",
+            session_id="s1",
+            workspace=str(tmp_path),
+            model="gpt-5.5",
+            mode="interactive",
+            agent="ops",
         )
     )
     loaded = store.load("s1")
@@ -29,8 +33,11 @@ def test_persona_binding_is_stable_across_reload(tmp_path):
     store = _store(tmp_path)
     store.save(
         SessionRecord(
-            session_id="s2", workspace=str(tmp_path), model="gpt-5.5",
-            mode="interactive", agent="code",
+            session_id="s2",
+            workspace=str(tmp_path),
+            model="gpt-5.5",
+            mode="interactive",
+            agent="code",
         )
     )
     # A fresh store instance over the same dir still sees the original persona.
@@ -41,8 +48,11 @@ def test_pin_persists(tmp_path):
     store = _store(tmp_path)
     store.save(
         SessionRecord(
-            session_id="s3", workspace=str(tmp_path), model="gpt-5.5",
-            mode="interactive", agent="ops",
+            session_id="s3",
+            workspace=str(tmp_path),
+            model="gpt-5.5",
+            mode="interactive",
+            agent="ops",
         )
     )
     assert store.set_flags("s3", pinned=True)
@@ -53,8 +63,11 @@ def test_rename_persists(tmp_path):
     store = _store(tmp_path)
     store.save(
         SessionRecord(
-            session_id="s4", workspace=str(tmp_path), model="gpt-5.5",
-            mode="interactive", agent="ops",
+            session_id="s4",
+            workspace=str(tmp_path),
+            model="gpt-5.5",
+            mode="interactive",
+            agent="ops",
         )
     )
     assert store.rename("s4", "Release Captain")

--- a/platform/tests/test_slack_directory.py
+++ b/platform/tests/test_slack_directory.py
@@ -66,7 +66,9 @@ def test_members_filtered_ranked_and_guest_tagged(secrets, monkeypatch):
 
     out = slack_directory.list_members(secrets, "T1", query="ro")
     assert [m["id"] for m in out["members"]] == ["U2"]  # prefix beats substring
-    out = slack_directory.list_members(secrets, "T1", query="maya")  # handle matches too
+    out = slack_directory.list_members(
+        secrets, "T1", query="maya"
+    )  # handle matches too
     assert [m["id"] for m in out["members"]] == ["U1"]
 
 
@@ -86,7 +88,12 @@ def test_channels_carry_privacy_and_membership(secrets, monkeypatch):
         {
             "conversations.list": [
                 {"id": "C1", "name": "general", "is_private": False, "is_member": True},
-                {"id": "C2", "name": "launch-team", "is_private": False, "is_member": False},
+                {
+                    "id": "C2",
+                    "name": "launch-team",
+                    "is_private": False,
+                    "is_member": False,
+                },
                 {"id": "C3", "name": "leads", "is_private": True, "is_member": True},
             ]
         },

--- a/platform/tests/test_slack_relay.py
+++ b/platform/tests/test_slack_relay.py
@@ -17,6 +17,7 @@ from coworker.connectors.slack_addr import qualify, split
 from coworker.connectors.tools import make_send_message_tool
 from coworker.secrets import SecretStore
 
+
 @pytest.fixture(autouse=True)
 def _no_slack_network(monkeypatch):
     """Name/channel resolution is best-effort; unstubbed lookups must fail
@@ -72,7 +73,13 @@ def _event_frame(team, channel, user, text="hi", ts="1.0"):
         "address": f"slack:{team}:{channel}",
         "channel": channel,
         "event_id": f"Ev-{ts}",
-        "event": {"type": "app_mention", "user": user, "channel": channel, "text": text, "ts": ts},
+        "event": {
+            "type": "app_mention",
+            "user": user,
+            "channel": channel,
+            "text": text,
+            "ts": ts,
+        },
     }
 
 
@@ -169,7 +176,10 @@ async def test_relay_name_cache_is_per_workspace(monkeypatch):
 
     async def fake_get(team_id, method, params):
         calls.append((team_id, params.get("user")))
-        return {"ok": True, "user": {"profile": {"display_name": f"{team_id}:{params['user']}"}}}
+        return {
+            "ok": True,
+            "user": {"profile": {"display_name": f"{team_id}:{params['user']}"}},
+        }
 
     monkeypatch.setattr(adapter, "_slack_get", fake_get)
     # Same uid string in two workspaces resolves independently + caches per team.
@@ -181,7 +191,10 @@ async def test_relay_name_cache_is_per_workspace(monkeypatch):
 
 async def test_relay_two_workspace_fan_in():
     adapter = _adapter(
-        [_event_frame("T1", "C1", "U_A", ts="1"), _event_frame("T2", "C2", "U_B", ts="2")]
+        [
+            _event_frame("T1", "C1", "U_A", ts="1"),
+            _event_frame("T2", "C2", "U_B", ts="2"),
+        ]
     )
     events: list[MessageEvent] = []
 

--- a/platform/tests/test_slack_status.py
+++ b/platform/tests/test_slack_status.py
@@ -50,7 +50,9 @@ async def _noop_stop():
 
 def _gateway_with(adapter) -> SimpleNamespace:
     # `stop` because app shutdown tears the gateway down.
-    return SimpleNamespace(_adapters={"slack": adapter} if adapter else {}, stop=_noop_stop)
+    return SimpleNamespace(
+        _adapters={"slack": adapter} if adapter else {}, stop=_noop_stop
+    )
 
 
 # --- endpoint aggregation ----------------------------------------------------
@@ -139,7 +141,14 @@ async def test_adapter_stamps_last_event_and_reports_live():
         assert adapter.status()["state"] == "live"
         assert adapter.status()["last_event_at"] is None
         await adapter._dispatch_slack_event(
-            "T1", {"type": "app_mention", "user": "U1", "channel": "C1", "text": "x", "ts": "1"}
+            "T1",
+            {
+                "type": "app_mention",
+                "user": "U1",
+                "channel": "C1",
+                "text": "x",
+                "ts": "1",
+            },
         )
         assert adapter.status()["last_event_at"] is not None
     finally:

--- a/platform/tests/test_slack_workspaces.py
+++ b/platform/tests/test_slack_workspaces.py
@@ -87,9 +87,7 @@ def test_disconnect_one_workspace_keeps_the_other(client, monkeypatch):
     assert client.manager.secrets.get("slack:team:T1") is None
     assert client.manager.secrets.get("slack:team:T2") is not None
     # connector still connected in relay mode for the surviving workspace
-    slack = next(
-        c for c in client.manager.list_connectors() if c["name"] == "slack"
-    )
+    slack = next(c for c in client.manager.list_connectors() if c["name"] == "slack")
     assert slack["connected"] is True
     assert [w["team_id"] for w in slack["workspaces"]] == ["T2"]
 
@@ -101,9 +99,7 @@ def test_disconnect_last_workspace_flips_connector_off(client, monkeypatch):
     body = client.post("/v1/connectors/slack/workspaces/T1/disconnect").json()
     assert body["ok"] is True and body["remaining_workspaces"] == 0
     assert client.manager.secrets.get("slack:default") is None
-    slack = next(
-        c for c in client.manager.list_connectors() if c["name"] == "slack"
-    )
+    slack = next(c for c in client.manager.list_connectors() if c["name"] == "slack")
     assert slack["connected"] is False
 
 

--- a/platform/tests/test_standing_approvals.py
+++ b/platform/tests/test_standing_approvals.py
@@ -68,7 +68,11 @@ def test_task_rule_helpers():
     assert t.revoke_rule("send_message slack:T1/C2") is True
     assert t.revoke_rule("send_message slack:T1/C2") is False
     rules = t.public()["always_allowed"]
-    assert {"entry": "send_message slack:T1/C1", "tool": "send_message", "target": "slack:T1/C1"} in rules
+    assert {
+        "entry": "send_message slack:T1/C1",
+        "tool": "send_message",
+        "target": "slack:T1/C1",
+    } in rules
     assert {"entry": "web_search", "tool": "web_search", "target": None} in rules
 
 
@@ -77,9 +81,21 @@ def test_grant_entries_validation():
         [
             {"tool": "send_message", "target": "slack:T1/C1", "access": "write"},
             {"tool": "send_message", "target": "slack:T1/C1", "access": "write"},  # dup
-            {"tool": "github_list_commits", "target": "r/x", "access": "read"},  # read = disclosure
-            {"tool": "run_shell", "target": "rm -rf /", "access": "write"},  # no target arg, exec
-            {"tool": "github_create_issue", "target": "r/x", "access": "write"},  # no declared target arg
+            {
+                "tool": "github_list_commits",
+                "target": "r/x",
+                "access": "read",
+            },  # read = disclosure
+            {
+                "tool": "run_shell",
+                "target": "rm -rf /",
+                "access": "write",
+            },  # no target arg, exec
+            {
+                "tool": "github_create_issue",
+                "target": "r/x",
+                "access": "write",
+            },  # no declared target arg
             {"tool": "send_message", "target": "", "access": "write"},  # empty target
             "garbage",
         ]
@@ -92,11 +108,19 @@ def test_grant_entries_validation():
 
 
 def test_standing_rule_candidate():
-    assert standing_rule_candidate("send_message", {"target": "slack:C1"}, _Meta()) == "slack:C1"
+    assert (
+        standing_rule_candidate("send_message", {"target": "slack:C1"}, _Meta())
+        == "slack:C1"
+    )
     # exec risk is never eligible, even with a hand-crafted arg
     assert standing_rule_candidate("run_shell", {"command": "ls"}, _Meta()) is None
     # no declared target argument → not eligible
-    assert standing_rule_candidate("github_create_issue", {"repo": "x"}, _Meta("connector")) is None
+    assert (
+        standing_rule_candidate(
+            "github_create_issue", {"repo": "x"}, _Meta("connector")
+        )
+        is None
+    )
     # eligible tool, but the call names no target
     assert standing_rule_candidate("send_message", {"text": "hi"}, _Meta()) is None
     # local writes are covered by path scoping, not standing rules
@@ -116,10 +140,16 @@ def test_engine_matches_target(tmp_path):
 def test_task_rules_cover_connector_tools(tmp_path):
     # The session allowlist deliberately excludes connector tools; a task rule's exact
     # target binding is what makes lifting that exclusion safe (§25 gap 4).
-    e = PermissionEngine(workspace_root=tmp_path, task_rules={"discord_send_message": {"C9"}})
-    e.allow_tool_for_session("discord_send_message")  # session allow alone must NOT unlock it
+    e = PermissionEngine(
+        workspace_root=tmp_path, task_rules={"discord_send_message": {"C9"}}
+    )
+    e.allow_tool_for_session(
+        "discord_send_message"
+    )  # session allow alone must NOT unlock it
     meta = _Meta(category="connector")
-    assert not e.evaluate("discord_send_message", {"channel_id": "C8", "content": "x"}, meta).allowed
+    assert not e.evaluate(
+        "discord_send_message", {"channel_id": "C8", "content": "x"}, meta
+    ).allowed
     hit = e.evaluate("discord_send_message", {"channel_id": "C9", "content": "x"}, meta)
     assert hit.allowed and "standing rule" in hit.reason
 
@@ -127,7 +157,9 @@ def test_task_rules_cover_connector_tools(tmp_path):
 def test_read_only_modes_ignore_task_rules(tmp_path):
     # Rules are additive on top of the run's permission mode — never an upgrade.
     e = PermissionEngine(
-        workspace_root=tmp_path, mode=Mode.PLAN, task_rules={"send_message": {"slack:C1"}}
+        workspace_root=tmp_path,
+        mode=Mode.PLAN,
+        task_rules={"send_message": {"slack:C1"}},
     )
     assert not e.evaluate("send_message", {"target": "slack:C1"}, _Meta()).allowed
 
@@ -158,7 +190,10 @@ def test_create_tool_stores_write_grants(tmp_path):
     assert saved.always_allowed_tools == ["send_message slack:T1/C1"]
     # The agent-facing update tool has no permissions field — rules are human-minted only.
     update = next(t for t in tools if t.__name__ == "update_scheduled_task")
-    assert "permissions" not in update.__coworker_schema__["function"]["parameters"]["properties"]
+    assert (
+        "permissions"
+        not in update.__coworker_schema__["function"]["parameters"]["properties"]
+    )
 
 
 # -- store: run-session → owning task --------------------------------------------
@@ -216,14 +251,21 @@ async def test_scheduled_approver_parks_and_mints(tmp_path, monkeypatch):
     outcome, _ = await asyncio.gather(approver(request), click_allow_every_time())
     assert outcome is ApprovalOutcome.ONCE
     # The rule persisted to the task record…
-    assert "send_message slack:T1/C1" in manager.task_store.get(task.id).always_allowed_tools
+    assert (
+        "send_message slack:T1/C1"
+        in manager.task_store.get(task.id).always_allowed_tools
+    )
     # …and a rebuilt run engine auto-allows exactly that call, nothing else.
     engine = manager._build_task_engine(
         manager.task_store.get(task.id), session_id=run.session_id
     )
-    hit = engine.permissions.evaluate("send_message", {"target": "slack:T1/C1"}, _Meta())
+    hit = engine.permissions.evaluate(
+        "send_message", {"target": "slack:T1/C1"}, _Meta()
+    )
     assert hit.allowed and hit.rule
-    assert not engine.permissions.evaluate("send_message", {"target": "slack:T1/C2"}, _Meta()).allowed
+    assert not engine.permissions.evaluate(
+        "send_message", {"target": "slack:T1/C2"}, _Meta()
+    ).allowed
 
 
 async def test_scheduled_approver_name_allows_and_denies(tmp_path, monkeypatch):
@@ -274,14 +316,24 @@ def test_mint_task_rule_validates(tmp_path, monkeypatch):
     manager.task_store.add_run(run)
 
     # Not an automation run session → no rule, ever.
-    assert not manager.mint_task_rule("session-1", "send_message", {"target": "slack:C1"}, _Meta())
+    assert not manager.mint_task_rule(
+        "session-1", "send_message", {"target": "slack:C1"}, _Meta()
+    )
     # Exec risk → never mintable, even from a run session.
-    assert not manager.mint_task_rule(run.session_id, "run_shell", {"command": "ls"}, _Meta())
+    assert not manager.mint_task_rule(
+        run.session_id, "run_shell", {"command": "ls"}, _Meta()
+    )
     # No declared target argument → not mintable.
-    assert not manager.mint_task_rule(run.session_id, "github_create_issue", {"repo": "x"}, _Meta())
+    assert not manager.mint_task_rule(
+        run.session_id, "github_create_issue", {"repo": "x"}, _Meta()
+    )
     # Eligible call mints exactly one rule.
-    assert manager.mint_task_rule(run.session_id, "send_message", {"target": "slack:C1"}, _Meta())
-    assert manager.task_store.get(task.id).always_allowed_tools == ["send_message slack:C1"]
+    assert manager.mint_task_rule(
+        run.session_id, "send_message", {"target": "slack:C1"}, _Meta()
+    )
+    assert manager.task_store.get(task.id).always_allowed_tools == [
+        "send_message slack:C1"
+    ]
 
 
 def test_get_engine_seeds_run_session_rules(tmp_path, monkeypatch):
@@ -291,7 +343,11 @@ def test_get_engine_seeds_run_session_rules(tmp_path, monkeypatch):
     ws = tmp_path / "ws"
     ws.mkdir()
     manager = SessionManager(data_dir=tmp_path / "data", provider=_provider())
-    task = _task(workspace=str(ws), agent="cowork", always_allowed_tools=["send_message slack:T1/C1"])
+    task = _task(
+        workspace=str(ws),
+        agent="cowork",
+        always_allowed_tools=["send_message slack:T1/C1"],
+    )
     manager.task_store.save(task)
     run = TaskRun(task_id=task.id)
     manager.task_store.add_run(run)
@@ -322,9 +378,15 @@ def test_create_automation_grants_and_revoke(tmp_path, monkeypatch):
     assert res["ok"]
     rules = res["task"]["always_allowed"]
     assert rules == [
-        {"entry": "send_message slack:T1/C1", "tool": "send_message", "target": "slack:T1/C1"}
+        {
+            "entry": "send_message slack:T1/C1",
+            "tool": "send_message",
+            "target": "slack:T1/C1",
+        }
     ]
-    out = manager.update_automation(res["task"]["id"], {"revoke": "send_message slack:T1/C1"})
+    out = manager.update_automation(
+        res["task"]["id"], {"revoke": "send_message slack:T1/C1"}
+    )
     assert out["ok"] and out["task"]["always_allowed"] == []
     assert manager.task_store.get(res["task"]["id"]).always_allowed_tools == []
 
@@ -367,7 +429,12 @@ async def test_blocked_run_does_not_stall_other_tasks(tmp_path):
 
 def test_engine_events_carry_standing_context(tmp_path):
     from coworker.events import EventType
-    from coworker.providers import AssistantTurn, ModelCapabilities, ProviderClient, ToolCall
+    from coworker.providers import (
+        AssistantTurn,
+        ModelCapabilities,
+        ProviderClient,
+        ToolCall,
+    )
     from coworker.engine import TurnEngine
     from coworker.tools import ToolRegistry
 
@@ -383,14 +450,24 @@ def test_engine_events_carry_standing_context(tmp_path):
     )
     send_message.__coworker_schema__ = {
         "type": "function",
-        "function": {"name": "send_message", "description": "send", "parameters": {"type": "object", "properties": {}}},
+        "function": {
+            "name": "send_message",
+            "description": "send",
+            "parameters": {"type": "object", "properties": {}},
+        },
     }
 
     class _P(ProviderClient):
         def __init__(self):
             self._turns = [
                 AssistantTurn(
-                    tool_calls=[ToolCall(id="c1", name="send_message", arguments={"target": "slack:T1/C1", "text": "hi"})],
+                    tool_calls=[
+                        ToolCall(
+                            id="c1",
+                            name="send_message",
+                            arguments={"target": "slack:T1/C1", "text": "hi"},
+                        )
+                    ],
                     finish_reason="tool_calls",
                 ),
                 AssistantTurn(text="sent", finish_reason="stop"),

--- a/platform/tests/test_subscriptions.py
+++ b/platform/tests/test_subscriptions.py
@@ -32,7 +32,9 @@ def test_resolve_channel():
     assert resolve_channel("C0777") == "slack:C0777"  # bare id → default platform
     assert resolve_channel("") == ""
     # Slack "Copy link" URL → the id in the path (case-normalized), query/anchor tolerated.
-    assert resolve_channel("https://acme.slack.com/archives/C0123ABC") == "slack:C0123ABC"
+    assert (
+        resolve_channel("https://acme.slack.com/archives/C0123ABC") == "slack:C0123ABC"
+    )
     assert (
         resolve_channel("https://acme.slack.com/archives/c0123abc?foo=1")
         == "slack:C0123ABC"
@@ -139,7 +141,10 @@ def _connect_slack(mgr):
     """Inbound delivery is gated on the connector being CONNECTED (§4.3). Tests used to pass
     by riding the developer's real Slack profile; with the isolated state dir (conftest) each
     test must connect its own."""
-    mgr.secrets.put("slack:default", {"bot_token": "xoxb-test", "app_token": "xapp-test", "enabled": True})
+    mgr.secrets.put(
+        "slack:default",
+        {"bot_token": "xoxb-test", "app_token": "xapp-test", "enabled": True},
+    )
 
 
 def test_dispatch_fans_out_to_subscribers(tmp_path, monkeypatch):
@@ -227,7 +232,8 @@ def test_subscribe_unsubscribe_and_recent_endpoints(tmp_path):
 
 def test_unauthorized_messages_park_and_resolve(tmp_path, monkeypatch):
     """§19: an allow-list drop PARKS the message; resolving it can dismiss, allow the sender,
-    or allow AND deliver the original message through the normal inbound path (no re-send)."""
+    or allow AND deliver the original message through the normal inbound path (no re-send).
+    """
     from coworker.connectors import Gateway
 
     mgr = SessionManager(workspace=tmp_path, provider=ScriptedProvider([]))
@@ -252,7 +258,10 @@ def test_unauthorized_messages_park_and_resolve(tmp_path, monkeypatch):
     ev = MessageEvent(
         text="deploy failed",
         source=SessionSource(
-            platform="slack", chat_id="C1", user_id="U9", user_name="bob",
+            platform="slack",
+            chat_id="C1",
+            user_id="U9",
+            user_name="bob",
             chat_type="channel",
         ),
     )
@@ -270,7 +279,9 @@ def test_unauthorized_messages_park_and_resolve(tmp_path, monkeypatch):
 
     # allow_deliver: sender allow-listed AND the parked message reaches the subscriber + buffer
     r = asyncio.run(
-        mgr.resolve_unauthorized("slack", mgr.parked.list("slack")[0]["id"], "allow_deliver")
+        mgr.resolve_unauthorized(
+            "slack", mgr.parked.list("slack")[0]["id"], "allow_deliver"
+        )
     )
     assert r["ok"]
     profile = mgr.secrets.get("slack:default")
@@ -283,7 +294,9 @@ def test_unauthorized_messages_park_and_resolve(tmp_path, monkeypatch):
     assert slack["allowed_user_names"] == {"U9": "bob"}
 
     # unknown item / wrong platform → error
-    assert asyncio.run(mgr.resolve_unauthorized("slack", "nope", "dismiss"))["ok"] is False
+    assert (
+        asyncio.run(mgr.resolve_unauthorized("slack", "nope", "dismiss"))["ok"] is False
+    )
 
 
 def test_parked_store_persists_and_caps(tmp_path):
@@ -293,7 +306,9 @@ def test_parked_store_persists_and_caps(tmp_path):
     store = ParkedStore(path, cap=2)
     store.park(platform="slack", chat_id="C1", user_id="U1", text="one")
     store.park(platform="slack", chat_id="C1", user_id="U1", text="two")
-    store.park(platform="slack", chat_id="C1", user_id="U1", text="three")  # evicts "one"
+    store.park(
+        platform="slack", chat_id="C1", user_id="U1", text="three"
+    )  # evicts "one"
     assert [i["text"] for i in store.list("slack")] == ["three", "two"]  # newest first
 
     reloaded = ParkedStore(path, cap=2)

--- a/platform/tests/test_team_allowlist.py
+++ b/platform/tests/test_team_allowlist.py
@@ -92,9 +92,7 @@ def test_is_authorized_flat_path_unchanged():
 # -- load_settings ---------------------------------------------------------------
 def test_load_settings_populates_teams(tmp_path):
     secrets = SecretStore(tmp_path / "secrets.json")
-    secrets.put(
-        "slack:default", {"type": "oauth", "mode": "relay", "enabled": True}
-    )
+    secrets.put("slack:default", {"type": "oauth", "mode": "relay", "enabled": True})
     secrets.put(
         "slack:team:T1",
         {"bot_token": "xoxb-1", "allowed_users": ["U_A", "U_B"]},
@@ -180,7 +178,8 @@ async def test_resolve_teamless_parked_uses_flat_list(tmp_path):
     m._dispatch_inbound = _noop
     await m._park_unauthorized(
         MessageEvent(
-            text="hi", source=SessionSource("slack", "D1", user_id="U_M", chat_type="dm")
+            text="hi",
+            source=SessionSource("slack", "D1", user_id="U_M", chat_type="dm"),
         )
     )
     item = m.parked.list("slack")[0]
@@ -200,7 +199,8 @@ def test_rest_allow_with_team_and_workspaces_field(tmp_path):
     )
     assert r.json()["ok"] is True
     slack = next(
-        c for c in client.get("/v1/connectors").json()["connectors"]
+        c
+        for c in client.get("/v1/connectors").json()["connectors"]
         if c["name"] == "slack"
     )
     assert slack["connected"] is True and slack["mode"] == "relay"


### PR DESCRIPTION
Mechanical: `black .` over the repo (71 files) so the lint check can pass; no behavior change, full suite green.