### PR TITLE
Add streaming support to chat completions (stream=True on create/acreate)

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,17 @@ for model in models:
 
 **→ Quickstart:** [docs/chat-completions-quickstart.md](docs/chat-completions-quickstart.md) — install, key setup, local models, and more examples.
 
+### Streaming
+
+Pass `stream=True` to get an iterator of OpenAI-shaped chunks from any supporting provider (OpenAI, Anthropic, Ollama, and OpenAI-compatible endpoints) — the same loop works across all of them:
+
+```python
+for chunk in client.chat.completions.create(model=model, messages=messages, stream=True):
+    print(chunk.choices[0].delta.content or "", end="", flush=True)
+```
+
+The async variant is `await client.chat.completions.acreate(..., stream=True)`, iterated with `async for`. Tool calls stream too: schema dicts and callables are passed to the model as usual, and the chunks carry incremental `delta.tool_calls` fragments for you to assemble and execute (streaming is manual tool calling — it can't be combined with `max_turns`).
+
 ---
 
 <a id="agents"></a>

--- a/aisuite/client.py
+++ b/aisuite/client.py
@@ -476,6 +476,8 @@ class Completions:
         """
         Create chat completion based on the model, messages, and any extra arguments.
         Supports automatic tool execution when max_turns is specified.
+        With stream=True, returns an iterator of OpenAI-shaped chunks instead
+        (see ``aisuite.framework.chat_completion_chunk``).
         """
         provider, model_name = self._resolve_provider(model)
 
@@ -484,6 +486,12 @@ class Completions:
         tools = kwargs.pop("tools", None)
         tool_policy = kwargs.pop("tool_policy", None)
         tool_policy_context = kwargs.pop("tool_policy_context", None)
+
+        if kwargs.pop("stream", False):
+            kwargs = self._prepare_stream_kwargs(tools, max_turns, kwargs)
+            return provider.chat_completions_create_stream(
+                model_name, messages, **kwargs
+            )
 
         # Use ExitStack to manage MCP client cleanup automatically
         with ExitStack() as stack:
@@ -519,6 +527,38 @@ class Completions:
             response = provider.chat_completions_create(model_name, messages, **kwargs)
             return self._extract_thinking_content(response)
 
+    def _prepare_stream_kwargs(self, tools, max_turns, kwargs):
+        """Validate and finish kwargs for a streaming call.
+
+        Raises eagerly — before any generator is handed back — so misuse fails
+        at the call site rather than on first iteration. Streaming is manual
+        tool calling only: the tool runner needs whole turns to execute tools,
+        and MCP configs need a client whose lifetime the runner manages, so
+        neither combines with a caller-driven chunk iterator.
+        """
+        if max_turns is not None:
+            raise ValueError(
+                "stream=True cannot be combined with max_turns. Run the tool "
+                "loop without streaming, or stream and execute tools manually."
+            )
+        if tools is not None:
+            if any(self._is_mcp_tool_config(tool) for tool in tools):
+                raise ValueError(
+                    "MCP tool configs are not supported with stream=True; "
+                    "pass tool schemas or callables instead."
+                )
+            kwargs["tools"] = self._provider_ready_tools(tools)
+        return kwargs
+
+    @staticmethod
+    def _is_mcp_tool_config(tool) -> bool:
+        """True for MCP config dicts, whether or not the mcp extra is installed."""
+        if not isinstance(tool, dict):
+            return False
+        if MCP_AVAILABLE:
+            return is_mcp_config(tool)
+        return tool.get("type") == "mcp"
+
     @staticmethod
     def _provider_ready_tools(tools: list) -> list:
         """Tools as a provider request can carry them: schema dicts pass through
@@ -537,6 +577,7 @@ class Completions:
         Awaits the provider's async completion and, when ``max_turns`` and
         ``tools`` are supplied, the async tool-execution loop. MCP client
         cleanup remains synchronous and is handled by the ExitStack.
+        With stream=True, returns an async iterator of OpenAI-shaped chunks.
         """
         provider, model_name = self._resolve_provider(model)
 
@@ -544,6 +585,12 @@ class Completions:
         tools = kwargs.pop("tools", None)
         tool_policy = kwargs.pop("tool_policy", None)
         tool_policy_context = kwargs.pop("tool_policy_context", None)
+
+        if kwargs.pop("stream", False):
+            kwargs = self._prepare_stream_kwargs(tools, max_turns, kwargs)
+            return provider.achat_completions_create_stream(
+                model_name, messages, **kwargs
+            )
 
         with ExitStack() as stack:
             mcp_clients = []

--- a/aisuite/framework/__init__.py
+++ b/aisuite/framework/__init__.py
@@ -1,3 +1,10 @@
 from .provider_interface import ProviderInterface
 from .chat_completion_response import ChatCompletionResponse
+from .chat_completion_chunk import (
+    ChatCompletionChunk,
+    ChoiceDelta,
+    ChoiceDeltaFunction,
+    ChoiceDeltaToolCall,
+    StreamChoice,
+)
 from .message import Message

--- a/aisuite/framework/chat_completion_chunk.py
+++ b/aisuite/framework/chat_completion_chunk.py
@@ -1,0 +1,57 @@
+"""OpenAI `chat.completion.chunk`-shaped models for unified chat streaming.
+
+Providers that stream natively in OpenAI's wire format (e.g. OpenAI, Ollama)
+yield the SDK's own chunk objects; providers with a different event stream
+(e.g. Anthropic) are normalized into these models. Both are duck-type
+compatible: `chunk.choices[0].delta.content`, `delta.tool_calls`, and
+`choices[0].finish_reason` read the same either way.
+"""
+
+from typing import List, Optional
+
+from pydantic import BaseModel
+
+from aisuite.framework.message import CompletionUsage
+
+
+class ChoiceDeltaFunction(BaseModel):
+    """Function fragment inside a streamed tool call: the name arrives on the
+    first fragment, the JSON arguments arrive as string pieces to concatenate."""
+
+    name: Optional[str] = None
+    arguments: Optional[str] = None
+
+
+class ChoiceDeltaToolCall(BaseModel):
+    """One streamed tool-call fragment. `index` identifies which tool call the
+    fragment belongs to (0-based across the assistant turn's tool calls)."""
+
+    index: int
+    id: Optional[str] = None
+    type: Optional[str] = None
+    function: Optional[ChoiceDeltaFunction] = None
+
+
+class ChoiceDelta(BaseModel):
+    """The incremental payload of one chunk."""
+
+    role: Optional[str] = None
+    content: Optional[str] = None
+    tool_calls: Optional[List[ChoiceDeltaToolCall]] = None
+
+
+class StreamChoice(BaseModel):
+    """One choice within a chunk. `finish_reason` is set on the final chunk,
+    using the same normalized values as non-streaming responses."""
+
+    index: int = 0
+    delta: ChoiceDelta = ChoiceDelta()
+    finish_reason: Optional[str] = None
+
+
+class ChatCompletionChunk(BaseModel):
+    """One streamed piece of a chat completion. `usage`, when the provider
+    reports it, rides on the final chunk."""
+
+    choices: List[StreamChoice]
+    usage: Optional[CompletionUsage] = None

--- a/aisuite/provider.py
+++ b/aisuite/provider.py
@@ -43,6 +43,51 @@ class Provider(ABC):
             lambda: self.chat_completions_create(model, messages, **kwargs)
         )
 
+    def chat_completions_create_stream(self, model, messages, **kwargs):
+        """Streaming chat completion.
+
+        Yields OpenAI ``chat.completion.chunk``-shaped objects (see
+        ``aisuite.framework.chat_completion_chunk``). Providers opt in by
+        overriding; the default reports the gap explicitly instead of hanging
+        or returning a fake stream.
+        """
+        raise LLMError(
+            f"{type(self).__name__} does not support streaming chat completions."
+        )
+
+    async def achat_completions_create_stream(self, model, messages, **kwargs):
+        """Async streaming chat completion.
+
+        Default implementation runs the provider's synchronous
+        ``chat_completions_create_stream`` in a worker thread and hands chunks
+        to the event loop through a queue, so any provider with a sync stream
+        is async-iterable without per-provider work. Providers with a native
+        async SDK (e.g. OpenAI, Anthropic) should override this.
+        """
+        loop = asyncio.get_running_loop()
+        queue: asyncio.Queue = asyncio.Queue()
+
+        def produce():
+            try:
+                for chunk in self.chat_completions_create_stream(
+                    model, messages, **kwargs
+                ):
+                    loop.call_soon_threadsafe(queue.put_nowait, ("chunk", chunk))
+            except BaseException as exc:  # surfaced to the awaiting consumer
+                loop.call_soon_threadsafe(queue.put_nowait, ("error", exc))
+            finally:
+                loop.call_soon_threadsafe(queue.put_nowait, ("done", None))
+
+        loop.run_in_executor(None, produce)
+        while True:
+            kind, payload = await queue.get()
+            if kind == "chunk":
+                yield payload
+            elif kind == "error":
+                raise payload
+            else:
+                return
+
 
 class ProviderFactory:
     """Factory to dynamically load provider instances based on naming conventions."""

--- a/aisuite/providers/anthropic_provider.py
+++ b/aisuite/providers/anthropic_provider.py
@@ -6,6 +6,13 @@ import anthropic
 import json
 from aisuite.provider import Provider
 from aisuite.framework import ChatCompletionResponse
+from aisuite.framework.chat_completion_chunk import (
+    ChatCompletionChunk,
+    ChoiceDelta,
+    ChoiceDeltaFunction,
+    ChoiceDeltaToolCall,
+    StreamChoice,
+)
 from aisuite.framework.message import (
     Message,
     ChatCompletionMessageToolCall,
@@ -45,6 +52,105 @@ class AnthropicMessageConverter:
         normalized_response.usage = self._get_completion_usage(response)
         normalized_response.choices[0].message = self._get_message(response)
         return normalized_response
+
+    def convert_stream_event(self, event, state):
+        """Normalize one Anthropic stream event into an OpenAI-shaped chunk.
+
+        Returns ``None`` for events with nothing to surface (block stops,
+        pings, thinking deltas). ``state`` is a plain dict owned by the caller,
+        carried across one message's events: it maps Anthropic content-block
+        indices to OpenAI tool-call indices (Anthropic counts every content
+        block, OpenAI counts only tool calls) and holds the prompt-token counts
+        reported at message start until usage is emitted on the final chunk.
+        """
+        event_type = getattr(event, "type", None)
+
+        if event_type == "message_start":
+            usage = getattr(getattr(event, "message", None), "usage", None)
+            state["input_tokens"] = getattr(usage, "input_tokens", 0) or 0
+            state["cached_tokens"] = getattr(usage, "cache_read_input_tokens", 0) or 0
+            return self._delta_chunk(ChoiceDelta(role=self.ROLE_ASSISTANT))
+
+        if event_type == "content_block_start":
+            block = getattr(event, "content_block", None)
+            if getattr(block, "type", None) != "tool_use":
+                return None
+            positions = state.setdefault("tool_positions", {})
+            position = positions.setdefault(getattr(event, "index", 0), len(positions))
+            return self._delta_chunk(
+                ChoiceDelta(
+                    tool_calls=[
+                        ChoiceDeltaToolCall(
+                            index=position,
+                            id=block.id,
+                            type="function",
+                            function=ChoiceDeltaFunction(name=block.name, arguments=""),
+                        )
+                    ]
+                )
+            )
+
+        if event_type == "content_block_delta":
+            delta = getattr(event, "delta", None)
+            delta_type = getattr(delta, "type", None)
+            if delta_type == "text_delta":
+                text = getattr(delta, "text", "") or ""
+                return self._delta_chunk(ChoiceDelta(content=text)) if text else None
+            if delta_type == "input_json_delta":
+                position = state.get("tool_positions", {}).get(
+                    getattr(event, "index", None)
+                )
+                partial = getattr(delta, "partial_json", "") or ""
+                if position is None or not partial:
+                    return None
+                return self._delta_chunk(
+                    ChoiceDelta(
+                        tool_calls=[
+                            ChoiceDeltaToolCall(
+                                index=position,
+                                function=ChoiceDeltaFunction(arguments=partial),
+                            )
+                        ]
+                    )
+                )
+            return None
+
+        if event_type == "message_delta":
+            stop_reason = getattr(getattr(event, "delta", None), "stop_reason", None)
+            output_tokens = getattr(
+                getattr(event, "usage", None), "output_tokens", None
+            )
+            if stop_reason is None and output_tokens is None:
+                return None
+            usage = None
+            if output_tokens is not None:
+                prompt_tokens = state.get("input_tokens", 0)
+                usage = CompletionUsage(
+                    completion_tokens=output_tokens,
+                    prompt_tokens=prompt_tokens,
+                    total_tokens=prompt_tokens + output_tokens,
+                    prompt_tokens_details=PromptTokensDetails(
+                        cached_tokens=state.get("cached_tokens", 0),
+                    ),
+                )
+            finish_reason = (
+                self.FINISH_REASON_MAPPING.get(stop_reason, "stop")
+                if stop_reason
+                else None
+            )
+            return ChatCompletionChunk(
+                choices=[
+                    StreamChoice(delta=ChoiceDelta(), finish_reason=finish_reason)
+                ],
+                usage=usage,
+            )
+
+        return None
+
+    @staticmethod
+    def _delta_chunk(delta):
+        """Wrap a delta in a single-choice chunk with no finish reason."""
+        return ChatCompletionChunk(choices=[StreamChoice(delta=delta)])
 
     def _convert_single_message(self, msg):
         """Convert a single message to Anthropic format."""
@@ -219,6 +325,8 @@ class AnthropicProvider(Provider):
     def __init__(self, **config):
         """Initialize the Anthropic provider with the given configuration."""
         self.client = anthropic.Anthropic(**config)
+        # Async client shares the same config for native async streaming.
+        self.async_client = anthropic.AsyncAnthropic(**config)
         self.converter = AnthropicMessageConverter()
 
     def chat_completions_create(self, model, messages, **kwargs):
@@ -230,6 +338,42 @@ class AnthropicProvider(Provider):
             model=model, system=system_message, messages=converted_messages, **kwargs
         )
         return self.converter.convert_response(response)
+
+    def chat_completions_create_stream(self, model, messages, **kwargs):
+        """Stream a chat completion as OpenAI-shaped chunks."""
+        kwargs = self._prepare_kwargs(kwargs)
+        system_message, converted_messages = self.converter.convert_request(messages)
+
+        events = self.client.messages.create(
+            model=model,
+            system=system_message,
+            messages=converted_messages,
+            stream=True,
+            **kwargs,
+        )
+        state = {}
+        for event in events:
+            chunk = self.converter.convert_stream_event(event, state)
+            if chunk is not None:
+                yield chunk
+
+    async def achat_completions_create_stream(self, model, messages, **kwargs):
+        """Stream a chat completion natively async, as OpenAI-shaped chunks."""
+        kwargs = self._prepare_kwargs(kwargs)
+        system_message, converted_messages = self.converter.convert_request(messages)
+
+        events = await self.async_client.messages.create(
+            model=model,
+            system=system_message,
+            messages=converted_messages,
+            stream=True,
+            **kwargs,
+        )
+        state = {}
+        async for event in events:
+            chunk = self.converter.convert_stream_event(event, state)
+            if chunk is not None:
+                yield chunk
 
     def _prepare_kwargs(self, kwargs):
         """Prepare kwargs for the API call."""

--- a/aisuite/providers/openai_provider.py
+++ b/aisuite/providers/openai_provider.py
@@ -65,6 +65,35 @@ class OpenaiProvider(Provider):
         except Exception as e:
             raise LLMError(f"An error occurred: {e}")
 
+    def chat_completions_create_stream(self, model, messages, **kwargs):
+        # OpenAI's own chunks already have the unified shape — pass them through.
+        try:
+            transformed_messages = self.transformer.convert_request(messages)
+            stream = self.client.chat.completions.create(
+                model=model,
+                messages=transformed_messages,
+                stream=True,
+                **kwargs,
+            )
+        except Exception as e:
+            raise LLMError(f"An error occurred: {e}")
+        yield from stream
+
+    async def achat_completions_create_stream(self, model, messages, **kwargs):
+        # Native async streaming via openai.AsyncOpenAI.
+        try:
+            transformed_messages = self.transformer.convert_request(messages)
+            stream = await self.aclient.chat.completions.create(
+                model=model,
+                messages=transformed_messages,
+                stream=True,
+                **kwargs,
+            )
+        except Exception as e:
+            raise LLMError(f"An error occurred: {e}")
+        async for chunk in stream:
+            yield chunk
+
 
 # Audio Classes
 class OpenAIAudio(Audio):

--- a/tests/client/test_streaming.py
+++ b/tests/client/test_streaming.py
@@ -1,0 +1,155 @@
+"""Tests for the streaming client path (create/acreate with stream=True)."""
+
+from unittest.mock import Mock, patch
+
+import pytest
+
+from aisuite import Client
+
+
+def _stream_provider(chunks):
+    provider = Mock()
+    provider.chat_completions_create_stream = Mock(return_value=iter(chunks))
+    return provider
+
+
+@patch("aisuite.provider.ProviderFactory.create_provider")
+def test_create_stream_routes_to_provider_stream(mock_create_provider):
+    chunks = [object(), object()]
+    provider = _stream_provider(chunks)
+    mock_create_provider.return_value = provider
+
+    client = Client()
+    stream = client.chat.completions.create(
+        model="openai:gpt-4o",
+        messages=[{"role": "user", "content": "hi"}],
+        stream=True,
+        temperature=0.2,
+    )
+
+    assert list(stream) == chunks
+    call = provider.chat_completions_create_stream.call_args
+    assert call.args == ("gpt-4o", [{"role": "user", "content": "hi"}])
+    # `stream` is consumed by the client; extra settings pass through.
+    assert call.kwargs == {"temperature": 0.2}
+    provider.chat_completions_create.assert_not_called()
+
+
+@patch("aisuite.provider.ProviderFactory.create_provider")
+def test_create_stream_converts_tools(mock_create_provider):
+    """Streaming is manual tool calling: schemas pass through, callables
+    become specs — same contract as the non-streaming manual path (#266)."""
+    provider = _stream_provider([])
+    mock_create_provider.return_value = provider
+
+    def get_weather(location: str):
+        """Get the weather for a location."""
+        return {"location": location}
+
+    schema = {
+        "type": "function",
+        "function": {
+            "name": "manual_tool",
+            "parameters": {"type": "object", "properties": {}},
+        },
+    }
+
+    client = Client()
+    client.chat.completions.create(
+        model="openai:gpt-4o",
+        messages=[{"role": "user", "content": "hi"}],
+        tools=[schema, get_weather],
+        stream=True,
+    )
+
+    sent = provider.chat_completions_create_stream.call_args.kwargs["tools"]
+    assert sent[0] == schema
+    assert sent[1]["function"]["name"] == "get_weather"
+
+
+@patch("aisuite.provider.ProviderFactory.create_provider")
+def test_create_stream_with_max_turns_raises(mock_create_provider):
+    mock_create_provider.return_value = _stream_provider([])
+
+    client = Client()
+    with pytest.raises(ValueError, match="max_turns"):
+        client.chat.completions.create(
+            model="openai:gpt-4o",
+            messages=[{"role": "user", "content": "hi"}],
+            tools=[{"type": "function", "function": {"name": "t", "parameters": {}}}],
+            max_turns=3,
+            stream=True,
+        )
+
+
+@patch("aisuite.provider.ProviderFactory.create_provider")
+def test_create_stream_rejects_mcp_configs(mock_create_provider):
+    mock_create_provider.return_value = _stream_provider([])
+
+    client = Client()
+    with pytest.raises(ValueError, match="MCP"):
+        client.chat.completions.create(
+            model="openai:gpt-4o",
+            messages=[{"role": "user", "content": "hi"}],
+            tools=[{"type": "mcp", "name": "fs", "command": "npx", "args": []}],
+            stream=True,
+        )
+
+
+@patch("aisuite.provider.ProviderFactory.create_provider")
+def test_stream_false_keeps_non_streaming_path(mock_create_provider):
+    provider = Mock()
+    provider.chat_completions_create = Mock(return_value=Mock(choices=[]))
+    mock_create_provider.return_value = provider
+
+    client = Client()
+    client.chat.completions.create(
+        model="openai:gpt-4o",
+        messages=[{"role": "user", "content": "hi"}],
+        stream=False,
+    )
+
+    provider.chat_completions_create.assert_called_once()
+    provider.chat_completions_create_stream.assert_not_called()
+
+
+@pytest.mark.asyncio
+@patch("aisuite.provider.ProviderFactory.create_provider")
+async def test_acreate_stream_returns_async_iterator(mock_create_provider):
+    chunks = [object(), object()]
+
+    async def astream(model, messages, **kwargs):
+        for chunk in chunks:
+            yield chunk
+
+    provider = Mock()
+    provider.achat_completions_create_stream = astream
+    mock_create_provider.return_value = provider
+
+    client = Client()
+    stream = await client.chat.completions.acreate(
+        model="openai:gpt-4o",
+        messages=[{"role": "user", "content": "hi"}],
+        stream=True,
+    )
+
+    received = [chunk async for chunk in stream]
+    assert received == chunks
+    provider.achat_completions_create.assert_not_called()
+
+
+@pytest.mark.asyncio
+@patch("aisuite.provider.ProviderFactory.create_provider")
+async def test_acreate_stream_with_max_turns_raises_eagerly(mock_create_provider):
+    """The guard fires at the acreate call, not on first iteration."""
+    mock_create_provider.return_value = Mock()
+
+    client = Client()
+    with pytest.raises(ValueError, match="max_turns"):
+        await client.chat.completions.acreate(
+            model="openai:gpt-4o",
+            messages=[{"role": "user", "content": "hi"}],
+            tools=[{"type": "function", "function": {"name": "t", "parameters": {}}}],
+            max_turns=2,
+            stream=True,
+        )

--- a/tests/providers/test_anthropic_streaming.py
+++ b/tests/providers/test_anthropic_streaming.py
@@ -1,0 +1,187 @@
+"""Tests for Anthropic streaming: event normalization into OpenAI-shaped chunks."""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+
+from aisuite.providers.anthropic_provider import (
+    AnthropicMessageConverter,
+    AnthropicProvider,
+)
+
+
+def _ev(**kwargs):
+    return SimpleNamespace(**kwargs)
+
+
+def _events():
+    """A representative Anthropic stream: text, then one tool call.
+
+    Note the tool_use block has Anthropic content-block index 1 (the text block
+    is index 0) but must surface as OpenAI tool-call index 0.
+    """
+    return [
+        _ev(
+            type="message_start",
+            message=_ev(usage=_ev(input_tokens=10, cache_read_input_tokens=3)),
+        ),
+        _ev(type="content_block_start", index=0, content_block=_ev(type="text")),
+        _ev(
+            type="content_block_delta",
+            index=0,
+            delta=_ev(type="text_delta", text="Hel"),
+        ),
+        _ev(
+            type="content_block_delta", index=0, delta=_ev(type="text_delta", text="lo")
+        ),
+        _ev(type="content_block_stop", index=0),
+        _ev(
+            type="content_block_start",
+            index=1,
+            content_block=_ev(type="tool_use", id="toolu_1", name="get_weather"),
+        ),
+        _ev(
+            type="content_block_delta",
+            index=1,
+            delta=_ev(type="input_json_delta", partial_json='{"location"'),
+        ),
+        _ev(
+            type="content_block_delta",
+            index=1,
+            delta=_ev(type="input_json_delta", partial_json=': "SF"}'),
+        ),
+        _ev(type="content_block_stop", index=1),
+        _ev(
+            type="message_delta",
+            delta=_ev(stop_reason="tool_use"),
+            usage=_ev(output_tokens=7),
+        ),
+        _ev(type="message_stop"),
+    ]
+
+
+def _convert_all(events):
+    converter = AnthropicMessageConverter()
+    state = {}
+    chunks = [converter.convert_stream_event(event, state) for event in events]
+    return [chunk for chunk in chunks if chunk is not None]
+
+
+def test_stream_events_normalize_to_openai_chunks():
+    chunks = _convert_all(_events())
+
+    # message_start → role chunk
+    assert chunks[0].choices[0].delta.role == "assistant"
+
+    # text deltas surface incrementally
+    text = "".join(c.choices[0].delta.content or "" for c in chunks)
+    assert text == "Hello"
+
+    # tool call opens with id/name at OpenAI index 0 (not Anthropic block index 1)
+    tool_start = chunks[3].choices[0].delta.tool_calls[0]
+    assert tool_start.index == 0
+    assert tool_start.id == "toolu_1"
+    assert tool_start.type == "function"
+    assert tool_start.function.name == "get_weather"
+
+    # argument fragments concatenate to the full JSON
+    arguments = "".join(
+        fragment.function.arguments
+        for chunk in chunks
+        if chunk.choices[0].delta.tool_calls
+        for fragment in chunk.choices[0].delta.tool_calls
+    )
+    assert arguments == '{"location": "SF"}'
+
+    # final chunk: normalized finish reason + usage
+    final = chunks[-1]
+    assert final.choices[0].finish_reason == "tool_calls"
+    assert final.usage.prompt_tokens == 10
+    assert final.usage.completion_tokens == 7
+    assert final.usage.total_tokens == 17
+    assert final.usage.prompt_tokens_details.cached_tokens == 3
+
+
+def test_stop_reason_maps_like_non_streaming():
+    converter = AnthropicMessageConverter()
+    chunk = converter.convert_stream_event(
+        _ev(type="message_delta", delta=_ev(stop_reason="end_turn"), usage=None), {}
+    )
+    assert chunk.choices[0].finish_reason == "stop"
+
+
+def test_uninteresting_events_yield_nothing():
+    converter = AnthropicMessageConverter()
+    state = {}
+    for event in (
+        _ev(type="content_block_start", index=0, content_block=_ev(type="text")),
+        _ev(type="content_block_stop", index=0),
+        _ev(type="message_stop"),
+        _ev(type="ping"),
+        _ev(
+            type="content_block_delta",
+            index=0,
+            delta=_ev(type="thinking_delta", thinking="hmm"),
+        ),
+    ):
+        assert converter.convert_stream_event(event, state) is None
+
+
+# -- provider wiring ---------------------------------------------------------------------
+@pytest.fixture
+def provider():
+    return AnthropicProvider(api_key="test-api-key")
+
+
+def test_sync_stream_converts_request_and_streams(provider):
+    provider.client.messages.create = Mock(return_value=iter(_events()))
+
+    chunks = list(
+        provider.chat_completions_create_stream(
+            "model-x",
+            [
+                {"role": "system", "content": "Be brief."},
+                {"role": "user", "content": "hi"},
+            ],
+        )
+    )
+
+    call = provider.client.messages.create.call_args
+    assert call.kwargs["stream"] is True
+    assert call.kwargs["system"] == "Be brief."
+    assert call.kwargs["messages"] == [{"role": "user", "content": "hi"}]
+    assert call.kwargs["max_tokens"] == 4096  # default applied, as non-streaming
+    assert "".join(c.choices[0].delta.content or "" for c in chunks) == "Hello"
+    assert chunks[-1].choices[0].finish_reason == "tool_calls"
+
+
+class _AsyncIter:
+    def __init__(self, items):
+        self._items = list(items)
+
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self):
+        if not self._items:
+            raise StopAsyncIteration
+        return self._items.pop(0)
+
+
+@pytest.mark.asyncio
+async def test_async_stream_uses_native_async_client(provider):
+    provider.async_client.messages.create = AsyncMock(
+        return_value=_AsyncIter(_events())
+    )
+
+    chunks = [
+        chunk
+        async for chunk in provider.achat_completions_create_stream(
+            "model-x", [{"role": "user", "content": "hi"}]
+        )
+    ]
+
+    assert provider.async_client.messages.create.await_args.kwargs["stream"] is True
+    assert "".join(c.choices[0].delta.content or "" for c in chunks) == "Hello"
+    assert chunks[-1].usage.total_tokens == 17

--- a/tests/providers/test_streaming_provider.py
+++ b/tests/providers/test_streaming_provider.py
@@ -1,0 +1,148 @@
+"""Tests for the streaming provider contract (chat_completions_create_stream)."""
+
+import threading
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+
+from aisuite.provider import Provider, LLMError
+from aisuite.providers.openai_provider import OpenaiProvider
+
+
+class _NonStreamingProvider(Provider):
+    """A provider that never opted into streaming."""
+
+    def chat_completions_create(self, model, messages, **kwargs):  # pragma: no cover
+        return SimpleNamespace()
+
+
+class _SyncStreamProvider(Provider):
+    """A provider with only a synchronous stream (no native async)."""
+
+    def __init__(self, chunks=(), fail_after=None):
+        super().__init__()
+        self._chunks = list(chunks)
+        self._fail_after = fail_after
+        self.streamed_on_thread = None
+
+    def chat_completions_create(self, model, messages, **kwargs):  # pragma: no cover
+        return SimpleNamespace()
+
+    def chat_completions_create_stream(self, model, messages, **kwargs):
+        self.streamed_on_thread = threading.current_thread().name
+        for i, chunk in enumerate(self._chunks):
+            if self._fail_after is not None and i == self._fail_after:
+                raise RuntimeError("stream broke")
+            yield chunk
+
+
+def test_base_sync_stream_reports_unsupported():
+    provider = _NonStreamingProvider()
+    with pytest.raises(LLMError, match="does not support streaming"):
+        provider.chat_completions_create_stream("m", [])
+
+
+@pytest.mark.asyncio
+async def test_default_async_stream_bridges_sync_off_the_loop():
+    """The base achat_completions_create_stream drains the provider's sync
+    stream in a worker thread and yields the chunks in order."""
+    provider = _SyncStreamProvider(chunks=["a", "b", "c"])
+
+    received = [
+        chunk
+        async for chunk in provider.achat_completions_create_stream(
+            "m", [{"role": "user", "content": "hi"}]
+        )
+    ]
+
+    assert received == ["a", "b", "c"]
+    assert provider.streamed_on_thread != threading.main_thread().name
+
+
+@pytest.mark.asyncio
+async def test_default_async_stream_propagates_errors():
+    provider = _SyncStreamProvider(chunks=["a", "b"], fail_after=1)
+
+    received = []
+    with pytest.raises(RuntimeError, match="stream broke"):
+        async for chunk in provider.achat_completions_create_stream("m", []):
+            received.append(chunk)
+
+    assert received == ["a"]
+
+
+@pytest.mark.asyncio
+async def test_default_async_stream_surfaces_unsupported():
+    provider = _NonStreamingProvider()
+    with pytest.raises(LLMError, match="does not support streaming"):
+        async for _ in provider.achat_completions_create_stream("m", []):
+            pass  # pragma: no cover
+
+
+# -- OpenAI: chunks pass through, stream=True reaches the SDK ---------------------------
+@pytest.fixture
+def openai_provider(monkeypatch):
+    monkeypatch.setenv("OPENAI_API_KEY", "test-api-key")
+    return OpenaiProvider()
+
+
+def test_openai_sync_stream_passes_through(openai_provider):
+    chunks = [SimpleNamespace(id="1"), SimpleNamespace(id="2")]
+    openai_provider.client.chat.completions.create = Mock(return_value=iter(chunks))
+
+    received = list(
+        openai_provider.chat_completions_create_stream(
+            "gpt-4o", [{"role": "user", "content": "hi"}], temperature=0.1
+        )
+    )
+
+    assert received == chunks
+    call = openai_provider.client.chat.completions.create.call_args
+    assert call.kwargs["stream"] is True
+    assert call.kwargs["temperature"] == 0.1
+    assert call.kwargs["model"] == "gpt-4o"
+
+
+def test_openai_sync_stream_wraps_errors(openai_provider):
+    openai_provider.client.chat.completions.create = Mock(
+        side_effect=RuntimeError("boom")
+    )
+    with pytest.raises(LLMError, match="boom"):
+        list(
+            openai_provider.chat_completions_create_stream(
+                "gpt-4o", [{"role": "user", "content": "hi"}]
+            )
+        )
+
+
+class _AsyncIter:
+    def __init__(self, items):
+        self._items = list(items)
+
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self):
+        if not self._items:
+            raise StopAsyncIteration
+        return self._items.pop(0)
+
+
+@pytest.mark.asyncio
+async def test_openai_async_stream_passes_through(openai_provider):
+    chunks = [SimpleNamespace(id="1"), SimpleNamespace(id="2")]
+    openai_provider.aclient.chat.completions.create = AsyncMock(
+        return_value=_AsyncIter(chunks)
+    )
+
+    received = [
+        chunk
+        async for chunk in openai_provider.achat_completions_create_stream(
+            "gpt-4o", [{"role": "user", "content": "hi"}]
+        )
+    ]
+
+    assert received == chunks
+    call = openai_provider.aclient.chat.completions.create.await_args
+    assert call.kwargs["stream"] is True


### PR DESCRIPTION
Chat completions gain streaming: `create`/`acreate` with `stream=True` return a (sync/async) iterator of OpenAI `chat.completion.chunk`-shaped chunks from any supporting provider — OpenAI and Ollama pass the SDK's chunks. through.
Anthropic's stream events are normalized (text deltas, tool-call fragments, finish_reason, usage on the final chunk), and any provider with a sync stream is async-iterable via a default worker-thread bridge on the base class.
Verified live against both OpenAI and Anthropic (text, async, and streamed tool-call assembly).

```python
for chunk in client.chat.completions.create(model=model, messages=messages, stream=True):
    print(chunk.choices[0].delta.content or "", end="", flush=True)
```

Note that, aisuite has two ways to use tools:
1. Automatic tool execution (max_turns) — you pass Python callables and max_turns=5, and aisuite runs the whole agent loop internally: call model → execute tools → feed results back → repeat, then hand you only the final response.
2. Manual tool calling (no max_turns) — aisuite sends the tool schemas to the model and gives you back whatever the model said, including tool-call requests. You execute the tools and send follow-up messages yourself.

Streaming only supports mode 2, for structural reasons and for keeping the design simple. Providing streaming support with max_turns would need for "turn" detection so that we only stream the last message in the turn as opposed to every response, and that is not the scope of this PR.