### PR TITLE
Support OpenAI-style image content parts in the Anthropic provider

### DIFF
--- a/aisuite/providers/anthropic_provider.py
+++ b/aisuite/providers/anthropic_provider.py
@@ -4,6 +4,7 @@
 
 import anthropic
 import json
+import re
 from aisuite.provider import Provider
 from aisuite.framework import ChatCompletionResponse
 from aisuite.framework.chat_completion_chunk import (
@@ -23,6 +24,11 @@ from aisuite.framework.message import (
 
 # Define a constant for the default max_tokens value
 DEFAULT_MAX_TOKENS = 4096
+
+# OpenAI-style image_url parts carry either a data URL or a plain http(s) URL.
+DATA_URL_RE = re.compile(
+    r"^data:(image/[a-z0-9.+-]+);base64,(.+)$", re.IGNORECASE | re.DOTALL
+)
 
 
 class AnthropicMessageConverter:
@@ -166,7 +172,7 @@ class AnthropicMessageConverter:
             return self._create_assistant_tool_message(
                 msg["content"], msg["tool_calls"]
             )
-        return {"role": msg["role"], "content": msg["content"]}
+        return {"role": msg["role"], "content": self._convert_content(msg["content"])}
 
     def _convert_message_object(self, msg):
         """Convert a Message object to Anthropic format."""
@@ -174,7 +180,46 @@ class AnthropicMessageConverter:
             return self._create_tool_result_message(msg.tool_call_id, msg.content)
         elif msg.role == self.ROLE_ASSISTANT and msg.tool_calls:
             return self._create_assistant_tool_message(msg.content, msg.tool_calls)
-        return {"role": msg.role, "content": msg.content}
+        return {"role": msg.role, "content": self._convert_content(msg.content)}
+
+    def _convert_content(self, content):
+        """String content passes through unchanged; an OpenAI-style parts list
+        (``{"type": "text"}`` / ``{"type": "image_url"}``) becomes Anthropic
+        content blocks. Empty text parts are dropped — Anthropic rejects them."""
+        if not isinstance(content, list):
+            return content
+        blocks = []
+        for part in content:
+            block = self._convert_content_part(part)
+            if block is not None:
+                blocks.append(block)
+        return blocks
+
+    def _convert_content_part(self, part):
+        """One OpenAI-style content part → an Anthropic content block (or None)."""
+        kind = part.get("type") if isinstance(part, dict) else None
+        if kind == "text":
+            text = part.get("text") or ""
+            return {"type": "text", "text": text} if text else None
+        if kind == "image_url":
+            url = (part.get("image_url") or {}).get("url") or ""
+            match = DATA_URL_RE.match(url)
+            if match:
+                return {
+                    "type": "image",
+                    "source": {
+                        "type": "base64",
+                        "media_type": match.group(1).lower(),
+                        "data": match.group(2),
+                    },
+                }
+            if url.startswith(("http://", "https://")):
+                return {"type": "image", "source": {"type": "url", "url": url}}
+            raise ValueError(
+                "Unsupported image_url for Anthropic: expected a base64 data URL "
+                f"(data:image/...;base64,...) or an http(s) URL, got {url[:80]!r}"
+            )
+        raise ValueError(f"Unsupported content part type for Anthropic: {kind!r}")
 
     def _create_tool_result_message(self, tool_call_id, content):
         """Create a tool result message in Anthropic format."""

--- a/tests/providers/test_anthropic_images.py
+++ b/tests/providers/test_anthropic_images.py
@@ -1,0 +1,112 @@
+"""Tests for OpenAI-style image content parts in the Anthropic converter."""
+
+import pytest
+
+from aisuite.providers.anthropic_provider import AnthropicMessageConverter
+
+RED_PIXEL_B64 = (
+    "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR4"
+    "nGP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg=="
+)
+DATA_URL = f"data:image/png;base64,{RED_PIXEL_B64}"
+
+
+@pytest.fixture
+def converter():
+    return AnthropicMessageConverter()
+
+
+def _convert(converter, content):
+    _, messages = converter.convert_request([{"role": "user", "content": content}])
+    return messages[0]
+
+
+def test_string_content_passes_through_unchanged(converter):
+    message = _convert(converter, "Hello")
+    assert message == {"role": "user", "content": "Hello"}
+
+
+def test_data_url_image_becomes_base64_source_block(converter):
+    message = _convert(
+        converter, [{"type": "image_url", "image_url": {"url": DATA_URL}}]
+    )
+    assert message["content"] == [
+        {
+            "type": "image",
+            "source": {
+                "type": "base64",
+                "media_type": "image/png",
+                "data": RED_PIXEL_B64,
+            },
+        }
+    ]
+
+
+def test_http_url_image_becomes_url_source_block(converter):
+    url = "https://example.com/cat.jpg"
+    message = _convert(converter, [{"type": "image_url", "image_url": {"url": url}}])
+    assert message["content"] == [
+        {"type": "image", "source": {"type": "url", "url": url}}
+    ]
+
+
+def test_mixed_text_and_image_parts_preserve_order(converter):
+    message = _convert(
+        converter,
+        [
+            {"type": "text", "text": "What is in this image?"},
+            {"type": "image_url", "image_url": {"url": DATA_URL}},
+            {"type": "text", "text": "Answer briefly."},
+        ],
+    )
+    kinds = [block["type"] for block in message["content"]]
+    assert kinds == ["text", "image", "text"]
+    assert message["content"][0]["text"] == "What is in this image?"
+
+
+def test_media_type_is_lowercased_from_data_url(converter):
+    message = _convert(
+        converter,
+        [
+            {
+                "type": "image_url",
+                "image_url": {"url": f"data:image/JPEG;base64,{RED_PIXEL_B64}"},
+            }
+        ],
+    )
+    assert message["content"][0]["source"]["media_type"] == "image/jpeg"
+
+
+def test_empty_text_parts_are_dropped(converter):
+    message = _convert(
+        converter,
+        [{"type": "text", "text": ""}, {"type": "text", "text": "hi"}],
+    )
+    assert message["content"] == [{"type": "text", "text": "hi"}]
+
+
+def test_unsupported_image_scheme_raises(converter):
+    with pytest.raises(ValueError, match="Unsupported image_url"):
+        _convert(
+            converter,
+            [{"type": "image_url", "image_url": {"url": "file:///tmp/x.png"}}],
+        )
+
+
+def test_unknown_part_type_raises(converter):
+    with pytest.raises(ValueError, match="content part type"):
+        _convert(converter, [{"type": "input_audio", "input_audio": {}}])
+
+
+def test_system_and_tool_paths_are_unaffected(converter):
+    """Regression: the parts conversion only touches plain user/assistant content."""
+    system, messages = converter.convert_request(
+        [
+            {"role": "system", "content": "Be brief."},
+            {"role": "user", "content": [{"type": "text", "text": "hi"}]},
+            {"role": "tool", "tool_call_id": "t1", "content": "result"},
+        ]
+    )
+    assert system == "Be brief."
+    assert messages[0]["content"] == [{"type": "text", "text": "hi"}]
+    assert messages[1]["content"][0]["type"] == "tool_result"


### PR DESCRIPTION
The Anthropic converter now accepts OpenAI-style multimodal user content (`content` as a list of `text`/`image_url` parts) and converts it to Anthropic content blocks -
-  base64 data URLs map to `base64` image sources
- plain http(s) URLs map to `url` sources
- empty text parts are dropped (Anthropic rejects them)
- unsupported part types or URL schemes raise a clear `ValueError` instead of sending a request the API will 400. 
- Plain string content is untouched.

Verified live against the Anthropic API on both the non-streaming and streaming paths.

```python
client.chat.completions.create(model="anthropic:...", messages=[{"role": "user", "content": [
    {"type": "text", "text": "What color is this?"},
    {"type": "image_url", "image_url": {"url": "data:image/png;base64,..."}},
]}])
```