### PR TITLE
OpenWorker: Dev bootstrap for fresh checkouts + approval-card preview clamp

### DIFF
--- a/platform/packaging/setup_dev_env.sh
+++ b/platform/packaging/setup_dev_env.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# One-time dev bootstrap for a fresh checkout: creates the Python venv every
+# from-source flow expects at platform/.venv — the browser dev flow runs its
+# coworker-server directly, and the Tauri desktop shell falls back to it when
+# no packaged sidecar binary is present (src-tauri/src/lib.rs, resolution step 3).
+#
+# Usage: bash platform/packaging/setup_dev_env.sh
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+VENV="$ROOT/platform/.venv"
+
+python3 -m venv "$VENV"
+# The coworker package (server, engine, connectors) + inbound-messaging extras.
+"$VENV/bin/pip" install --quiet --upgrade pip
+"$VENV/bin/pip" install --quiet -e "$ROOT/platform[messaging,dev]"
+
+# `import aisuite` resolves from THIS checkout, not PyPI — a .pth puts the repo
+# root on the venv's path (the packaged app freezes it the same way).
+SITE="$("$VENV/bin/python" -c 'import site; print(site.getsitepackages()[0])')"
+echo "$ROOT" > "$SITE/aisuite_src.pth"
+
+"$VENV/bin/python" -c 'import aisuite, coworker' # fail loudly if the wiring broke
+echo "Ready: $VENV"
+echo "  server: $VENV/bin/coworker-server --cwd /path/to/your/project --port 8765"

--- a/platform/surfaces/gui/README.md
+++ b/platform/surfaces/gui/README.md
@@ -1,14 +1,22 @@
 # coworker GUI (React + Tauri)
 
 A thin client of the coworker server (OpenAI-compatible API + WS event/approval stream).
-Same codebase runs in a browser (dev) and as a Tauri desktop app.
+Same codebase runs in a browser (dev) and as the OpenCoworker desktop app.
+
+## First time: bootstrap the Python backend
+
+A fresh checkout has no server to run — create the venv both flows below expect:
+
+```bash
+bash platform/packaging/setup_dev_env.sh   # → platform/.venv (server + this repo's aisuite)
+```
 
 ## Run it (browser, two terminals)
 
-1. **Start the server** (needs `OPENAI_API_KEY` in the environment):
+1. **Start the server** (needs a model key, e.g. `OPENAI_API_KEY`, in the environment —
+   or add one later in the app's Settings):
    ```bash
    cd platform
-   export OPENAI_API_KEY=sk-...
    ./.venv/bin/coworker-server --cwd /path/to/your/project --port 8765
    ```
 2. **Start the UI:**
@@ -21,11 +29,22 @@ Same codebase runs in a browser (dev) and as a Tauri desktop app.
 Open http://localhost:5173. The UI talks to `http://127.0.0.1:8765` (override with
 `VITE_COWORKER_HTTP` / `VITE_COWORKER_WS`).
 
-## Desktop (Tauri) — later
+## Run the desktop app from source
 
-The Tauri shell wraps this same app and supervises the Python server as a sidecar. It
-requires the Rust toolchain (`cargo`), which isn't installed yet:
+The Tauri shell wraps the same UI and supervises the Python server itself — no separate
+terminal. It needs the Rust toolchain (`rustup`) plus the venv from the bootstrap step;
+in dev it finds the server at `platform/.venv/bin/coworker-server` automatically (a
+packaged sidecar binary is only produced by the release scripts in `platform/packaging/`).
+
 ```bash
-curl https://sh.rustup.rs -sSf | sh   # install Rust, then add the Tauri scaffold
+cd platform/surfaces/gui
+npm install        # first time
+npm run tauri dev  # builds the shell, launches the window, starts the server
 ```
-Until then, use the browser flow above — it's the identical UI.
+
+## Tests
+
+```bash
+npx tsc --noEmit && npx vitest run   # typecheck + unit
+npx playwright test                  # hermetic e2e (mocked /v1 + WS, no Python needed)
+```

--- a/platform/surfaces/gui/e2e/approval-card.spec.ts
+++ b/platform/surfaces/gui/e2e/approval-card.spec.ts
@@ -55,3 +55,26 @@ test("run_shell → full card: description title, command preview, stays-on-this
   await page.getByRole("button", { name: "Allow once" }).last().click();
   await expect(page.getByText("The command ran; 1 file found.")).toBeVisible();
 });
+
+test("a one-paragraph digest send is clamped to a card, expandable in place", async ({
+  page,
+}) => {
+  await page.goto("/");
+  const box = page.getByPlaceholder(/Ask the coworker/);
+  await box.fill("post the long digest");
+  await page.getByRole("button", { name: "Send" }).click();
+
+  // The message rides in a clamped preview box — not an unbounded quote wall.
+  const prev = page.locator(".approval-prev");
+  await expect(prev).toBeVisible();
+  await expect(prev).toContainText("aisuite — last 24 hours");
+  const clampedHeight = (await prev.boundingBox())!.height;
+  expect(clampedHeight).toBeLessThan(200);
+
+  await page.screenshot({ path: "test-results/send-digest-clamped.png", fullPage: false });
+
+  // Expands in place, and can collapse back.
+  await prev.getByText("show the full message").click();
+  expect((await prev.boundingBox())!.height).toBeGreaterThan(clampedHeight);
+  await expect(prev.getByText("show less")).toBeVisible();
+});

--- a/platform/surfaces/gui/e2e/fixtures.ts
+++ b/platform/surfaces/gui/e2e/fixtures.ts
@@ -511,6 +511,21 @@ export async function mockApi(page: import("@playwright/test").Page) {
           send("permission_required", { name: "write_file", arguments: args, reason: "" });
           return; // suspended on the approval
         }
+        // A one-paragraph digest with NO newlines — the owner-repro shape that once
+        // ballooned the card to full-transcript height (char clamp, 2026-07-15).
+        if (/post the long digest/i.test(msg.text)) {
+          pendingTool = "send_message";
+          const args = {
+            target: "slack:T1/C1",
+            text:
+              "aisuite — last 24 hours of work (through Jul 15): 5 PRs merged covering chat-completion streaming with unified chunks across providers, multimodal input conversion, Slack collaboration improvements, human attribution for outbound posts, and repo-wide formatting. ".repeat(
+                6,
+              ),
+          };
+          send("tool_proposed", { name: "send_message", arguments: args });
+          send("permission_required", { name: "send_message", arguments: args, reason: "", category: "messaging" });
+          return;
+        }
         // Standing scoped approvals (§25): an eligible connector-ish write — the event
         // carries the pinnable target, exactly like the real engine computes it.
         if (/post the digest/i.test(msg.text)) {

--- a/platform/surfaces/gui/src/components/ApprovalCard.test.tsx
+++ b/platform/surfaces/gui/src/components/ApprovalCard.test.tsx
@@ -127,6 +127,25 @@ describe("ApprovalCard — §35 shapes", () => {
     expect(screen.getByText("Allow once")).toBeTruthy();
   });
 
+  it("long single-paragraph send_message text is clamped, expandable, and never a wall", () => {
+    // Owner repro 2026-07-15: a one-paragraph Slack digest (no newlines) blew the card
+    // up to full-transcript height — the preview clamped by LINES only.
+    const digest = "aisuite last 24 hours of work: five PRs merged covering streaming, multimodal input, Slack improvements, human attribution, and formatting. ".repeat(8);
+    render(<ApprovalCard item={sendApproval({ args: { target: "slack:T1/C1", text: digest } })} onApprove={vi.fn()} />);
+
+    const prev = document.querySelector(".approval-prev") as HTMLElement;
+    expect(prev.textContent!.length).toBeLessThan(500);
+    fireEvent.click(screen.getByText("show the full message"));
+    expect(document.querySelector(".approval-prev")!.textContent!.length).toBeGreaterThan(1000);
+    expect(screen.getByText("show less")).toBeTruthy();
+  });
+
+  it("short send_message text keeps the inline quote (no preview box)", () => {
+    render(<ApprovalCard item={sendApproval()} onApprove={vi.fn()} />);
+    expect(screen.getByText(/“digest”/)).toBeTruthy();
+    expect(document.querySelector(".approval-prev")).toBeNull();
+  });
+
   it("run_shell titles with the model's description and previews the command", () => {
     render(
       <ApprovalCard

--- a/platform/surfaces/gui/src/components/ApprovalCard.tsx
+++ b/platform/surfaces/gui/src/components/ApprovalCard.tsx
@@ -77,20 +77,47 @@ export function scopeNote(
 
 // The proposed content/command, straight from the tool call's ARGS — the file/action
 // doesn't exist yet, so no viewer could show it (§35; see UX-018 mock note).
+// Clamps by CHARACTERS as well as lines: a one-paragraph Slack digest has no
+// newlines at all and once ballooned the card to full-transcript height.
+const PREVIEW_LINES = 5;
+const PREVIEW_CHARS = 420;
+
 export function PreviewBlock({ text, mono = true }: { text: string; mono?: boolean }) {
   const [all, setAll] = useState(false);
   const lines = text.split("\n");
-  const shown = all ? text : lines.slice(0, 5).join("\n");
+  const clipped = lines.length > PREVIEW_LINES || text.length > PREVIEW_CHARS;
+  let shown = text;
+  if (!all && clipped) {
+    shown = lines.slice(0, PREVIEW_LINES).join("\n");
+    if (shown.length > PREVIEW_CHARS) shown = shown.slice(0, PREVIEW_CHARS).trimEnd() + "…";
+  }
   return (
     <div className={"approval-prev" + (mono ? "" : " prose")}>
       {shown}
-      {lines.length > 5 && (
+      {clipped && (
         <button className="approval-prev-more" onClick={() => setAll((v) => !v)}>
-          {all ? "show less" : `show all ${lines.length} lines`}
+          {all
+            ? "show less"
+            : lines.length > PREVIEW_LINES
+              ? `show all ${lines.length} lines`
+              : "show the full message"}
         </button>
       )}
     </div>
   );
+}
+
+// Outbound message text: short one-liners keep the cozy inline quote; anything
+// long (or multi-line) gets the clamped preview so the card stays card-sized.
+function MessagePreview({ text, label }: { text: string; label?: string }) {
+  if (text.length <= 220 && !text.includes("\n")) {
+    return (
+      <div className="approval-with">
+        {label ? `${label}: ` : ""}“{text}”
+      </div>
+    );
+  }
+  return <PreviewBlock text={text} mono={false} />;
 }
 
 function Buttons({
@@ -218,12 +245,12 @@ export function ApprovalCard({
             {item.args?.as_screenshot ? " · as a PNG screenshot" : ""}
           </span>
           {item.args?.comment && (
-            <div className="approval-with">With the message: “{String(item.args.comment)}”</div>
+            <MessagePreview text={String(item.args.comment)} label="With the message" />
           )}
         </>
       )}
       {item.name === "send_message" && item.args?.text && (
-        <div className="approval-with">“{String(item.args.text)}”</div>
+        <MessagePreview text={String(item.args.text)} />
       )}
 
       {grants.length > 0 && (

--- a/platform/surfaces/gui/src/styles.css
+++ b/platform/surfaces/gui/src/styles.css
@@ -397,6 +397,8 @@ body {
   font-size: 11.5px; color: var(--accent); background: none; border: 0; padding: 0; cursor: pointer;
 }
 .approval-with { margin-top: 9px; font-size: 12.5px; color: var(--muted); }
+/* long outbound messages: same box as code previews but reads as text, not code */
+.approval-prev.prose { font-family: inherit; font-size: 12.5px; }
 .approval-filechip {
   display: inline-flex; align-items: center; gap: 7px; margin-top: 11px; align-self: flex-start;
   border: 1px solid var(--line); border-radius: 9px; background: var(--paper);


### PR DESCRIPTION
Two small fixes:
1. a fresh clone had no runnable backend and no instructions to create one, so `platform/packaging/setup_dev_env.sh` now bootstraps the expected venv in one command (verified by booting the server to a 200 health check) and the GUI README documents the real browser and tauri-dev flows.
2. Approval-card previews now clamp by characters as well as lines (expand in place), so a long one-paragraph outbound message no longer stretches the card to transcript height.