### PR TITLE
macOS bundle: declare minimumSystemVersion 12.0

### DIFF
--- a/platform/surfaces/gui/src-tauri/tauri.conf.json
+++ b/platform/surfaces/gui/src-tauri/tauri.conf.json
@@ -29,7 +29,8 @@
     ],
     "externalBin": ["binaries/coworker-server"],
     "macOS": {
-      "entitlements": "entitlements.plist"
+      "entitlements": "entitlements.plist",
+      "minimumSystemVersion": "12.0"
     },
     "windows": {
       "webviewInstallMode": { "type": "downloadBootstrapper" },


### PR DESCRIPTION
One-line release fix: without a declared minimum, Tauri pins release builds to a 10.13 deployment target and whisper.cpp's std::filesystem use (voice input) fails to compile — dev builds and cargo check pass, only `tauri build` breaks. 12.0 matches the app's real floor (Apple-Silicon-only; voice requires macOS 12+). Verified by the first fully-notarized DMG built from main with this change.