### PR TITLE
OCW App: faster boot, faster sign-in, onboarding clarity, drag-drop attach

### DIFF
--- a/platform/coworker/cloud.py
+++ b/platform/coworker/cloud.py
@@ -141,14 +141,12 @@ def complete_login(
         profile["account"] = me.get("user", {}).get("email") or ""
         profile["user_id"] = me.get("user", {}).get("user_id") or ""
         secrets.put(CLOUD_AUTH_PROFILE, profile)
-    # Best-effort restore of managed connections (a failure never fails the
-    # sign-in — the user can still connect by hand). The /auth/callback route
-    # hot-adds the gateway when anything came back.
-    try:
-        restored = sync_connections(secrets, config).get("restored", [])
-    except Exception:
-        restored = []
-    return {"ok": True, "restored_github_installs": restored, **status(secrets)}
+    # Connection restore (sync_connections) deliberately does NOT run here: it is
+    # best-effort metadata work, and doing it inline held the browser's "Signed in"
+    # page + the GUI's signed-in flip hostage to an extra broker round trip (slow
+    # sign-in complaint, 2026-07-16). The /auth/callback route kicks it off in the
+    # background after responding.
+    return {"ok": True, **status(secrets)}
 
 
 def sync_connections(secrets: SecretStore, config: Config) -> dict[str, Any]:

--- a/platform/coworker/server/app.py
+++ b/platform/coworker/server/app.py
@@ -869,10 +869,22 @@ def create_app(manager: SessionManager) -> FastAPI:
                 ),
                 status_code=400,
             )
-        # Sign-in restored GitHub installs from the broker's metadata rows —
-        # hot-add the gateway so the relay connects without a restart.
-        if result.get("restored_github_installs"):
-            await manager.refresh_gateway()
+
+        # Restore managed connections in the background: best-effort metadata work
+        # that must not hold the "Signed in" page (or the GUI's signed-in flip)
+        # hostage to another broker round trip. Restored GitHub installs hot-add
+        # the gateway so the relay connects without a restart.
+        async def _restore_connections() -> None:
+            try:
+                out = await asyncio.to_thread(
+                    lambda: cloud.sync_connections(manager.secrets, load_config())
+                )
+                if out.get("restored"):
+                    await manager.refresh_gateway()
+            except Exception:
+                pass  # sign-in stands; the user can still connect by hand
+
+        asyncio.get_running_loop().create_task(_restore_connections())
         return HTMLResponse(
             _browser_page(
                 "Signed in",

--- a/platform/docs/UX-DECISIONS.md
+++ b/platform/docs/UX-DECISIONS.md
@@ -625,13 +625,17 @@ and it duplicated the Automations page's template system.
 
 - **Onboarding = three fixed-height pages, one decision each:**
   1. **Model** — unchanged (§24 + its revisions).
-  2. **Connect your tools** — value-framed cloud sign-in: real connector logos (ConnectorIcon
-     set, never letter stand-ins), "one sign-in unlocks every one-click connection — your
-     tokens stay on this Mac", the manual path spelled out ("every tool can also be connected
-     with your own API keys — signing in just makes it one click"), plain-link skip (no
-     confirm; sign-in is genuinely optional — the lazy first-connect sign-in stays for
-     skippers). Signed-in replay shows the ✓ state instead of the button.
-     `↪ Open:` the owner finds this page's copy still confusing — copy iteration pending.
+  2. **Sign in for one-click connections** *(amended 2026-07-16, owner design — resolves the
+     copy iteration that was pending here)* — the VALUE is the headline and there is ONE
+     primary action: the footer is the flow's standard pair — quiet "Skip for now" left,
+     primary **Sign in** right, which becomes **Continue** once signed in. (The old page was
+     headlined "Connect your tools" but offered no connecting, and its mid-page sign-in
+     button competed with a footer Continue that did something else.) The security story is
+     one titled card — **"Secure by design"**: broker framing ("OpenCoworker Cloud brokers
+     the OAuth handshake — your tokens never leave this Mac") with the manual-keys path as
+     the card's divider-set footnote. Real connector logos kept (ConnectorIcon set, never
+     letter stand-ins); sign-in stays genuinely optional (the lazy first-connect sign-in
+     remains for skippers); signed-in replay shows the ✓ state.
   3. **You're set up** — two CTAs: "Create your first automation" → the Automations
      quickstart; "Start working with Coworker" → fresh session with the session-settings
      panel open (§24's teach-by-landing kept). The gallery card + scope line stay hidden.

--- a/platform/packaging/build_dmg.sh
+++ b/platform/packaging/build_dmg.sh
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
 # Build the macOS desktop app + a drag-to-install .dmg.
 #
-#   1. PyInstaller-bundle the server into a standalone binary (no venv needed at runtime).
-#   2. Drop it into Tauri's externalBin slot (binaries/coworker-server-<triple>).
-#   3. `tauri build --bundles app` → OpenCoworker.app (the externalBin is copied in).
+#   1. PyInstaller-bundle the server into a standalone onedir folder (no venv at runtime).
+#   2. Stage it at binaries/sidecar/ for Tauri's `resources` slot (+ sign its Mach-Os).
+#   3. `tauri build --bundles app` → OpenCoworker.app (resources are copied in).
 #   4. Wrap the .app in a compressed .dmg via hdiutil (reliable + headless; Tauri's own
 #      bundle_dmg.sh uses Finder AppleScript and fails in non-interactive sessions).
 #
@@ -50,14 +50,32 @@ echo "==> [1/5] PyInstaller: bundling coworker-server ($TRIPLE)"
 "$PLATFORM/.venv/bin/pyinstaller" --noconfirm --clean \
   --distpath "$HERE/dist" --workpath "$HERE/build" "$HERE/coworker-server.spec"
 
-echo "==> [2/5] staging externalBin"
+echo "==> [2/5] staging sidecar resources"
+# Onedir bundle (exe + _internal/) ships via Tauri `resources` as Contents/Resources/sidecar/
+# — onefile's per-launch self-extraction cost 6-7s of boot splash. rm -rf first: cp WRITES
+# THROUGH a symlink at the destination (a dev-convenience symlink in the old externalBin slot
+# once clobbered another worktree's venv console script, caught 2026-07-11); also clears any
+# stale onefile binary from pre-onedir builds.
 mkdir -p "$GUI/src-tauri/binaries"
-# rm first: cp WRITES THROUGH a symlink at the destination. A dev-convenience symlink left in
-# this slot once routed the fresh binary into another worktree's venv, clobbering its console
-# script (caught 2026-07-11) — the bundle stayed correct only by accident.
-rm -f "$GUI/src-tauri/binaries/coworker-server-$TRIPLE"
-cp "$HERE/dist/coworker-server" "$GUI/src-tauri/binaries/coworker-server-$TRIPLE"
-chmod +x "$GUI/src-tauri/binaries/coworker-server-$TRIPLE"
+rm -rf "$GUI/src-tauri/binaries/sidecar" "$GUI/src-tauri/binaries/coworker-server-$TRIPLE"
+cp -R "$HERE/dist/coworker-server" "$GUI/src-tauri/binaries/sidecar"
+chmod +x "$GUI/src-tauri/binaries/sidecar/coworker-server"
+
+# Sign the sidecar's Mach-O files BEFORE tauri build: `tauri build` signs the .app (sealing
+# resources into its signature) but does NOT sign nested binaries inside resources — unsigned
+# Mach-Os there fail notarization. Hardened runtime + timestamp on every one, same identity,
+# entitlements on the executable (disable-library-validation: the bundled python dylibs carry
+# other Team IDs). externalBin used to get this from tauri itself.
+if [ -n "${APPLE_SIGNING_IDENTITY:-}" ]; then
+  echo "    signing sidecar binaries"
+  find "$GUI/src-tauri/binaries/sidecar" -type f \
+    ! -name "*.py" ! -name "*.pyc" ! -name "*.txt" ! -name "*.pem" ! -name "*.json" \
+    -print0 | while IFS= read -r -d '' f; do
+    file -b "$f" | grep -q "Mach-O" || continue
+    codesign --force --sign "$APPLE_SIGNING_IDENTITY" --timestamp --options runtime \
+      --entitlements "$GUI/src-tauri/entitlements.plist" "$f"
+  done
+fi
 
 echo "==> [3/5] tauri build (.app)"
 ( cd "$GUI" && npm run tauri build -- --bundles app )

--- a/platform/packaging/build_windows.ps1
+++ b/platform/packaging/build_windows.ps1
@@ -5,9 +5,9 @@
 
 .DESCRIPTION
   The Windows counterpart to build_dmg.sh:
-    1. PyInstaller-bundle the server into a standalone coworker-server.exe (no venv at runtime).
-    2. Drop it into Tauri's externalBin slot (binaries\coworker-server-<triple>.exe).
-    3. `tauri build --bundles nsis,msi` -> Coworker NSIS setup .exe + .msi (externalBin copied in).
+    1. PyInstaller-bundle the server into a standalone onedir folder (no venv at runtime).
+    2. Stage it at binaries\sidecar\ for Tauri's `resources` slot.
+    3. `tauri build --bundles nsis,msi` -> Coworker NSIS setup .exe + .msi (resources copied in).
 
   Prerequisites (see the toolchain notes in the PR/plan):
     - Rust (rustup) with the x86_64-pc-windows-msvc target + the MSVC C++ build tools (link.exe).
@@ -68,12 +68,17 @@ Write-Host "==> [1/3] PyInstaller: bundling coworker-server ($Triple)" -Foregrou
     (Join-Path $Here "coworker-server.spec")
 if ($LASTEXITCODE -ne 0) { throw "PyInstaller failed (exit $LASTEXITCODE)" }
 
-Write-Host "==> [2/3] staging externalBin" -ForegroundColor Cyan
+Write-Host "==> [2/3] staging sidecar resources" -ForegroundColor Cyan
+# Onedir bundle (exe + _internal\) ships via Tauri `resources`, landing at <install>\sidecar\
+# next to the app exe — onefile's per-launch self-extraction cost seconds of boot splash.
 $BinDir = Join-Path $Gui "src-tauri\binaries"
 New-Item -ItemType Directory -Force -Path $BinDir | Out-Null
-$Src = Join-Path $Here "dist\coworker-server.exe"
-$Dst = Join-Path $BinDir "coworker-server-$Triple.exe"
-Copy-Item -Force $Src $Dst
+$Src = Join-Path $Here "dist\coworker-server"
+$Dst = Join-Path $BinDir "sidecar"
+if (Test-Path $Dst) { Remove-Item -Recurse -Force $Dst }
+# Clear any stale onefile binary from pre-onedir builds.
+Remove-Item -Force (Join-Path $BinDir "coworker-server-$Triple.exe") -ErrorAction SilentlyContinue
+Copy-Item -Recurse -Force $Src $Dst
 Write-Host "    -> $Dst"
 
 Write-Host "==> [3/3] tauri build (--bundles $Bundles)" -ForegroundColor Cyan

--- a/platform/packaging/coworker-server.spec
+++ b/platform/packaging/coworker-server.spec
@@ -1,7 +1,10 @@
 # -*- mode: python ; coding: utf-8 -*-
 """PyInstaller spec for the bundled `coworker-server` (desktop sidecar).
 
-One-file binary so it drops into Tauri's externalBin slot. The wrinkles handled here:
+One-DIR bundle (exe + `_internal/` support folder) shipped via Tauri's `resources` slot.
+It used to be a onefile binary in the externalBin slot, but onefile self-extracts its whole
+archive to a temp dir on EVERY launch — 6-7s of "Starting coworker…" splash (measured; the
+actual Python import is ~0.5s). The wrinkles handled here:
   - aisuite isn't pip-installed — it lives at <repo>/aisuite on sys.path via a `.pth`. We add
     both the repo root and platform/ to `pathex` and collect coworker + aisuite submodules.
   - uvicorn loads its protocol/lifespan impls dynamically → collect_all.
@@ -88,9 +91,8 @@ pyz = PYZ(a.pure)
 exe = EXE(
     pyz,
     a.scripts,
-    a.binaries,
-    a.datas,
     [],
+    exclude_binaries=True,
     name="coworker-server",
     debug=False,
     bootloader_ignore_signals=False,
@@ -100,4 +102,14 @@ exe = EXE(
     # shell hides the window on Windows via CREATE_NO_WINDOW when spawning the sidecar.
     console=True,
     # target_arch left unset → PyInstaller builds for the host architecture.
+)
+# Onedir: dist/coworker-server/{coworker-server[.exe], _internal/}. The build scripts stage
+# this whole folder into src-tauri/binaries/sidecar/ for Tauri's `resources` bundling.
+coll = COLLECT(
+    exe,
+    a.binaries,
+    a.datas,
+    strip=False,
+    upx=False,
+    name="coworker-server",
 )

--- a/platform/surfaces/gui/e2e/onboarding.spec.ts
+++ b/platform/surfaces/gui/e2e/onboarding.spec.ts
@@ -52,6 +52,34 @@ test("model step: configured provider fast-path; Continue verifies automatically
   await expect(page.getByTestId("ob-step-tools")).toBeVisible();
 });
 
+test("model step: switching providers keeps unsaved input and shows the connected state", async ({
+  page,
+}) => {
+  await openOnboarding(page);
+
+  // The configured provider (OpenAI) says so ON the form — the stored key is never echoed
+  // back, so without this line the empty password field read as "not set up" (owner
+  // complaint 2026-07-16).
+  await expect(page.getByTestId("ob-provider-connected")).toBeVisible();
+  await expect(page.getByTestId("ob-field-api_key")).toHaveAttribute(
+    "placeholder",
+    /key saved/,
+  );
+
+  // Type a key on another vendor, peek back at OpenAI, return: the draft survives the
+  // round trip (it used to be silently blanked) and OpenAI still reads connected.
+  await page.getByRole("button", { name: "Provider" }).click();
+  await page.getByRole("option", { name: "Z AI (GLM)" }).click();
+  await expect(page.getByTestId("ob-provider-connected")).toHaveCount(0);
+  await page.getByTestId("ob-field-api_key").fill("zk-draft");
+  await page.getByRole("button", { name: "Provider" }).click();
+  await page.getByRole("option", { name: "OpenAI" }).click();
+  await expect(page.getByTestId("ob-provider-connected")).toBeVisible();
+  await page.getByRole("button", { name: "Provider" }).click();
+  await page.getByRole("option", { name: "Z AI (GLM)" }).click();
+  await expect(page.getByTestId("ob-field-api_key")).toHaveValue("zk-draft");
+});
+
 test("tools page: out-of-band sign-in flips to the signed-in state; the automation CTA lands on the quickstart", async ({
   page,
 }) => {
@@ -59,9 +87,13 @@ test("tools page: out-of-band sign-in flips to the signed-in state; the automati
   await page.getByTestId("ob-continue").click();
   await expect(page.getByTestId("ob-step-tools")).toBeVisible();
 
-  // §29's tools page: value-framed sign-in (never an account gate) — the manual-keys path is
-  // spelled out, and the sign-in lands out-of-band (browser flow), flipping to the ✓ state.
+  // §29's tools page (2026-07-16 owner redesign): the value is the headline, ONE primary
+  // action — Sign in sits in the footer slot and Continue only replaces it once signed in.
+  // The manual-keys path is spelled out inside the "Secure by design" card, and the sign-in
+  // lands out-of-band (browser flow), flipping to the ✓ state.
+  await expect(page.getByText("Secure by design")).toBeVisible();
   await expect(page.getByText("Prefer manual setup?")).toBeVisible();
+  await expect(page.getByTestId("ob-continue-tools")).toHaveCount(0);
   await page.getByTestId("ob-cloud-signin").click();
   await expect(page.getByTestId("ob-tools-signedin")).toBeVisible({ timeout: 10_000 });
   await expect(page.getByTestId("ob-tools-signedin")).toContainText("rohit@opencoworker.app");

--- a/platform/surfaces/gui/src-tauri/src/lib.rs
+++ b/platform/surfaces/gui/src-tauri/src/lib.rs
@@ -44,10 +44,12 @@ fn free_port() -> u16 {
 
 /// Path to the server entrypoint. Resolution order:
 ///   1. `COWORKER_SERVER_BIN` env override.
-///   2. The bundled sidecar next to the app executable (production — Tauri externalBin drops
-///      `coworker-server[.exe]` next to the app binary: Contents/MacOS on macOS, the install
-///      dir on Windows).
-///   3. Dev fallback: the repo venv, relative to this crate (`src-tauri` → `platform/.venv`;
+///   2. The bundled onedir sidecar shipped via Tauri `resources` (production): the
+///      `sidecar/` folder lands in Contents/Resources on macOS and in the install dir
+///      (next to the app exe) on Windows.
+///   3. Legacy onefile slot: `coworker-server[.exe]` next to the app binary (pre-onedir
+///      builds used Tauri externalBin).
+///   4. Dev fallback: the repo venv, relative to this crate (`src-tauri` → `platform/.venv`;
 ///      `bin/` on POSIX, `Scripts\` on Windows).
 fn server_bin() -> PathBuf {
     if let Ok(p) = std::env::var("COWORKER_SERVER_BIN") {
@@ -60,9 +62,17 @@ fn server_bin() -> PathBuf {
     };
     if let Ok(exe) = std::env::current_exe() {
         if let Some(dir) = exe.parent() {
-            let bundled = dir.join(exe_name);
-            if bundled.exists() {
-                return bundled;
+            // macOS: Contents/MacOS/<app> → Contents/Resources/sidecar/; Windows: resources
+            // unpack next to the exe, so <install>/sidecar/.
+            let mut candidates = vec![dir.join("sidecar").join(exe_name)];
+            if let Some(contents) = dir.parent() {
+                candidates.push(contents.join("Resources").join("sidecar").join(exe_name));
+            }
+            candidates.push(dir.join(exe_name)); // legacy onefile externalBin slot
+            for c in candidates {
+                if c.exists() {
+                    return c;
+                }
             }
         }
     }
@@ -563,6 +573,12 @@ pub fn run() {
                     .title("OpenCoworker")
                     .inner_size(1360.0, 900.0)
                     .min_inner_size(980.0, 640.0)
+                    // Let the WEBVIEW receive OS file drags: Tauri's own drag-drop handler
+                    // otherwise intercepts them, so the composer's HTML5 onDrop (attach by
+                    // dragging a file in) never fired in the desktop shell — browser dev
+                    // worked, DMGs didn't. main.tsx guards against drops outside the
+                    // composer navigating the page.
+                    .disable_drag_drop_handler()
                     .initialization_script(&inject);
             #[cfg(target_os = "macos")]
             {

--- a/platform/surfaces/gui/src-tauri/tauri.conf.json
+++ b/platform/surfaces/gui/src-tauri/tauri.conf.json
@@ -27,9 +27,10 @@
       "icons/icon.icns",
       "icons/icon.ico"
     ],
-    "externalBin": ["binaries/coworker-server"],
+    "resources": { "binaries/sidecar": "sidecar" },
     "macOS": {
-      "entitlements": "entitlements.plist"
+      "entitlements": "entitlements.plist",
+      "minimumSystemVersion": "12.0"
     },
     "windows": {
       "webviewInstallMode": { "type": "downloadBootstrapper" },

--- a/platform/surfaces/gui/src/App.tsx
+++ b/platform/surfaces/gui/src/App.tsx
@@ -950,11 +950,18 @@ export function App() {
   if (booting || !uiReady) {
     return (
       <div className={"app boot-splash" + (overlay ? " tauri-overlay" : "")}>
-        {desktop && (
+        {/* overlay (not desktop): ?overlay=1 previews the splash's top-left in the browser
+            too — the wordmark/traffic-light alignment is exactly what it exists to tune. */}
+        {overlay && (
           <div className="titlebar-drag" data-tauri-drag-region>
             <span className="titlebar-brand brand-wordmark">
               <Icon name="logo" size={13} className="mark" /> OpenCoworker
             </span>
+          </div>
+        )}
+        {simOverlay && (
+          <div className="sim-traffic-lights" aria-hidden="true">
+            <span /><span /><span />
           </div>
         )}
         <div className="boot-mark">✦</div>

--- a/platform/surfaces/gui/src/api.ts
+++ b/platform/surfaces/gui/src/api.ts
@@ -404,6 +404,34 @@ export async function cloudLogin(): Promise<{ ok: boolean }> {
   return res.json();
 }
 
+/** Poll cloud status until the browser sign-in lands (or the bound runs out).
+ *
+ * Fast 500ms polls for the first 20s — the moment the user finishes in the
+ * browser they're staring at the app waiting for it to flip, and a 2s interval
+ * reads as "sign-in is slow" (owner complaint, 2026-07-16) — then relaxes to 2s
+ * for the long tail (~2min total). Calls `onDone` with the signed-in status, or
+ * null when it timed out. Returns a cancel function (call on unmount). */
+export function waitForCloudSignIn(
+  onDone: (s: CloudStatus | null) => void,
+): () => void {
+  let cancelled = false;
+  let timer: ReturnType<typeof setTimeout> | null = null;
+  let polls = 0;
+  const tick = async () => {
+    polls += 1;
+    const s = await getCloudStatus().catch(() => null);
+    if (cancelled) return;
+    if (s?.signed_in) return onDone(s);
+    if (polls >= 90) return onDone(null); // 40×500ms + 50×2s ≈ 2min
+    timer = setTimeout(tick, polls < 40 ? 500 : 2000);
+  };
+  timer = setTimeout(tick, 500);
+  return () => {
+    cancelled = true;
+    if (timer) clearTimeout(timer);
+  };
+}
+
 export async function cloudLogout(): Promise<{ ok: boolean }> {
   const res = await fetch(`${httpBase()}/v1/cloud/logout`, { method: "POST" });
   return res.json();

--- a/platform/surfaces/gui/src/components/AutomationQuickstart.tsx
+++ b/platform/surfaces/gui/src/components/AutomationQuickstart.tsx
@@ -5,6 +5,7 @@ import {
   getCloudStatus,
   getConnectors,
   getRecentChannels,
+  waitForCloudSignIn,
   type CloudStatus,
   type Connector,
   type RecentChannel,
@@ -247,9 +248,9 @@ export function AutomationQuickstart({
     refresh();
   };
 
-  const signinPollRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const signinPollRef = useRef<(() => void) | null>(null);
   const cancelSignin = () => {
-    if (signinPollRef.current) clearInterval(signinPollRef.current);
+    signinPollRef.current?.();
     signinPollRef.current = null;
     setSigninPhase(null);
   };
@@ -260,30 +261,20 @@ export function AutomationQuickstart({
     await cloudLogin().catch(() => {});
     setSigninPhase("waiting");
     // Poll until the browser flow lands, then finish the pending connect (bounded).
-    let polls = 0;
-    const t = setInterval(async () => {
-      polls += 1;
-      const s = await getCloudStatus().catch(() => null);
-      if (s?.signed_in) {
-        clearInterval(t);
-        signinPollRef.current = null;
-        setSigninPhase(null);
-        setCloud(s);
-        if (pendingConn) {
-          const name = pendingConn;
-          setConnFlow({ name, phase: "opening" });
-          await connectManaged(name).catch(() => {});
-          setConnFlow((f) => (f?.name === name ? { name, phase: "waiting" } : f));
-          setPendingConn(null);
-          refresh();
-        }
-      } else if (polls > 90) {
-        clearInterval(t);
-        signinPollRef.current = null;
-        setSigninPhase(null);
+    signinPollRef.current = waitForCloudSignIn(async (s) => {
+      signinPollRef.current = null;
+      setSigninPhase(null);
+      if (!s?.signed_in) return;
+      setCloud(s);
+      if (pendingConn) {
+        const name = pendingConn;
+        setConnFlow({ name, phase: "opening" });
+        await connectManaged(name).catch(() => {});
+        setConnFlow((f) => (f?.name === name ? { name, phase: "waiting" } : f));
+        setPendingConn(null);
+        refresh();
       }
-    }, 2000);
-    signinPollRef.current = t;
+    });
   };
 
   const create = () => {

--- a/platform/surfaces/gui/src/components/Onboarding.tsx
+++ b/platform/surfaces/gui/src/components/Onboarding.tsx
@@ -62,13 +62,21 @@ export function Onboarding({ onDone }: { onDone: (next?: "work" | "gallery" | "a
 
   const info = providers.find((p) => p.name === prov);
 
+  // Unsaved per-provider input, kept across switches WITHIN this modal: typing an OpenAI key,
+  // peeking at Anthropic, and coming back used to silently blank the OpenAI field (owner
+  // complaint 2026-07-16 — "can't make out if OpenAI is already connected").
+  const [drafts, setDrafts] = useState<Record<string, Record<string, string>>>({});
+
   const pickProvider = (name: string, list?: ProviderInfo[]) => {
     const p = (list || providers).find((x) => x.name === name);
+    setDrafts((d) => ({ ...d, [prov]: fields }));
     setProv(name);
     setVerify({ state: "idle" });
     setShowEndpoint(false);
+    const draft = drafts[name];
     const next: Record<string, string> = {};
-    for (const f of p?.fields || []) next[f.key] = p?.values?.[f.key] || f.default || "";
+    for (const f of p?.fields || [])
+      next[f.key] = draft?.[f.key] || p?.values?.[f.key] || f.default || "";
     setFields(next);
   };
 
@@ -104,7 +112,9 @@ export function Onboarding({ onDone }: { onDone: (next?: "work" | "gallery" | "a
   // §30: narrate the sign-in — "opening" while the POST is in flight, "waiting" once the
   // browser is off (the 3 s poll below flips to the ✓ state when the flow lands).
   const [signinPhase, setSigninPhase] = useState<"opening" | "waiting" | null>(null);
-  // Poll while on the tools page: the browser sign-in flow lands out-of-band.
+  // Poll while on the tools page: the browser sign-in flow lands out-of-band. Tighten the
+  // interval while a sign-in is actually in flight — staring at "Waiting for sign-in…" for
+  // seconds after the browser finished read as "sign-in is slow" (owner, 2026-07-16).
   useEffect(() => {
     if (step !== 1) return;
     const load = () => {
@@ -112,9 +122,9 @@ export function Onboarding({ onDone }: { onDone: (next?: "work" | "gallery" | "a
       getCloudStatus().then(setCloud).catch(() => {});
     };
     load();
-    const t = setInterval(load, 3000);
+    const t = setInterval(load, signinPhase === "waiting" ? 750 : 3000);
     return () => clearInterval(t);
-  }, [step]);
+  }, [step, signinPhase]);
 
   // The logo row: the headline managed connectors, REAL brand icons (owner call 2026-07-12 —
   // the mock's letter badges were stand-ins).
@@ -176,6 +186,15 @@ export function Onboarding({ onDone }: { onDone: (next?: "work" | "gallery" | "a
                 })}
               onChange={(name) => pickProvider(name)}
             />
+            {/* Connected state, ON the form (owner complaint 2026-07-16): the stored key is
+                never echoed back, so without this line a connected provider's empty password
+                field read as "not set up". */}
+            {credentialed && (
+              <p className="text-[12px] text-ok mt-1.5" data-testid="ob-provider-connected">
+                ✓ Already connected — a key is saved for {info?.title}. Leave the field blank to
+                keep it.
+              </p>
+            )}
             {info?.blurb && <p className="text-[11.5px] text-faint mt-1">{info.blurb}</p>}
 
             {(info?.fields || []).map((f) => {
@@ -202,7 +221,9 @@ export function Onboarding({ onDone }: { onDone: (next?: "work" | "gallery" | "a
                   <input
                     className={input}
                     type={f.secret ? "password" : "text"}
-                    placeholder={f.placeholder}
+                    placeholder={
+                      f.secret && credentialed ? "••••••••  (key saved)" : f.placeholder
+                    }
                     value={fields[f.key] || ""}
                     data-testid={`ob-field-${f.key}`}
                     onChange={(e) => {
@@ -278,8 +299,15 @@ export function Onboarding({ onDone }: { onDone: (next?: "work" | "gallery" | "a
         )}
 
         {step === 1 && (
+          /* §29 amendment (owner design, 2026-07-16): the value IS the headline, ONE primary
+             action. The old page led with "Connect your tools" but offered no connecting —
+             only a sign-in button mid-page COMPETING with a Continue that did something else.
+             Now: headline names what sign-in buys, the security story is one titled card with
+             the manual path as its footnote, and the footer is the §29 pair everywhere else
+             in the flow: quiet "Skip for now" left, primary "Sign in" right (→ "Continue"
+             once signed in). */
           <section data-testid="ob-step-tools" className="flex-1 min-h-0 flex flex-col overflow-y-auto">
-            <h1 className="text-[19px] font-semibold">Connect your tools</h1>
+            <h1 className="text-[19px] font-semibold">Sign in for one-click connections</h1>
             <p className="text-[13px] text-muted mt-0.5 mb-5">
               OpenCoworker works with the apps you already use.
             </p>
@@ -293,18 +321,19 @@ export function Onboarding({ onDone }: { onDone: (next?: "work" | "gallery" | "a
 
             <div className="rounded-xl2 border border-line bg-paper px-4 py-3.5 text-[12.5px] text-muted">
               <span className="block text-[13px] text-ink font-medium mb-0.5">
-                One sign-in unlocks every one-click connection
+                Secure by design
               </span>
-              Connections are brokered by OpenCoworker Cloud — your tokens stay on this Mac.
-              Connect Slack, GitHub, HubSpot, Gmail and Calendar later with a single click each.
+              OpenCoworker Cloud brokers the OAuth handshake — your tokens never leave this
+              Mac. Connect Slack, GitHub, HubSpot, Gmail and Calendar later with one click
+              each.
+              {/* Sign-in is the one-click path, never the ONLY path (owner call 2026-07-12). */}
+              <span className="block text-[11.5px] text-faint mt-3 pt-3 border-t border-line">
+                Prefer manual setup? Every tool also works with your own API keys from the
+                Connectors page — signing in just makes it one click.
+              </span>
             </div>
-            {/* Sign-in is the one-click path, never the ONLY path (owner call 2026-07-12). */}
-            <p className="text-[11.5px] text-faint mt-2.5">
-              Prefer manual setup? Every tool can also be connected with your own API keys from
-              the Connectors page — signing in just makes it one click.
-            </p>
 
-            <div className="mt-4">
+            <div className="mt-4 min-h-[36px]">
               {cloud?.signed_in ? (
                 <span
                   className="inline-flex items-center gap-2 text-[13px] text-ok bg-okSoft/60 rounded-lg px-3 py-2"
@@ -329,19 +358,7 @@ export function Onboarding({ onDone }: { onDone: (next?: "work" | "gallery" | "a
                     </span>
                   )}
                 </span>
-              ) : (
-                <button
-                  className="px-4 py-2 rounded-full bg-accent text-white text-[13px]"
-                  onClick={async () => {
-                    setSigninPhase("opening");
-                    await cloudLogin().catch(() => {});
-                    setSigninPhase("waiting");
-                  }}
-                  data-testid="ob-cloud-signin"
-                >
-                  Sign in to OpenCoworker Cloud
-                </button>
-              )}
+              ) : null}
             </div>
 
             <div className="flex items-center gap-3 mt-auto pt-5">
@@ -350,15 +367,30 @@ export function Onboarding({ onDone }: { onDone: (next?: "work" | "gallery" | "a
                 onClick={() => setStep(2)}
                 data-testid="ob-tools-skip"
               >
-                Skip — you can sign in whenever you first connect something
+                Skip for now
               </button>
-              <button
-                className="ml-auto px-5 py-2 rounded-full bg-ink text-panel text-[13px] shrink-0"
-                onClick={() => setStep(2)}
-                data-testid="ob-continue-tools"
-              >
-                Continue
-              </button>
+              {cloud?.signed_in ? (
+                <button
+                  className="ml-auto px-5 py-2 rounded-full bg-ink text-panel text-[13px] shrink-0"
+                  onClick={() => setStep(2)}
+                  data-testid="ob-continue-tools"
+                >
+                  Continue
+                </button>
+              ) : (
+                <button
+                  className="ml-auto px-5 py-2 rounded-full bg-accent text-white text-[13px] shrink-0 disabled:opacity-40"
+                  disabled={signinPhase === "opening"}
+                  onClick={async () => {
+                    setSigninPhase("opening");
+                    await cloudLogin().catch(() => {});
+                    setSigninPhase("waiting");
+                  }}
+                  data-testid="ob-cloud-signin"
+                >
+                  Sign in
+                </button>
+              )}
             </div>
           </section>
         )}

--- a/platform/surfaces/gui/src/components/Sidebar.tsx
+++ b/platform/surfaces/gui/src/components/Sidebar.tsx
@@ -10,6 +10,7 @@ import {
   INBOX_UNLOCK,
   PERSONAS_CHANGED,
   setNavLayout,
+  waitForCloudSignIn,
   type CloudStatus,
   type Persona,
   type RecentWorkspace,
@@ -1023,20 +1024,14 @@ export function Sidebar(props: Props) {
                       onClick={async () => {
                         setAppMenuOpen(false);
                         // Opens the system browser server-side; completion lands out-of-band,
-                        // so poll briefly (refocusing the window also refetches).
+                        // so poll until it flips (refocusing the window also refetches).
                         await cloudLogin().catch(() => {});
-                        let polls = 0;
-                        const t = setInterval(async () => {
-                          polls += 1;
-                          const s = await getCloudStatus().catch(() => null);
-                          if (s?.signed_in || polls > 60) {
-                            clearInterval(t);
-                            if (s) setCloud(s);
-                            // Other always-mounted consumers (Settings' telemetry card,
-                            // connector panes) refetch on this.
-                            if (s?.signed_in) announceCloudChanged();
-                          }
-                        }, 2000);
+                        waitForCloudSignIn((s) => {
+                          if (s) setCloud(s);
+                          // Other always-mounted consumers (Settings' telemetry card,
+                          // connector panes) refetch on this.
+                          if (s?.signed_in) announceCloudChanged();
+                        });
                       }}
                     >
                       <Icon name="plug" size={15} className="shrink-0" /> Sign in to OpenCoworker

--- a/platform/surfaces/gui/src/main.tsx
+++ b/platform/surfaces/gui/src/main.tsx
@@ -7,6 +7,13 @@ import "./styles.css";
 
 initTheme();
 
+// A file dropped OUTSIDE a drop target (the composer) must never navigate the webview to the
+// file itself — the browser/WKWebView default. Drop targets stopPropagation-free preventDefault
+// in their own handlers; these guards only catch the misses. (The desktop shell disables Tauri's
+// native drag-drop interception so HTML5 drag events reach the DOM at all — see lib.rs.)
+window.addEventListener("dragover", (e) => e.preventDefault());
+window.addEventListener("drop", (e) => e.preventDefault());
+
 ReactDOM.createRoot(document.getElementById("root")!).render(
   <React.StrictMode>
     <App />

--- a/platform/surfaces/gui/src/styles.css
+++ b/platform/surfaces/gui/src/styles.css
@@ -992,7 +992,11 @@ button.btn.sm.danger-btn:hover { border-color: var(--danger); }
   top: 0;
   left: 0;
   right: 0;
-  height: 36px;
+  /* Center the wordmark on the traffic lights' midline: the lights sit at (19,24) with 12px
+     buttons (lib.rs traffic_light_position), so their center is y=30 — 12px padding + 36px
+     content box puts our center there too. */
+  height: 48px;
+  padding-top: 12px;
   z-index: 180;
   background: transparent;
   display: flex;

--- a/platform/tests/test_cloud.py
+++ b/platform/tests/test_cloud.py
@@ -92,11 +92,10 @@ def test_complete_login_stores_tokens_and_account(secrets, config, monkeypatch):
         )
 
     def fake_get(url, **kwargs):
-        if url == "https://cloud.test/v1/me":
-            return FakeResponse(200, {"user": {"email": "a@b.c", "user_id": "usr_1"}})
-        # complete_login also syncs connection state (restore-on-sign-in).
-        assert url == "https://cloud.test/v1/connections"
-        return FakeResponse(200, {"connections": []})
+        # Connection restore is NOT part of complete_login (it runs in the
+        # background from the /auth/callback route) — only /v1/me is hit here.
+        assert url == "https://cloud.test/v1/me"
+        return FakeResponse(200, {"user": {"email": "a@b.c", "user_id": "usr_1"}})
 
     monkeypatch.setattr(cloud.httpx, "post", fake_post)
     monkeypatch.setattr(cloud.httpx, "get", fake_get)
@@ -104,7 +103,6 @@ def test_complete_login_stores_tokens_and_account(secrets, config, monkeypatch):
     result = cloud.complete_login(secrets, config, "code1", state)
     assert result["ok"] and result["signed_in"]
     assert result["account"] == "a@b.c"
-    assert result["restored_github_installs"] == []
     profile = secrets.get(cloud.CLOUD_AUTH_PROFILE)
     assert profile["access_token"] == "at1"
     assert profile["refresh_token"] == "rt1"


### PR DESCRIPTION
Sidecar ships as a onedir bundle (boot splash ~7s → <1s warm), cloud sign-in stops blocking on connection restore and the GUI polls faster, onboarding keeps unsaved keys and shows connected state (page 2 rebuilt to the new design), and OS file drags now reach the composer in the desktop shell. Includes minimumSystemVersion 12.0 (main did not build without it).