### PR TITLE
OCW App: auto-update

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -96,6 +96,10 @@ jobs:
           APPLE_API_KEY_CONTENT: ${{ secrets.APPLE_API_KEY_CONTENT }}
           APPLE_API_KEY: ${{ secrets.APPLE_API_KEY }}
           APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
+          # Auto-update artifact signing (minisign, separate from Apple signing). Absent →
+          # the build script skips updater artifacts with a warning (fork/scratch runs).
+          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
         run: |
           # Unset empty APPLE_* vars so runs without secrets stay cleanly unsigned
           # (Tauri treats a present-but-empty var as a config error).
@@ -112,6 +116,9 @@ jobs:
       - name: Build .msi + NSIS .exe (Windows)
         if: runner.os == 'Windows'
         shell: pwsh
+        env:
+          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
         run: ./platform/packaging/build_windows.ps1
 
       - name: Stage artifacts (versioned + stable names)
@@ -123,9 +130,18 @@ jobs:
             cp "$BUNDLE"/nsis/*.exe out/OpenCoworker-windows-setup.exe
             cp "$BUNDLE"/msi/*.msi out/
             cp "$BUNDLE"/msi/*.msi out/OpenCoworker-windows.msi
+            # Updater signature for the NSIS installer (present only when the updater key
+            # secret is configured). The .sig signs CONTENT, so the stable rename is safe.
+            SIG=$(ls "$BUNDLE"/nsis/*.exe.sig 2>/dev/null | head -1 || true)
+            [ -n "$SIG" ] && cp "$SIG" out/OpenCoworker-windows-setup.exe.sig
           else
             cp "$BUNDLE"/dmg/*.dmg out/
             cp "$BUNDLE"/dmg/*.dmg out/OpenCoworker-${{ matrix.slug }}.dmg
+            # macOS updater artifact: the signed .app tarball the installed app swaps in.
+            if [ -f "$BUNDLE"/macos/OpenCoworker.app.tar.gz ]; then
+              cp "$BUNDLE"/macos/OpenCoworker.app.tar.gz out/OpenCoworker-${{ matrix.slug }}.app.tar.gz
+              cp "$BUNDLE"/macos/OpenCoworker.app.tar.gz.sig out/OpenCoworker-${{ matrix.slug }}.app.tar.gz.sig
+            fi
           fi
           ls -la out
 
@@ -142,10 +158,34 @@ jobs:
     permissions:
       contents: write
     steps:
+      - uses: actions/checkout@v4
+
       - uses: actions/download-artifact@v4
         with:
           path: dist
           merge-multiple: true
+
+      - name: Compose the auto-update manifest (latest.json)
+        # Shipped apps poll releases/latest/download/latest.json (via the branded
+        # download.opencoworker.app redirect) — publishing this release IS pushing the
+        # update. The tag must match tauri.conf.json's version or installed apps would
+        # see a permanent phantom update; fail loudly on drift. Runs only when signed
+        # updater artifacts exist (i.e. the TAURI_SIGNING_PRIVATE_KEY secret is set).
+        run: |
+          TAG="${GITHUB_REF_NAME}"
+          CONF_VERSION=$(python3 -c "import json; print(json.load(open('platform/surfaces/gui/src-tauri/tauri.conf.json'))['version'])")
+          if [ "${TAG#v}" != "$CONF_VERSION" ]; then
+            echo "::error::tag $TAG != tauri.conf.json version $CONF_VERSION — bump the config before tagging"
+            exit 1
+          fi
+          if ls dist/*.sig >/dev/null 2>&1; then
+            python3 platform/packaging/make_update_manifest.py \
+              --version "${TAG#v}" --tag "$TAG" --repo "$GITHUB_REPOSITORY" \
+              --dist dist --out dist/latest.json \
+              --notes "OpenCoworker ${TAG#v}"
+          else
+            echo "::warning::no updater signatures in dist/ — release ships WITHOUT auto-update manifest"
+          fi
 
       - uses: softprops/action-gh-release@v2
         with:

--- a/platform/packaging/build_dmg.sh
+++ b/platform/packaging/build_dmg.sh
@@ -58,7 +58,28 @@ echo "==> [2/5] staging sidecar resources"
 # stale onefile binary from pre-onedir builds.
 mkdir -p "$GUI/src-tauri/binaries"
 rm -rf "$GUI/src-tauri/binaries/sidecar" "$GUI/src-tauri/binaries/coworker-server-$TRIPLE"
-cp -R "$HERE/dist/coworker-server" "$GUI/src-tauri/binaries/sidecar"
+# -L (dereference): Tauri's resource bundler flattens symlinks into duplicate REAL files.
+# Python.framework's symlinks (Python -> Versions/Current/Python, …) therefore arrive in
+# the .app as standalone copies whose framework-context signatures don't validate outside
+# the bundle — notarization rejected them twice (submissions f73463f3, ca30027a,
+# 2026-07-16). Dereferencing at staging makes what we SIGN byte-identical to what tauri
+# COPIES, and every Mach-O below gets a plain file signature that stands alone.
+cp -RL "$HERE/dist/coworker-server" "$GUI/src-tauri/binaries/sidecar"
+if [ -n "$(find "$GUI/src-tauri/binaries/sidecar" -type l | head -1)" ]; then
+  echo "ERROR: symlinks survived sidecar staging — tauri would flatten them into unsigned copies" >&2
+  exit 1
+fi
+# Drop the pseudo-framework: after dereferencing, Python.framework is just a duplicate of
+# _internal/Python (which the PyInstaller bootloader actually loads — verified by running
+# the sidecar without it) plus an Info.plist. Any file living under a *.framework/ path
+# triggers codesign/notary bundle inference, which can NEVER validate this flattened
+# layout — three Invalid notarization verdicts (f73463f3, ca30027a, + one more) before
+# this removal. No .framework may ever ship inside the sidecar resources.
+rm -rf "$GUI/src-tauri/binaries/sidecar/_internal/Python.framework"
+if [ -n "$(find "$GUI/src-tauri/binaries/sidecar" -type d -name "*.framework" | head -1)" ]; then
+  echo "ERROR: a .framework appeared in the sidecar — it cannot pass notarization in this layout" >&2
+  exit 1
+fi
 chmod +x "$GUI/src-tauri/binaries/sidecar/coworker-server"
 
 # Sign the sidecar's Mach-O files BEFORE tauri build: `tauri build` signs the .app (sealing
@@ -68,17 +89,39 @@ chmod +x "$GUI/src-tauri/binaries/sidecar/coworker-server"
 # other Team IDs). externalBin used to get this from tauri itself.
 if [ -n "${APPLE_SIGNING_IDENTITY:-}" ]; then
   echo "    signing sidecar binaries"
-  find "$GUI/src-tauri/binaries/sidecar" -type f \
+  SIDECAR="$GUI/src-tauri/binaries/sidecar"
+  # Every Mach-O gets a plain FILE signature (no framework-bundle signing: the staged
+  # tree is fully dereferenced, so each file must validate standalone — that is exactly
+  # what the notary service checks). Entitlements only on the entrypoint
+  # (disable-library-validation: the bundled python.org dylibs carry another Team ID).
+  find "$SIDECAR" -type f ! -name "coworker-server" \
     ! -name "*.py" ! -name "*.pyc" ! -name "*.txt" ! -name "*.pem" ! -name "*.json" \
     -print0 | while IFS= read -r -d '' f; do
     file -b "$f" | grep -q "Mach-O" || continue
-    codesign --force --sign "$APPLE_SIGNING_IDENTITY" --timestamp --options runtime \
-      --entitlements "$GUI/src-tauri/entitlements.plist" "$f"
+    codesign --force --sign "$APPLE_SIGNING_IDENTITY" --timestamp --options runtime "$f"
   done
+  codesign --force --sign "$APPLE_SIGNING_IDENTITY" --timestamp --options runtime \
+    --entitlements "$GUI/src-tauri/entitlements.plist" "$SIDECAR/coworker-server"
 fi
 
 echo "==> [3/5] tauri build (.app)"
-( cd "$GUI" && npm run tauri build -- --bundles app )
+# Auto-update artifacts (.app.tar.gz + minisign .sig): produced only when the updater
+# signing key is available — from the env (CI secret TAURI_SIGNING_PRIVATE_KEY), or from
+# `.ocw-updater.env` one directory above the repo (same convention as the notary env).
+# Keyless builds skip the overlay entirely so dev/fork builds keep working; keyless
+# RELEASES would strand every install without auto-update, hence the loud warning.
+UPDATER_ENV="${OCW_UPDATER_ENV:-$PLATFORM/../../.ocw-updater.env}"
+if [ -z "${TAURI_SIGNING_PRIVATE_KEY:-}" ] && [ -f "$UPDATER_ENV" ]; then
+  # shellcheck disable=SC1090
+  source "$UPDATER_ENV"
+fi
+UPDATER_OVERLAY=()
+if [ -n "${TAURI_SIGNING_PRIVATE_KEY:-}" ]; then
+  UPDATER_OVERLAY=(--config '{"bundle":{"createUpdaterArtifacts":true}}')
+else
+  echo "    WARNING: no updater signing key — building WITHOUT auto-update artifacts (not releasable)."
+fi
+( cd "$GUI" && npm run tauri build -- --bundles app "${UPDATER_OVERLAY[@]}" )
 
 echo "==> [4/5] hdiutil: wrapping into .dmg"
 BUNDLE="$GUI/src-tauri/target/release/bundle"

--- a/platform/packaging/build_windows.ps1
+++ b/platform/packaging/build_windows.ps1
@@ -82,9 +82,19 @@ Copy-Item -Recurse -Force $Src $Dst
 Write-Host "    -> $Dst"
 
 Write-Host "==> [3/3] tauri build (--bundles $Bundles)" -ForegroundColor Cyan
+# Auto-update artifacts (NSIS setup .exe + minisign .sig): produced only when the updater
+# signing key env is present (CI secret TAURI_SIGNING_PRIVATE_KEY). Keyless builds skip
+# the overlay so dev builds keep working; keyless RELEASES strand installs without
+# auto-update.
+$UpdaterArgs = @()
+if ($env:TAURI_SIGNING_PRIVATE_KEY) {
+    $UpdaterArgs = @("--config", '{"bundle":{"createUpdaterArtifacts":true}}')
+} else {
+    Write-Host "    WARNING: no updater signing key - building WITHOUT auto-update artifacts (not releasable)." -ForegroundColor Yellow
+}
 Push-Location $Gui
 try {
-    & npm run tauri build -- --bundles $Bundles
+    & npm run tauri build -- --bundles $Bundles @UpdaterArgs
     if ($LASTEXITCODE -ne 0) { throw "tauri build failed (exit $LASTEXITCODE)" }
 }
 finally {

--- a/platform/packaging/make_update_manifest.py
+++ b/platform/packaging/make_update_manifest.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+"""Compose the Tauri updater manifest (latest.json) from staged release artifacts.
+
+Run by the release CI job after all platform builds are staged in one directory:
+
+    python3 make_update_manifest.py --version 0.1.2 --tag v0.1.2 \
+        --repo andrewyng/aisuite --dist dist/ --out dist/latest.json
+
+Looks for the updater artifacts by their STABLE names (the same names release.yml
+uploads):
+
+    OpenCoworker-macos-arm64.app.tar.gz(.sig)   -> platforms["darwin-aarch64"]
+    OpenCoworker-windows-setup.exe(.sig)        -> platforms["windows-x86_64"]
+
+URLs point at the TAG-pinned GitHub download path (releases/download/<tag>/<asset>),
+never at `latest/` — a manifest must reference exactly the artifacts it shipped with,
+or a half-published release would mix versions. Platforms whose artifact or .sig is
+missing are SKIPPED with a warning (e.g. a mac-only hotfix release), so shipped apps
+on other platforms simply see no update rather than a broken one.
+
+The desktop app finds this file through https://download.opencoworker.app/latest.json
+(branded redirect) falling back to the repo's releases/latest/download/latest.json —
+see tauri.conf.json `plugins.updater.endpoints`.
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime
+import json
+import pathlib
+import sys
+
+# stable asset name -> Tauri platform key
+ARTIFACTS = {
+    "OpenCoworker-macos-arm64.app.tar.gz": "darwin-aarch64",
+    "OpenCoworker-windows-setup.exe": "windows-x86_64",
+}
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--version", required=True, help="bare version, e.g. 0.1.2")
+    ap.add_argument(
+        "--tag", required=True, help="git tag the assets live under, e.g. v0.1.2"
+    )
+    ap.add_argument("--repo", required=True, help="owner/name, e.g. andrewyng/aisuite")
+    ap.add_argument(
+        "--dist", required=True, type=pathlib.Path, help="staged artifacts dir"
+    )
+    ap.add_argument("--out", required=True, type=pathlib.Path)
+    ap.add_argument(
+        "--notes", default="", help="release notes line shown in the update prompt"
+    )
+    args = ap.parse_args()
+
+    platforms: dict[str, dict[str, str]] = {}
+    for asset, platform in ARTIFACTS.items():
+        artifact = args.dist / asset
+        sig = args.dist / (asset + ".sig")
+        if not artifact.exists():
+            print(
+                f"warning: {asset} not in {args.dist} — skipping {platform}",
+                file=sys.stderr,
+            )
+            continue
+        if not sig.exists():
+            print(
+                f"warning: {asset} has no .sig — skipping {platform} (unsigned updates never install)",
+                file=sys.stderr,
+            )
+            continue
+        platforms[platform] = {
+            "signature": sig.read_text().strip(),
+            "url": f"https://github.com/{args.repo}/releases/download/{args.tag}/{asset}",
+        }
+
+    if not platforms:
+        print(
+            "error: no signed updater artifacts found — refusing to write an empty manifest",
+            file=sys.stderr,
+        )
+        return 1
+
+    manifest = {
+        "version": args.version,
+        "notes": args.notes,
+        "pub_date": datetime.datetime.now(datetime.timezone.utc)
+        .isoformat(timespec="seconds")
+        .replace("+00:00", "Z"),
+        "platforms": platforms,
+    }
+    args.out.write_text(json.dumps(manifest, indent=2) + "\n")
+    print(f"wrote {args.out} ({', '.join(sorted(platforms))})")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/platform/stt/src/lib.rs
+++ b/platform/stt/src/lib.rs
@@ -67,6 +67,9 @@ pub struct Dictation {
     ready_marker_path: PathBuf,
     commands: Sender<Command>,
     recording: Arc<Mutex<bool>>,
+    // Live handle onto the in-flight recording's sample buffer (set by the capture worker
+    // for the duration of a session) so hosts can meter input loudness for UI feedback.
+    live: Arc<Mutex<Option<(Arc<Mutex<Vec<f32>>>, u32)>>>,
     download_in_progress: AtomicBool,
     cancel_download: AtomicBool,
 }
@@ -88,8 +91,10 @@ impl Dictation {
         // rather than unsafely forcing it through Tauri's Send + Sync application state.
         let (commands, receiver) = mpsc::channel();
         let recording = Arc::new(Mutex::new(false));
+        let live = Arc::new(Mutex::new(None));
         let worker_recording = recording.clone();
-        thread::spawn(move || capture_worker(receiver, worker_recording));
+        let worker_live = live.clone();
+        thread::spawn(move || capture_worker(receiver, worker_recording, worker_live));
         let model_path = model_dir.into().join(DEFAULT_MODEL_FILE);
         Self {
             verified_marker_path: model_path.with_extension("bin.verified"),
@@ -97,6 +102,7 @@ impl Dictation {
             model_path,
             commands,
             recording,
+            live,
             download_in_progress: AtomicBool::new(false),
             cancel_download: AtomicBool::new(false),
         }
@@ -296,6 +302,29 @@ impl Dictation {
         transcribe(&self.model_path, &resample_mono(&samples, sample_rate))
     }
 
+    /// Instantaneous input loudness of the in-flight recording, 0.0..=1.0 — RMS over the
+    /// most recent ~100ms, scaled so conversational speech spans most of the range. 0.0
+    /// while not recording. Cheap enough to poll at UI frame-ish rates.
+    pub fn input_level(&self) -> f32 {
+        let live = match self.live.lock() {
+            Ok(guard) => guard,
+            Err(_) => return 0.0,
+        };
+        let Some((samples, sample_rate)) = live.as_ref() else {
+            return 0.0;
+        };
+        let Ok(samples) = samples.lock() else {
+            return 0.0;
+        };
+        let window = (*sample_rate as usize / 10).max(1);
+        let tail = &samples[samples.len().saturating_sub(window)..];
+        if tail.is_empty() {
+            return 0.0;
+        }
+        let mean_square: f32 = tail.iter().map(|s| s * s).sum::<f32>() / tail.len() as f32;
+        (mean_square.sqrt() * 8.0).clamp(0.0, 1.0)
+    }
+
     /// Discards the current in-memory recording without retaining or transcribing it.
     pub fn cancel(&self) {
         let (reply, done) = mpsc::channel();
@@ -371,8 +400,17 @@ fn model_verification_marker_matches(model_path: &Path, marker_path: &Path) -> b
     hash_matches && marker_modified == model_modified_millis(model_path)
 }
 
-fn capture_worker(receiver: Receiver<Command>, recording_status: Arc<Mutex<bool>>) {
+fn capture_worker(
+    receiver: Receiver<Command>,
+    recording_status: Arc<Mutex<bool>>,
+    live: Arc<Mutex<Option<(Arc<Mutex<Vec<f32>>>, u32)>>>,
+) {
     let mut recording: Option<Recording> = None;
+    let set_live = |value: Option<(Arc<Mutex<Vec<f32>>>, u32)>| {
+        if let Ok(mut guard) = live.lock() {
+            *guard = value;
+        }
+    };
     for command in receiver {
         match command {
             Command::Start(reply) => {
@@ -382,6 +420,7 @@ fn capture_worker(receiver: Receiver<Command>, recording_status: Arc<Mutex<bool>
                 }
                 match start_recording() {
                     Ok(next) => {
+                        set_live(Some((next.samples.clone(), next.sample_rate)));
                         recording = Some(next);
                         if let Ok(mut active) = recording_status.lock() {
                             *active = true;
@@ -394,6 +433,7 @@ fn capture_worker(receiver: Receiver<Command>, recording_status: Arc<Mutex<bool>
                 }
             }
             Command::Stop(reply) => {
+                set_live(None);
                 let result = recording
                     .take()
                     .ok_or_else(|| "Dictation is not recording.".to_owned())
@@ -404,6 +444,7 @@ fn capture_worker(receiver: Receiver<Command>, recording_status: Arc<Mutex<bool>
                 let _ = reply.send(result);
             }
             Command::Cancel(reply) => {
+                set_live(None);
                 recording.take();
                 if let Ok(mut active) = recording_status.lock() {
                     *active = false;

--- a/platform/surfaces/gui/e2e/onboarding.spec.ts
+++ b/platform/surfaces/gui/e2e/onboarding.spec.ts
@@ -20,9 +20,10 @@ test("model step: configured provider fast-path; Continue verifies automatically
   await openOnboarding(page);
 
   // The configured provider (OpenAI in fixtures) is auto-picked: no re-typing a key. The
-  // success state lives ON the Test button (no separate status line), and OpenAI's optional
-  // endpoint hides behind the disclosure link even though it has no vendor default.
-  await expect(page.getByTestId("ob-test")).toHaveText("✓ Connected");
+  // Test affordance lives IN the key field (owner call, DMG #28) and reads ✓ when a key is
+  // already saved; OpenAI's optional endpoint hides behind the disclosure link even though
+  // it has no vendor default.
+  await expect(page.getByTestId("ob-test")).toHaveText("✓");
   await expect(page.getByTestId("ob-field-base_url")).toHaveCount(0);
   await expect(page.getByTestId("ob-continue")).toBeEnabled();
 
@@ -46,8 +47,11 @@ test("model step: configured provider fast-path; Continue verifies automatically
   await expect(page.getByTestId("ob-step-model")).toBeVisible();
   await expect(page.getByTestId("ob-continue")).toBeEnabled();
 
-  // A good key: one click verifies and advances — no manual Test required.
+  // A good key: the in-field Test flips to a tick, and Continue advances (it verifies
+  // by itself too — Test stays optional).
   await page.getByTestId("ob-field-api_key").fill("zk-good");
+  await page.getByTestId("ob-test").click();
+  await expect(page.getByTestId("ob-test")).toHaveText("✓");
   await page.getByTestId("ob-continue").click();
   await expect(page.getByTestId("ob-step-tools")).toBeVisible();
 });

--- a/platform/surfaces/gui/src-tauri/Cargo.lock
+++ b/platform/surfaces/gui/src-tauri/Cargo.lock
@@ -70,6 +70,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
+dependencies = [
+ "derive_arbitrary",
+]
+
+[[package]]
 name = "async-broadcast"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -650,6 +659,7 @@ dependencies = [
  "tauri-plugin-autostart",
  "tauri-plugin-dialog",
  "tauri-plugin-single-instance",
+ "tauri-plugin-updater",
 ]
 
 [[package]]
@@ -662,7 +672,7 @@ dependencies = [
  "core-foundation-sys",
  "coreaudio-rs",
  "dasp_sample",
- "jni",
+ "jni 0.21.1",
  "js-sys",
  "libc",
  "mach2",
@@ -816,6 +826,17 @@ checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 dependencies = [
  "powerfmt",
  "serde_core",
+]
+
+[[package]]
+name = "derive_arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1126,6 +1147,16 @@ checksum = "38e2275cc4e4fc009b0669731a1e5ab7ebf11f469eaede2bab9309a5b4d6057f"
 dependencies = [
  "memoffset",
  "rustc_version",
+]
+
+[[package]]
+name = "filetime"
+version = "0.2.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c287a33c7f0a620c38e641e7f60827713987b3c0f26e8ddc9462cc69cf75759"
+dependencies = [
+ "cfg-if",
+ "libc",
 ]
 
 [[package]]
@@ -1696,6 +1727,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper-rustls"
+version = "0.27.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
+dependencies = [
+ "http",
+ "hyper",
+ "hyper-util",
+ "rustls",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
+]
+
+[[package]]
 name = "hyper-util"
 version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1960,6 +2006,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "jni"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
+dependencies = [
+ "cfg-if",
+ "combine",
+ "jni-macros",
+ "jni-sys 0.4.1",
+ "log",
+ "simd_cesu8",
+ "thiserror 2.0.18",
+ "walkdir",
+ "windows-link 0.2.1",
+]
+
+[[package]]
+name = "jni-macros"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "simd_cesu8",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "jni-sys"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2189,6 +2265,12 @@ name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
+name = "minisign-verify"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22f9645cb765ea72b8111f36c522475d2daa0d22c957a9826437e97534bc4e9e"
 
 [[package]]
 name = "miniz_oxide"
@@ -2489,6 +2571,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2-osa-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f112d1746737b0da274ef79a23aac283376f335f4095a083a267a082f21db0c0"
+dependencies = [
+ "bitflags 2.13.0",
+ "objc2",
+ "objc2-app-kit",
+ "objc2-foundation",
+]
+
+[[package]]
 name = "objc2-quartz-core"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2551,7 +2645,7 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8b61bebd49e5d43f5f8cc7ee2891c16e0f41ec7954d36bcb6c14c5e0de867fb"
 dependencies = [
- "jni",
+ "jni 0.21.1",
  "ndk 0.8.0",
  "ndk-context",
  "num-derive",
@@ -2586,6 +2680,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
+name = "openssl-probe"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+
+[[package]]
 name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2599,6 +2699,20 @@ checksum = "9aa2b01e1d916879f73a53d01d1d6cee68adbb31d6d9177a8cfce093cced1d50"
 dependencies = [
  "futures-core",
  "pin-project-lite",
+]
+
+[[package]]
+name = "osakit"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "732c71caeaa72c065bb69d7ea08717bd3f4863a4f451402fc9513e29dbd5261b"
+dependencies = [
+ "objc2",
+ "objc2-foundation",
+ "objc2-osa-kit",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -3013,15 +3127,20 @@ dependencies = [
  "http-body",
  "http-body-util",
  "hyper",
+ "hyper-rustls",
  "hyper-util",
  "js-sys",
  "log",
  "percent-encoding",
  "pin-project-lite",
+ "rustls",
+ "rustls-pki-types",
+ "rustls-platform-verifier",
  "serde",
  "serde_json",
  "sync_wrapper",
  "tokio",
+ "tokio-rustls",
  "tokio-util",
  "tower",
  "tower-http",
@@ -3115,6 +3234,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls-native-certs"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dab5152771c58876a2146916e53e35057e1a4dfa2b9df0f0305b07f611fdea4d"
+dependencies = [
+ "openssl-probe",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework",
+]
+
+[[package]]
 name = "rustls-pki-types"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3122,6 +3253,33 @@ checksum = "764899a24af3980067ee14bc143654f297b22eaebfe3c7b6b211920a5a59b046"
 dependencies = [
  "zeroize",
 ]
+
+[[package]]
+name = "rustls-platform-verifier"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d1e2536ce4f35f4846aa13bff16bd0ff40157cdb14cc056c7b14ba41233ba0"
+dependencies = [
+ "core-foundation",
+ "core-foundation-sys",
+ "jni 0.22.4",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-platform-verifier-android",
+ "rustls-webpki",
+ "security-framework",
+ "security-framework-sys",
+ "webpki-root-certs",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls-platform-verifier-android"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
@@ -3147,6 +3305,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "schannel"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
+dependencies = [
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3205,6 +3372,29 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "security-framework"
+version = "3.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
+dependencies = [
+ "bitflags 2.13.0",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
 
 [[package]]
 name = "selectors"
@@ -3433,6 +3623,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
+name = "simd_cesu8"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11031e251abf8611c80f460e19dbdeb54a66db918e49c65a7065b46ac7aec520"
+dependencies = [
+ "rustc_version",
+ "simdutf8",
+]
+
+[[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
+
+[[package]]
 name = "siphasher"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3633,7 +3839,7 @@ dependencies = [
  "gdkwayland-sys",
  "gdkx11-sys",
  "gtk",
- "jni",
+ "jni 0.21.1",
  "libc",
  "log",
  "ndk 0.9.0",
@@ -3667,6 +3873,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tar"
+version = "0.4.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f6221d9a6003c78398e3b239969f352578258df48c8eb051caadae0015bc840"
+dependencies = [
+ "filetime",
+ "libc",
+ "xattr",
+]
+
+[[package]]
 name = "target-lexicon"
 version = "0.12.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3689,7 +3906,7 @@ dependencies = [
  "gtk",
  "heck 0.5.0",
  "http",
- "jni",
+ "jni 0.21.1",
  "libc",
  "log",
  "mime",
@@ -3873,6 +4090,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "tauri-plugin-updater"
+version = "2.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "806d9dac662c2e4594ff03c647a552f2c9bd544e7d0f683ec58f872f952ce4af"
+dependencies = [
+ "base64 0.22.1",
+ "dirs 6.0.0",
+ "flate2",
+ "futures-util",
+ "http",
+ "infer",
+ "log",
+ "minisign-verify",
+ "osakit",
+ "percent-encoding",
+ "reqwest",
+ "rustls",
+ "semver",
+ "serde",
+ "serde_json",
+ "tar",
+ "tauri",
+ "tauri-plugin",
+ "tempfile",
+ "thiserror 2.0.18",
+ "time",
+ "tokio",
+ "url",
+ "windows-sys 0.60.2",
+ "zip",
+]
+
+[[package]]
 name = "tauri-runtime"
 version = "2.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3882,7 +4132,7 @@ dependencies = [
  "dpi",
  "gtk",
  "http",
- "jni",
+ "jni 0.21.1",
  "objc2",
  "objc2-ui-kit",
  "objc2-web-kit",
@@ -3905,7 +4155,7 @@ checksum = "b83849ee63ecb27a8e8d0fe51915ca215076914aca43f96db1179f0f415f6cd9"
 dependencies = [
  "gtk",
  "http",
- "jni",
+ "jni 0.21.1",
  "log",
  "objc2",
  "objc2-app-kit",
@@ -4103,6 +4353,16 @@ dependencies = [
  "pin-project-lite",
  "socket2",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
+dependencies = [
+ "rustls",
+ "tokio",
 ]
 
 [[package]]
@@ -4736,6 +4996,15 @@ dependencies = [
  "pkg-config",
  "soup3-sys",
  "system-deps",
+]
+
+[[package]]
+name = "webpki-root-certs"
+version = "1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d46a5a140e6f7afeccd8eae97eff335163939eac8b929834875168b29b3d267"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]
@@ -5438,7 +5707,7 @@ dependencies = [
  "gtk",
  "http",
  "javascriptcore-rs",
- "jni",
+ "jni 0.21.1",
  "libc",
  "ndk 0.9.0",
  "objc2",
@@ -5483,6 +5752,16 @@ dependencies = [
  "libc",
  "once_cell",
  "pkg-config",
+]
+
+[[package]]
+name = "xattr"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
+dependencies = [
+ "libc",
+ "rustix",
 ]
 
 [[package]]
@@ -5627,6 +5906,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "zip"
+version = "4.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caa8cd6af31c3b31c6631b8f483848b91589021b28fffe50adada48d4f4d2ed1"
+dependencies = [
+ "arbitrary",
+ "crc32fast",
+ "indexmap 2.14.0",
+ "memchr",
 ]
 
 [[package]]

--- a/platform/surfaces/gui/src-tauri/Cargo.toml
+++ b/platform/surfaces/gui/src-tauri/Cargo.toml
@@ -17,6 +17,7 @@ tauri = { version = "2", features = ["tray-icon"] }
 tauri-plugin-dialog = "2"
 tauri-plugin-autostart = "2"
 tauri-plugin-single-instance = "2"
+tauri-plugin-updater = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 # Kept outside the Tauri shell so another product can depend on the same local STT engine.

--- a/platform/surfaces/gui/src-tauri/src/lib.rs
+++ b/platform/surfaces/gui/src-tauri/src/lib.rs
@@ -461,12 +461,60 @@ fn delete_dictation_model(state: tauri::State<Arc<Dictation>>) -> Result<VoiceIn
     Ok(voice_input_status(&state))
 }
 
+/// Instantaneous mic loudness (0..1) while a dictation is recording — the composer polls
+/// this to draw a real input-driven waveform instead of decorative bars (owner catch,
+/// DMG #28 walkthrough).
+#[tauri::command]
+fn dictation_level(state: tauri::State<Arc<Dictation>>) -> f32 {
+    state.input_level()
+}
+
 fn show_main(app: &tauri::AppHandle) {
     if let Some(w) = app.get_webview_window("main") {
         let _ = w.unminimize();
         let _ = w.show();
         let _ = w.set_focus();
     }
+}
+
+// --- Auto-update (tauri-plugin-updater) -------------------------------------------
+// The GUI drives updates through these two commands (same invoke bridge as everything
+// else — no global plugin JS). Update artifacts are minisign-verified against the
+// pubkey in tauri.conf.json before anything is installed; the manifest lives at the
+// endpoints configured there (download.opencoworker.app → GitHub Releases).
+
+#[derive(serde::Serialize)]
+struct UpdateInfo {
+    version: String,
+    notes: String,
+}
+
+#[tauri::command]
+async fn check_for_update(app: tauri::AppHandle) -> Result<Option<UpdateInfo>, String> {
+    use tauri_plugin_updater::UpdaterExt;
+    let updater = app.updater().map_err(|e| e.to_string())?;
+    let update = updater.check().await.map_err(|e| e.to_string())?;
+    Ok(update.map(|u| UpdateInfo {
+        version: u.version.clone(),
+        notes: u.body.clone().unwrap_or_default(),
+    }))
+}
+
+#[tauri::command]
+async fn install_update(app: tauri::AppHandle) -> Result<(), String> {
+    use tauri_plugin_updater::UpdaterExt;
+    let updater = app.updater().map_err(|e| e.to_string())?;
+    let Some(update) = updater.check().await.map_err(|e| e.to_string())? else {
+        return Err("no update available".into());
+    };
+    update
+        .download_and_install(|_, _| {}, || {})
+        .await
+        .map_err(|e| e.to_string())?;
+    // Windows never reaches here (the NSIS installer takes over and relaunches).
+    // macOS: the .app was swapped in place — restart into the new version. The tray
+    // Exit path's sidecar kill runs via RunEvent, so no orphaned coworker-server.
+    app.restart();
 }
 
 pub fn run() {
@@ -485,6 +533,7 @@ pub fn run() {
             show_main(app);
         }))
         .plugin(tauri_plugin_dialog::init())
+        .plugin(tauri_plugin_updater::Builder::new().build())
         .plugin(tauri_plugin_autostart::init(
             tauri_plugin_autostart::MacosLauncher::LaunchAgent,
             None,
@@ -504,7 +553,10 @@ pub fn run() {
             cancel_dictation_model_download,
             verify_dictation_model,
             mark_dictation_test_passed,
-            delete_dictation_model
+            delete_dictation_model,
+            dictation_level,
+            check_for_update,
+            install_update
         ])
         .setup(move |app| {
             // 1. Start the Python server sidecar on the chosen port (inherits our env).

--- a/platform/surfaces/gui/src-tauri/tauri.conf.json
+++ b/platform/surfaces/gui/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "OpenCoworker",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "identifier": "app.opencoworker.desktop",
   "build": {
     "frontendDist": "../dist",
@@ -27,16 +27,29 @@
       "icons/icon.icns",
       "icons/icon.ico"
     ],
-    "resources": { "binaries/sidecar": "sidecar" },
+    "resources": {
+      "binaries/sidecar": "sidecar"
+    },
     "macOS": {
       "entitlements": "entitlements.plist",
       "minimumSystemVersion": "12.0"
     },
     "windows": {
-      "webviewInstallMode": { "type": "downloadBootstrapper" },
+      "webviewInstallMode": {
+        "type": "downloadBootstrapper"
+      },
       "nsis": {
         "installMode": "currentUser"
       }
+    }
+  },
+  "plugins": {
+    "updater": {
+      "endpoints": [
+        "https://download.opencoworker.app/latest.json",
+        "https://github.com/andrewyng/aisuite/releases/latest/download/latest.json"
+      ],
+      "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IDVCNzEzRjY5OTkzNUNBNjkKUldScHlqV1phVDl4VzBvTnFLLytzaDkzNVd3WWNuUm8yNE95WTBFNnBtcGF1RENxeTRuNVhQeloK"
     }
   }
 }

--- a/platform/surfaces/gui/src/App.tsx
+++ b/platform/surfaces/gui/src/App.tsx
@@ -41,6 +41,7 @@ import { SearchModal } from "./components/SearchModal";
 import { SessionIntro } from "./components/SessionIntro";
 import { FolderGate } from "./components/FolderGate";
 import { Onboarding } from "./components/Onboarding";
+import { UpdateBanner } from "./components/UpdateBanner";
 import { ScheduledView } from "./components/ScheduledView";
 import { RightRail } from "./components/RightRail";
 import { IntegrationsView } from "./components/IntegrationsView";
@@ -985,6 +986,8 @@ export function App() {
           <span /><span /><span />
         </div>
       )}
+      {/* Desktop-only auto-update prompt (checks once, 15s after boot; inert in browser). */}
+      <UpdateBanner />
       {/* When collapsed, a thin left-edge zone peeks the nav back as a floating overlay. */}
       {navCollapsed && (
         <div

--- a/platform/surfaces/gui/src/components/Composer.tsx
+++ b/platform/surfaces/gui/src/components/Composer.tsx
@@ -6,6 +6,7 @@ import { Icon } from "./Icon";
 import { Toggle } from "./Toggle";
 import {
   cancelDictation,
+  getDictationLevel,
   getDictationStatus,
   isTauri,
   startDictation,
@@ -144,6 +145,23 @@ export function Composer(props: Props) {
     const timer = window.setInterval(() => {
       setRecordingSeconds(Math.floor((Date.now() - started) / 1000));
     }, 250);
+    return () => window.clearInterval(timer);
+  }, [dictation?.recording]);
+
+  // Live waveform: poll mic loudness at ~10Hz while recording; the bars scroll left so the
+  // trace reads as a real input meter (owner catch on DMG #28 — the first cut's bars were
+  // decorative constants and read as fake).
+  const [levels, setLevels] = useState<number[]>([]);
+  useEffect(() => {
+    if (!dictation?.recording) {
+      setLevels([]);
+      return;
+    }
+    const timer = window.setInterval(() => {
+      getDictationLevel().then((level) => {
+        if (typeof level === "number") setLevels((cur) => [...cur.slice(-13), level]);
+      });
+    }, 100);
     return () => window.clearInterval(timer);
   }, [dictation?.recording]);
 
@@ -344,14 +362,16 @@ export function Composer(props: Props) {
             }}
           />
 
-          {/* Listening replaces the quiet middle controls with waveform + elapsed time (§37). */}
+          {/* Listening replaces the quiet middle controls with a LIVE waveform (mic RMS,
+              polled ~10Hz, scrolling left) + elapsed time (§37). */}
           {dictation?.recording ? (
             <div className="voice-wave-row flex-1 flex items-center gap-2 ml-1" aria-hidden="true">
               <span className="voice-wave-line" />
               <span className="voice-wave-bars">
-                {[8, 16, 11, 23, 14, 27, 18, 9, 21, 13, 25, 16, 10, 19].map((height, index) => (
-                  <i key={index} style={{ height }} />
-                ))}
+                {Array.from({ length: 14 }, (_, index) => {
+                  const level = levels[levels.length - 14 + index] ?? 0;
+                  return <i key={index} style={{ height: Math.round(4 + level * 24) }} />;
+                })}
               </span>
               <span className="text-[12px] text-muted tabular-nums">{recordingTime}</span>
             </div>
@@ -364,6 +384,29 @@ export function Composer(props: Props) {
             />
           ) : null}
 
+          {dictationBusy === "Transcribing…" && <span className="text-[11.5px] text-accent">Transcribing…</span>}
+
+          <span className="ml-auto" />
+
+          {/* model — a quiet chip on a FRESH session only; once the session has history the
+              fact moves up to the topbar subtitle (§17 expressed spatially). */}
+          {!dictation?.recording && (needsModel ? (
+            <button
+              className="pill model-warn chip"
+              onClick={() => props.onConnectModel?.()}
+              title="Connect a model"
+              aria-label="No model connected — connect a model"
+            >
+              <span className="pill-label">No model</span>
+              <span className="model-warn-ico" aria-hidden>⚠</span>
+            </button>
+          ) : (
+            !props.modelLocked && (
+              <Dropdown value={props.model} options={modelOptions} onChange={props.onModelChange} align="right" />
+            )
+          ))}
+
+          {/* mic — immediately before send (owner call, DMG #28 walkthrough) */}
           {isTauri() && (
             <button
               className={
@@ -388,28 +431,6 @@ export function Composer(props: Props) {
               <Icon name={dictation?.recording ? "stop" : "mic"} size={16} />
             </button>
           )}
-
-          {dictationBusy === "Transcribing…" && <span className="text-[11.5px] text-accent">Transcribing…</span>}
-
-          <span className="ml-auto" />
-
-          {/* model — a quiet chip on a FRESH session only; once the session has history the
-              fact moves up to the topbar subtitle (§17 expressed spatially). */}
-          {!dictation?.recording && (needsModel ? (
-            <button
-              className="pill model-warn chip"
-              onClick={() => props.onConnectModel?.()}
-              title="Connect a model"
-              aria-label="No model connected — connect a model"
-            >
-              <span className="pill-label">No model</span>
-              <span className="model-warn-ico" aria-hidden>⚠</span>
-            </button>
-          ) : (
-            !props.modelLocked && (
-              <Dropdown value={props.model} options={modelOptions} onChange={props.onModelChange} align="right" />
-            )
-          ))}
 
           {/* send / stop */}
           {props.running ? (

--- a/platform/surfaces/gui/src/components/Onboarding.tsx
+++ b/platform/surfaces/gui/src/components/Onboarding.tsx
@@ -215,22 +215,46 @@ export function Onboarding({ onDone }: { onDone: (next?: "work" | "gallery" | "a
                   </button>
                 );
               }
+              // The Test affordance lives IN the key field (owner call, DMG #28 walkthrough:
+              // the footer Test button sat too far from the thing being tested): a small
+              // right-edge button that flips to a green ✓ once the key verifies (or was
+              // already saved). Continue still auto-verifies — this is the optional check.
+              const testable = f.secret && f.key === (info?.fields || []).find((x) => x.secret)?.key;
               return (
                 <div key={f.key}>
                   <label className={label}>{f.label}</label>
-                  <input
-                    className={input}
-                    type={f.secret ? "password" : "text"}
-                    placeholder={
-                      f.secret && credentialed ? "••••••••  (key saved)" : f.placeholder
-                    }
-                    value={fields[f.key] || ""}
-                    data-testid={`ob-field-${f.key}`}
-                    onChange={(e) => {
-                      setFields((cur) => ({ ...cur, [f.key]: e.target.value }));
-                      setVerify({ state: "idle" });
-                    }}
-                  />
+                  <div className="relative">
+                    <input
+                      className={input + (testable ? " pr-16" : "")}
+                      type={f.secret ? "password" : "text"}
+                      placeholder={
+                        f.secret && credentialed ? "••••••••  (key saved)" : f.placeholder
+                      }
+                      value={fields[f.key] || ""}
+                      data-testid={`ob-field-${f.key}`}
+                      onChange={(e) => {
+                        setFields((cur) => ({ ...cur, [f.key]: e.target.value }));
+                        setVerify({ state: "idle" });
+                      }}
+                    />
+                    {testable && (
+                      <button
+                        className={
+                          "absolute right-1.5 top-1/2 -translate-y-1/2 px-2.5 py-1 rounded-full text-[12px] disabled:opacity-40 " +
+                          (verified
+                            ? "text-ok bg-okSoft/60"
+                            : "text-accent hover:bg-accentSoft/60")
+                        }
+                        onClick={runTest}
+                        disabled={verify.state === "testing" || (!requiredFilled && !credentialed)}
+                        title={verified ? "Connected" : "Test this key"}
+                        aria-label={verified ? "Connected" : "Test this key"}
+                        data-testid="ob-test"
+                      >
+                        {verify.state === "testing" ? "…" : verified ? "✓" : "Test"}
+                      </button>
+                    )}
+                  </div>
                   {f.help && <p className="text-[11.5px] text-faint mt-1">{f.help}</p>}
                 </div>
               );
@@ -275,19 +299,10 @@ export function Onboarding({ onDone }: { onDone: (next?: "work" | "gallery" | "a
                   </button>
                 </span>
               )}
+              {/* Test moved INTO the key field (owner call, DMG #28); Continue still
+                  auto-verifies before advancing. */}
               <button
-                className={
-                  "ml-auto px-4 py-2 rounded-full border text-[13px] disabled:opacity-40 " +
-                  (verified ? "border-ok/40 text-ok" : "border-line hover:bg-paper")
-                }
-                onClick={runTest}
-                disabled={verify.state === "testing"}
-                data-testid="ob-test"
-              >
-                {verify.state === "testing" ? "Testing…" : verified ? "✓ Connected" : "Test"}
-              </button>
-              <button
-                className="px-5 py-2 rounded-full bg-ink text-panel text-[13px] disabled:opacity-40"
+                className="ml-auto px-5 py-2 rounded-full bg-ink text-panel text-[13px] disabled:opacity-40"
                 disabled={!canContinue || verify.state === "testing"}
                 onClick={saveAndContinue}
                 data-testid="ob-continue"
@@ -323,9 +338,10 @@ export function Onboarding({ onDone }: { onDone: (next?: "work" | "gallery" | "a
               <span className="block text-[13px] text-ink font-medium mb-0.5">
                 Secure by design
               </span>
-              OpenCoworker Cloud brokers the OAuth handshake — your tokens never leave this
-              Mac. Connect Slack, GitHub, HubSpot, Gmail and Calendar later with one click
-              each.
+              {/* Owner copy (DMG #28 walkthrough) — leads with the integration breadth. */}
+              Signing in handles OAuth and token management for 20+ integrations — Slack,
+              GitHub, HubSpot, Gmail, Calendar and more. Tokens stay local on your Mac. No
+              digging through dev consoles for API keys.
               {/* Sign-in is the one-click path, never the ONLY path (owner call 2026-07-12). */}
               <span className="block text-[11.5px] text-faint mt-3 pt-3 border-t border-line">
                 Prefer manual setup? Every tool also works with your own API keys from the

--- a/platform/surfaces/gui/src/components/SettingsView.tsx
+++ b/platform/surfaces/gui/src/components/SettingsView.tsx
@@ -17,6 +17,8 @@ import {
   getAutostart,
   getDictationStatus,
   getKeepAwake,
+  checkForUpdate,
+  installUpdate,
   isTauri,
   listenDictationDownloadProgress,
   markDictationTestPassed,
@@ -442,7 +444,68 @@ function AppearanceSection() {
         </button>
         <div className={FIELD_HELP}>Replays the first-run setup: model, first automation, tips.</div>
       </div>
+
+      {/* Manual update check (desktop shell only; launch also checks automatically). */}
+      {desktop && <UpdateCard />}
     </section>
+  );
+}
+
+function UpdateCard() {
+  const [state, setState] = useState<"idle" | "checking" | "none" | "found" | "installing" | "error">("idle");
+  const [version, setVersion] = useState("");
+
+  const check = async () => {
+    setState("checking");
+    try {
+      const u = await checkForUpdate();
+      if (u) {
+        setVersion(u.version);
+        setState("found");
+      } else {
+        setState("none");
+      }
+    } catch {
+      setState("error");
+    }
+  };
+
+  const install = async () => {
+    setState("installing");
+    try {
+      await installUpdate(); // success restarts the app
+    } catch {
+      setState("error");
+    }
+  };
+
+  return (
+    <div className={CARD + " p-4 mt-4"}>
+      <div className={FIELD_LABEL + " mb-2"}>Updates</div>
+      {state === "found" ? (
+        <button className={BTN_BORDERED} onClick={install} data-testid="settings-update-install">
+          Update to v{version} and restart
+        </button>
+      ) : (
+        <button
+          className={BTN_BORDERED}
+          onClick={check}
+          disabled={state === "checking" || state === "installing"}
+          data-testid="settings-update-check"
+        >
+          {state === "checking" ? "Checking…" : "Check for updates"}
+        </button>
+      )}
+      <div className={FIELD_HELP}>
+        {state === "none"
+          ? "You're on the latest version."
+          : state === "error"
+            ? "Couldn't check right now — try again later."
+            : state === "installing"
+              ? "Downloading — OpenCoworker restarts by itself when it's ready."
+              : "Updates download from OpenCoworker's releases and install in place."}
+      </div>
+    </div>
   );
 }
 

--- a/platform/surfaces/gui/src/components/UpdateBanner.tsx
+++ b/platform/surfaces/gui/src/components/UpdateBanner.tsx
@@ -1,0 +1,73 @@
+import { useEffect, useRef, useState } from "react";
+import { checkForUpdate, installUpdate, isTauri, type UpdateInfo } from "../tauri";
+
+// Auto-update prompt (desktop shell only — the browser build never renders this).
+// Deliberately a PROMPT, not a silent background install: swapping the app under a
+// user mid-session would kill their running coworker turn, and quiet self-mutation
+// sits badly with the local-first trust posture. "Later" dismisses until next launch.
+//
+// The check runs once, shortly after boot settles (the splash and session restore own
+// the first seconds). Update integrity is enforced below this layer: the shell verifies
+// the manifest's minisign signature against the pubkey compiled into tauri.conf.json.
+
+export function UpdateBanner() {
+  const [update, setUpdate] = useState<UpdateInfo | null>(null);
+  const [phase, setPhase] = useState<"idle" | "installing" | "error">("idle");
+  const checked = useRef(false);
+
+  useEffect(() => {
+    if (!isTauri() || checked.current) return;
+    checked.current = true;
+    const t = setTimeout(() => {
+      checkForUpdate().then((u) => u && setUpdate(u)).catch(() => {});
+    }, 15_000);
+    return () => clearTimeout(t);
+  }, []);
+
+  if (!update) return null;
+
+  const install = async () => {
+    setPhase("installing");
+    try {
+      await installUpdate(); // success restarts the app — nothing to do after
+    } catch {
+      setPhase("error");
+    }
+  };
+
+  return (
+    <div
+      className="fixed bottom-4 right-4 z-50 w-[300px] rounded-xl border border-line bg-panel shadow-2xl px-4 py-3.5"
+      role="status"
+      data-testid="update-banner"
+    >
+      <div className="text-[13px] font-semibold">Update available</div>
+      <div className="text-[12px] text-muted mt-0.5">
+        OpenCoworker v{update.version} is ready to install.
+      </div>
+      {phase === "error" && (
+        <div className="text-[11.5px] text-warnInk mt-1.5">
+          The update couldn't be installed — it will be offered again next launch.
+        </div>
+      )}
+      <div className="flex items-center gap-2 mt-2.5">
+        <button
+          className="px-3 py-1.5 rounded-full bg-accent text-white text-[12.5px] disabled:opacity-50"
+          onClick={install}
+          disabled={phase === "installing"}
+          data-testid="update-install"
+        >
+          {phase === "installing" ? "Downloading…" : "Restart to update"}
+        </button>
+        <button
+          className="px-2 py-1.5 text-[12.5px] text-faint hover:text-muted"
+          onClick={() => setUpdate(null)}
+          disabled={phase === "installing"}
+          data-testid="update-later"
+        >
+          Later
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/platform/surfaces/gui/src/styles.css
+++ b/platform/surfaces/gui/src/styles.css
@@ -159,8 +159,8 @@ body {
    (and down to align with them in their lowered position — see traffic_light_position in lib.rs). */
 /* Desktop overlay: the whole top strip sits lower (center ~30) to line up with the lowered
    traffic lights — reveal/pin, the wordmark, and the topbar title all on that line. */
-.app.tauri-overlay .nav-reveal-btn { top: 16px; left: 84px; }
-.app.tauri-overlay .main-topbar { padding-top: 12px; }
+.app.tauri-overlay .nav-reveal-btn { top: 13px; left: 84px; }
+.app.tauri-overlay .main-topbar { padding-top: 9px; }
 /* The session topbar's collapsed-state cluster is INLINE (§22), so only the overlay build pads
    it — to clear the traffic lights. */
 .app.nav-collapsed.tauri-overlay .main-topbar { padding-left: 84px; }
@@ -992,11 +992,11 @@ button.btn.sm.danger-btn:hover { border-color: var(--danger); }
   top: 0;
   left: 0;
   right: 0;
-  /* Center the wordmark on the traffic lights' midline: the lights sit at (19,24) with 12px
-     buttons (lib.rs traffic_light_position), so their center is y=30 — 12px padding + 36px
-     content box puts our center there too. */
+  /* Sit the wordmark on the top strip's shared midline (a hair above the traffic lights'
+     y=30 center — owner-tuned on the DMG #28 walkthrough alongside the brand row and the
+     topbar cluster; keep all four -3px offsets in step). */
   height: 48px;
-  padding-top: 12px;
+  padding-top: 9px;
   z-index: 180;
   background: transparent;
   display: flex;
@@ -1010,7 +1010,7 @@ button.btn.sm.danger-btn:hover { border-color: var(--danger); }
    traffic lights float top-left, so shift the row RIGHT (not down) to clear them and keep it at
    the top — that puts the pin button just right of the lights, aligned with the reveal button.
    The row is a drag region (data-tauri-drag-region in Sidebar.tsx), so this strip moves the window. */
-.app.tauri-overlay .sidebar .brand { padding-top: 16px; padding-left: 84px; }
+.app.tauri-overlay .sidebar .brand { padding-top: 13px; padding-left: 84px; }
 
 /* ---- Onboarding wizard ----------------------------------------------------- */
 .ob-overlay {

--- a/platform/surfaces/gui/src/tauri.ts
+++ b/platform/surfaces/gui/src/tauri.ts
@@ -70,6 +70,9 @@ export const startWindowDrag = () => invoke<boolean>("start_window_drag");
 // Local dictation is native-only. The browser build deliberately keeps this unavailable rather
 // than silently sending microphone audio to a server.
 export const getDictationStatus = () => invoke<DictationStatus>("get_dictation_status");
+/** Instantaneous mic loudness 0..1 while recording (0 otherwise) — drives the composer's
+ * live waveform. Cheap; poll at ~10Hz. */
+export const getDictationLevel = () => invoke<number>("dictation_level");
 export const startDictation = () => invokeStrict<DictationStatus>("start_dictation");
 export const stopDictation = () => invokeStrict<string>("stop_dictation");
 export const cancelDictation = () => invokeStrict<void>("cancel_dictation");
@@ -88,6 +91,18 @@ export async function listenDictationDownloadProgress(
     handler(event.payload);
   })) as () => void;
 }
+
+// --- Auto-update (desktop only; browser builds see null / throw) -----------------
+
+export type UpdateInfo = { version: string; notes: string };
+
+/** Ask the shell whether a newer release exists (verified manifest; see lib.rs).
+ * null = up to date, unreachable endpoint, or not the desktop app. */
+export const checkForUpdate = () => invoke<UpdateInfo | null>("check_for_update");
+
+/** Download + verify + install the update, then relaunch. Resolves only on failure paths
+ * (success restarts the process on macOS; Windows hands off to the installer). */
+export const installUpdate = () => invokeStrict<void>("install_update");
 
 /** Best-effort open a URL in the user's browser. Uses the Tauri opener plugin if present, else
  * `window.open`. The caller should also render the raw URL so it stays copyable if both no-op


### PR DESCRIPTION
Signed update artifacts (minisign) + latest.json from release CI — publishing a release pushes the update. In-app prompt (never silent) + Settings check; endpoints download.opencoworker.app → GitHub Releases fallback;
v0.1.2.
Stacked on #367