### PR TITLE
OpenWorker: Settings redesign, onboarding benefit rows, Outlook one-click, launch fixes

### DIFF
--- a/platform/coworker/cloud.py
+++ b/platform/coworker/cloud.py
@@ -49,6 +49,7 @@ PROVIDER_FOR_CONNECTOR = {
     "attio": "attio",
     "hubspot": "hubspot",
     "github": "github",
+    "outlook": "microsoft",
 }
 
 # Pending PKCE verifiers keyed by OAuth state; in-process only. A login that

--- a/platform/coworker/server/app.py
+++ b/platform/coworker/server/app.py
@@ -1129,6 +1129,10 @@ def create_app(manager: SessionManager) -> FastAPI:
             return {"ok": False, "error": "name required"}
         return manager.set_provider(name, (body or {}).get("fields"))
 
+    @app.delete("/v1/providers/{name}")
+    def providers_remove(name: str) -> dict[str, Any]:
+        return manager.remove_provider(name)
+
     @app.post("/v1/providers/verify")
     async def providers_verify(body: dict) -> dict[str, Any]:
         # Live read-only credential check (sync httpx) — run off the event loop.

--- a/platform/coworker/server/manager.py
+++ b/platform/coworker/server/manager.py
@@ -1318,6 +1318,17 @@ class SessionManager:
             self.set_default_model(added)
         return {"ok": True, "provider": name, "recommended_model": rec}
 
+    def remove_provider(self, name: str) -> dict[str, Any]:
+        """Forget a provider's stored config (Settings ▸ Models "Remove key"). The whole
+        `provider:<name>` profile goes — key, endpoint, key_set_at — so the provider reads
+        as never configured. Curated models stay; they just gray out until a new key."""
+        d = get_descriptor(name)
+        if d is None:
+            return {"ok": False, "error": f"unknown provider: {name}"}
+        self.secrets.delete(f"provider:{name}")
+        self._refresh_provider(name)
+        return {"ok": True, "provider": name}
+
     def verify_provider(
         self, name: str, fields: Optional[dict[str, Any]]
     ) -> dict[str, Any]:

--- a/platform/docs/UX-DECISIONS.md
+++ b/platform/docs/UX-DECISIONS.md
@@ -1004,8 +1004,35 @@ and footer never move — only the middle region swaps, at a fixed height** (ext
   AWS Bedrock / Azure deferred: provider-layer auth work, and Azure OpenAI is already
   reachable via OpenAI's custom endpoint.
 
+## 40. Settings: three tabs, and Models is the shared provider gallery  *(Decided 2026-07-19 by owner → Built 2026-07-19; mock: `ocw-context/docs/ux-improvements/mocks/UX-021-settings-redesign.html`; ledger UX-021)*
+
+- **Three tabs — General · Models · Voice input.** "Appearance" was carrying seven cards, most
+  of them not appearance; it renames to **General** (the tab *key* stays `appearance` so
+  deep-links keep working). **Files folds into General as one card** — a single option doesn't
+  earn a nav entry. **Personas is launch-flagged off** (`flags.ts` `showPersonas()`, default
+  false; the e2e suite re-enables via localStorage to keep the hidden flows covered).
+- **Models = the §39 gallery, shared for real.** The provider gallery ⇄ key form was extracted
+  to `providers/ProviderSetup.tsx` (hook + `ProviderCards`/`ProviderForm`); Onboarding step 1
+  and Settings ▸ Models render the SAME components with different frames, so the two surfaces
+  cannot drift. Settings passes testid prefix `set-`, onboarding keeps `ob-`.
+- **Settings-only additions:** configured cards carry "✓ Connected · used Nh ago" (truncating,
+  never wrapping); the form of a credentialed provider gains a quiet red **"Remove key…"**
+  (confirm → `DELETE /v1/providers/{name}` forgets the stored profile; the card reverts to
+  "Not set up"; curated models stay, they just gray out).
+- **Below the gallery:** the **"In the composer's picker"** card lists every curated model
+  across providers with provider tags + the default badge (untick removes; adding happens from
+  a provider's card, whose form view keeps the per-provider ModelChecklist or, unconfigured,
+  the read-only "Included models" preview). **Token savings moved here from Appearance** —
+  it's model-spend behavior. The gallery⇄form swap happens in place and the page scrolls; the
+  fixed-height rule is onboarding-modal-specific.
+- The old dropdown provider picker, the API/Local sub-tabs, and the separate Save button are
+  retired — Test = verify + save + slide home, exactly as in onboarding.
+
 ## Change log (requests, newest first)
 
+- **2026-07-19 (24)** — Owner: "Settings is quite a mess visually" (token savings under
+  Appearance, one-option Files tab) + "Models should follow the onboarding look" + hide
+  Personas behind a flag + collapsed-nav overlap fix → §40 (mocked UX-021; built 2026-07-19).
 - **2026-07-18 (23)** — Owner: onboarding step 1 "bland, tasteless and non-informing" →
   provider gallery; three review iterations (fixed frame; in-field saved state + endpoint
   disclosure + "Next"; de-blued links); then step 2's why-paragraph + post-sign-in connector

--- a/platform/docs/UX-DECISIONS.md
+++ b/platform/docs/UX-DECISIONS.md
@@ -1028,8 +1028,38 @@ and footer never move — only the middle region swaps, at a fixed height** (ext
 - The old dropdown provider picker, the API/Local sub-tabs, and the separate Save button are
   retired — Test = verify + save + slide home, exactly as in onboarding.
 
+## 41. Onboarding tools page: benefit rows, a band that never moves  *(Decided 2026-07-19 by owner → Built 2026-07-19; mocks: `ocw-context/docs/ux-improvements/mocks/UX-022b-tools-page-redesign.html` (3 directions), `UX-022c-benefit-rows-connect.html` (chosen); ledger UX-022)*
+
+- **Benefit rows replace the card gallery** (supersedes §39's step-2 body; frame rules stand).
+  Six rows — *Stay on top of email (Outlook) · Keep up with Slack · Ship code (GitHub) · Keep
+  your notes in reach (Notion) · Keep the CRM current (HubSpot) · Track every relationship
+  (Attio)* — benefit first, tool named in the ONE-LINE detail (wrap made row heights jump
+  between states). Rows scroll past the fold; accepted ("let users scroll"). The gated Google
+  pair is ONE combined grayed row with a static "Coming soon" — hover-only labels read as
+  broken cards.
+- **Zero layout shift at sign-in.** The band below the rows is pinned outside the scroll area
+  and its slot never moves: pre-sign-in it carries the ask ("Sign in for one-click connections —
+  OpenWorker handles the OAuth for 20+ tools… Tokens stay on this Mac") with the page's ONE
+  black button; after sign-in the same slot turns green-congrats ("🎉 You're signed in as … —
+  connect a tool above with one click, or add them anytime later"), and every row grows a quiet
+  bordered **Connect** pill in place (Connect → "Check your browser…" → ✓ Connected; one in
+  flight, silent resets — §39's connect rules carry over).
+- **One footer button, one slot:** quiet bordered "Continue without sign-in" pre-sign-in →
+  black "Next" after. The left "Skip" link is gone. The footnote is STATIC across states
+  ("30+ more tools on the Connectors page — add or remove anytime. Tokens stay on this Mac"),
+  so nothing below the band ever changes.
+- **Modal is 560px** (down from 700) across all steps — the §39 fixed-frame rule holds; the
+  provider gallery scrolls ~4.5 rows and the form views stop floating over a void. On step 1,
+  **"Custom endpoint ⌄" renders below the key-help line** as its own advanced row (both
+  surfaces — the disclosure lives in the shared ProviderForm).
+
 ## Change log (requests, newest first)
 
+- **2026-07-19 (25)** — Owner critique of the built §39 flow (from DMG walkthrough screenshots):
+  hover-only Coming soon, scattered grayed cards, blue-vs-black primaries, 700px void, key
+  state-restore bug, endpoint placement → fixes + full step-2 redesign through three mock
+  directions and two refinement rounds (his idea: rows grow Connect buttons; band stays with
+  congrats content) → §41 (mocked UX-022b/c; built 2026-07-19).
 - **2026-07-19 (24)** — Owner: "Settings is quite a mess visually" (token savings under
   Appearance, one-option Files tab) + "Models should follow the onboarding look" + hide
   Personas behind a flag + collapsed-nav overlap fix → §40 (mocked UX-021; built 2026-07-19).

--- a/platform/surfaces/gui/e2e/cloud.spec.ts
+++ b/platform/surfaces/gui/e2e/cloud.spec.ts
@@ -70,7 +70,7 @@ test("telemetry toggle: lives in Settings, signed-in only, default on, opt-out r
   await page.goto("/");
   await page.getByTestId("account-row").click();
   await page.getByTestId("account-menu").getByRole("button", { name: "Settings" }).click();
-  await expect(page.getByRole("heading", { name: "Appearance" })).toBeVisible();
+  await expect(page.getByRole("heading", { name: "General" })).toBeVisible();
   await expect(page.getByTestId("telemetry-toggle")).toHaveCount(0);
 
   await signIn(page);

--- a/platform/surfaces/gui/e2e/fixtures.ts
+++ b/platform/surfaces/gui/e2e/fixtures.ts
@@ -1100,6 +1100,15 @@ export async function mockApi(page: import("@playwright/test").Page) {
       if (b.fields?.base_url) prov.values = { ...prov.values, base_url: b.fields.base_url };
       return json({ ok: true, provider: b.name, recommended_model: null });
     }
+    // forget a provider's stored config (Settings ▸ Models "Remove key…").
+    if (/\/v1\/providers\/[^/]+$/.test(p) && m === "DELETE") {
+      const name = p.split("/").pop()!;
+      const prov = providers.find((x) => x.name === name);
+      if (!prov) return json({ ok: false, error: `unknown provider: ${name}` });
+      prov.configured = !prov.needs_key; // keyless (ollama) stays "configured"
+      prov.key_set_at = null;
+      return json({ ok: true, provider: name });
+    }
     if (p.endsWith("/v1/providers")) return json(providers);
     if (p.endsWith("/v1/channels/recent"))
       return json({

--- a/platform/surfaces/gui/e2e/fixtures.ts
+++ b/platform/surfaces/gui/e2e/fixtures.ts
@@ -135,6 +135,8 @@ const CONNECTORS = {
     { name: "notion", title: "Notion", icon: "◰", blurb: "Search pages, read content, query databases, create pages.", auth: "oauth", two_way: false, channels: false, available: true, brand_color: "#1f2328", logo: "", fields: [{ key: "access_token", label: "Integration secret", secret: true, required: true, help: "", placeholder: "ntn_…" }], instructions: [], connected: false, account: null, enabled: false, allowed_users: [], tools: [], managed: true, managed_profile: false },
     // Managed email-keyed multi-account connector (outlook) — drives the onboarding tools gallery.
     { name: "outlook", title: "Outlook", icon: "◎", blurb: "Search, summarize, draft, and send Microsoft 365 email.", auth: "oauth", two_way: false, channels: false, available: true, brand_color: "#0078d4", logo: "outlook", fields: [{ key: "access_token", label: "OAuth access token", secret: true, required: true, help: "", placeholder: "" }], instructions: [], connected: false, account: null, enabled: false, allowed_users: [], tools: [], managed: true, managed_profile: false },
+    // Sixth active card in the onboarding gallery (promoted 2026-07-19 to even the grid).
+    { name: "attio", title: "Attio", icon: "▣", blurb: "Search and read Attio CRM records; log notes.", auth: "oauth", two_way: false, channels: false, available: true, brand_color: "#2d6ae0", logo: "attio", fields: [{ key: "access_token", label: "OAuth access token", secret: true, required: true, help: "", placeholder: "" }], instructions: [], connected: false, account: null, enabled: false, allowed_users: [], tools: [], managed: true, managed_profile: false },
   ],
 };
 

--- a/platform/surfaces/gui/e2e/gallery.spec.ts
+++ b/platform/surfaces/gui/e2e/gallery.spec.ts
@@ -6,6 +6,8 @@ import { expect } from "@playwright/test";
 import { test } from "./fixtures";
 
 async function openPersonas(page) {
+  // Personas is launch-flagged off by default — these suites cover the flagged-on flows.
+  await page.addInitScript(() => localStorage.setItem("ocw.flag.personas", "1"));
   await page.goto("/");
   await page.getByTestId("account-row").click();
   await page.getByRole("button", { name: "Settings", exact: true }).click();

--- a/platform/surfaces/gui/e2e/onboarding.spec.ts
+++ b/platform/surfaces/gui/e2e/onboarding.spec.ts
@@ -117,8 +117,12 @@ test("tools page: sign-in morphs the page into the connector gallery; a card con
   await expect(page.getByTestId("ob-tools-signedin")).toBeVisible({ timeout: 10_000 });
   await expect(page.getByTestId("ob-tool-gallery")).toBeVisible();
   await expect(page.getByTestId("ob-tool-outlook")).toContainText("One click");
-  // The Google trio is gated on Google verification: present but grayed "Coming soon".
-  await expect(page.getByTestId("ob-tool-gmail")).toBeVisible();
+  // Attio is the sixth active card (promoted 2026-07-19 to even the grid).
+  await expect(page.getByTestId("ob-tool-attio")).toContainText("One click");
+  // The Google pair is gated on Google verification: grayed with a STATIC
+  // "Coming soon" label (hover-only read as a broken card — owner, 2026-07-19).
+  await expect(page.getByTestId("ob-tool-gmail")).toContainText("Coming soon");
+  await expect(page.getByTestId("ob-tool-google_calendar")).toContainText("Coming soon");
   await expect(page.getByTestId("ob-tool-gmail").getByRole("button")).toHaveCount(0);
 
   // One-click connect: the consent completes in the (mock) browser; the poll flips the

--- a/platform/surfaces/gui/e2e/onboarding.spec.ts
+++ b/platform/surfaces/gui/e2e/onboarding.spec.ts
@@ -105,29 +105,30 @@ test("tools page: sign-in morphs the page into the connector gallery; a card con
   await page.getByTestId("ob-continue").click();
   await expect(page.getByTestId("ob-step-tools")).toBeVisible();
 
-  // Pre-sign-in: the why-paragraph page — value first, one primary action, and the
-  // skip label NAMES the manual path (§39).
-  await expect(page.getByText("A coworker that can only chat can only advise")).toBeVisible();
-  await expect(page.getByText("One click, keys handled")).toBeVisible();
-  await expect(page.getByTestId("ob-tools-skip")).toContainText("my own API tokens");
-  await expect(page.getByTestId("ob-tool-gallery")).toHaveCount(0);
+  // Pre-sign-in (§41): the benefit rows are already there (no Connect buttons yet),
+  // the combined Google row says Coming soon, the band asks for sign-in, and the one
+  // footer button is the quiet "Continue without sign-in".
+  await expect(page.getByText("Chat can only advise")).toBeVisible();
+  await expect(page.getByTestId("ob-tool-outlook")).toContainText("Stay on top of email");
+  await expect(page.getByTestId("ob-tool-outlook").getByRole("button")).toHaveCount(0);
+  await expect(page.getByTestId("ob-tool-attio")).toContainText("Track every relationship");
+  await expect(page.getByTestId("ob-tool-google-soon")).toContainText("Coming soon");
+  await expect(page.getByText("Sign in for one-click connections")).toBeVisible();
+  await expect(page.getByTestId("ob-tools-skip")).toContainText("Continue without sign-in");
 
-  // Sign-in lands out-of-band; the SAME page morphs into the mini gallery.
+  // Sign-in lands out-of-band; the band's SLOT stays put and flips to the congrats
+  // (zero layout shift), and every row grows its Connect pill.
   await page.getByTestId("ob-cloud-signin").click();
   await expect(page.getByTestId("ob-tools-signedin")).toBeVisible({ timeout: 10_000 });
-  await expect(page.getByTestId("ob-tool-gallery")).toBeVisible();
-  await expect(page.getByTestId("ob-tool-outlook")).toContainText("One click");
-  // Attio is the sixth active card (promoted 2026-07-19 to even the grid).
-  await expect(page.getByTestId("ob-tool-attio")).toContainText("One click");
-  // The Google pair is gated on Google verification: grayed with a STATIC
-  // "Coming soon" label (hover-only read as a broken card — owner, 2026-07-19).
-  await expect(page.getByTestId("ob-tool-gmail")).toContainText("Coming soon");
-  await expect(page.getByTestId("ob-tool-google_calendar")).toContainText("Coming soon");
-  await expect(page.getByTestId("ob-tool-gmail").getByRole("button")).toHaveCount(0);
+  await expect(page.getByTestId("ob-tools-signedin")).toContainText("You’re signed in");
+  await expect(
+    page.getByTestId("ob-tool-attio").getByRole("button", { name: "Connect" }),
+  ).toBeVisible();
+  await expect(page.getByTestId("ob-tool-google-soon").getByRole("button")).toHaveCount(0);
 
   // One-click connect: the consent completes in the (mock) browser; the poll flips the
-  // card to ✓ Connected. Next was armed the whole time — connecting is optional.
-  await page.getByTestId("ob-tool-outlook").click();
+  // row to ✓ Connected. Next was armed the whole time — connecting is optional.
+  await page.getByTestId("ob-tool-outlook").getByRole("button", { name: "Connect" }).click();
   await expect(page.getByTestId("ob-tool-outlook")).toContainText("✓ Connected", {
     timeout: 10_000,
   });

--- a/platform/surfaces/gui/e2e/persona-surfacing.spec.ts
+++ b/platform/surfaces/gui/e2e/persona-surfacing.spec.ts
@@ -1,5 +1,10 @@
 import { test, expect } from "./fixtures";
 
+// Personas is launch-flagged off by default — this suite covers the flagged-on flows.
+test.beforeEach(async ({ page }) => {
+  await page.addInitScript(() => localStorage.setItem("ocw.flag.personas", "1"));
+});
+
 // Regression for the invisible-after-install bug (2026-07-03): enabling a persona in
 // Settings ▸ Personas must surface it EVERYWHERE without a reload — the New-Session picker and
 // the grouped sidebar — via the PERSONAS_CHANGED event (and backend enable-implies-surface).

--- a/platform/surfaces/gui/e2e/provider-keys.spec.ts
+++ b/platform/surfaces/gui/e2e/provider-keys.spec.ts
@@ -1,8 +1,8 @@
-// Settings ▸ Models: the model-provider key flow Rohit tested by hand (add/verify/save keys for
-// OpenAI/GLM/Anthropic/DeepSeek). Providers are seeded in three states (OpenAI configured+used,
-// Anthropic configured-unused, Z AI unconfigured w/ a prefilled endpoint). The mock's POST
-// /v1/providers flips `configured` on save; /verify is a read-only check that fails on a key
-// containing "bad".
+// Settings ▸ Models key flows on the shared provider gallery (§39 components, UX-021 page):
+// bad key fails in place, a passing Test auto-saves and slides home to the gallery where the
+// card wears its ✓. Providers are seeded in three states (OpenAI configured+used, Anthropic
+// configured-unused, Z AI unconfigured w/ a prefilled endpoint behind the disclosure). The
+// mock's /verify fails on a key containing "bad"; POST /v1/providers flips `configured`.
 import { expect } from "@playwright/test";
 import { test } from "./fixtures";
 
@@ -11,62 +11,36 @@ async function openModels(page) {
   await page.getByTestId("account-row").click();
   await page.getByRole("button", { name: "Settings", exact: true }).click();
   await page.getByRole("button", { name: "Models", exact: true }).click();
-  // The API-models pane is the default sub-tab; the provider select is its anchor.
-  await expect(page.getByRole("button", { name: "Provider" })).toBeVisible();
+  await expect(page.getByTestId("set-provider-openai")).toBeVisible();
 }
 
-// Pick a provider from the custom SelectMenu (open the listbox, click the option by name).
-async function selectProvider(page, label: string) {
-  await page.getByRole("button", { name: "Provider" }).click();
-  await page.getByRole("option", { name: new RegExp(label) }).click();
-}
-
-test("configured provider (OpenAI) shows connected + last-used", async ({ page }) => {
-  await openModels(page);
-  // OpenAI is the default selection and is configured + used.
-  await expect(page.getByText(/● Connected/)).toBeVisible();
-  await expect(page.getByText(/last used/)).toBeVisible();
-});
-
-test("unconfigured provider (Z AI) shows not-connected, prefilled endpoint, model preview", async ({
+test("Test with a bad key fails in place; a good key saves and returns to the gallery", async ({
   page,
 }) => {
   await openModels(page);
-  await selectProvider(page, "Z AI");
-  await expect(page.getByText(/● Not connected/)).toBeVisible();
-  // The OpenAI-compatible endpoint comes prefilled from the field default.
-  await expect(page.getByRole("textbox", { name: "Endpoint" })).toHaveValue(
-    "https://api.z.ai/api/paas/v4",
-  );
-  // What a key unlocks is previewed even before the key is added.
-  await expect(page.getByTestId("model-preview")).toContainText("Included models");
-});
+  await page.getByTestId("set-provider-zai").click();
 
-test("Test button: bad key fails, good key verifies — neither saves", async ({ page }) => {
-  await openModels(page);
-  await selectProvider(page, "Z AI");
-  const key = page.locator('input[type="password"]');
-
-  await key.fill("sk-bad-key");
-  await page.getByRole("button", { name: "Test" }).click();
+  await page.getByTestId("set-field-api_key").fill("sk-bad-key");
+  await page.getByTestId("set-test").click();
   await expect(page.getByText("Invalid API key.")).toBeVisible();
 
-  await key.fill("sk-good-key");
-  await page.getByRole("button", { name: "Test" }).click();
-  await expect(page.getByText("✓ Key verified.")).toBeVisible();
-
-  // Still unconfigured — Test never saves.
-  await expect(page.getByText(/● Not connected/)).toBeVisible();
+  // A good key: Test verifies AND saves (§39) — the in-field pill confirms, then the form
+  // slides home and the card wears its ✓.
+  await page.getByTestId("set-field-api_key").fill("sk-glm-realkey");
+  await page.getByTestId("set-test").click();
+  await expect(page.getByTestId("set-saved-pill")).toContainText("Tested & saved");
+  await expect(page.getByTestId("set-provider-zai")).toContainText("✓ Connected", {
+    timeout: 5_000,
+  });
 });
 
-test("Save a key flips the provider to connected", async ({ page }) => {
+test("a configured provider's form opens with the saved state, no plaintext key", async ({
+  page,
+}) => {
   await openModels(page);
-  await selectProvider(page, "Z AI");
-  const key = page.locator('input[type="password"]');
-  await key.fill("sk-glm-realkey");
-  await page.getByRole("button", { name: "Save" }).click();
-
-  // Confirmation names the local-only storage; the provider is now connected.
-  await expect(page.getByText(/stored locally, never sent to the model|stored locally/)).toBeVisible();
-  await expect(page.getByText(/● Connected/)).toBeVisible();
+  await page.getByTestId("set-provider-openai").click();
+  // Stored credentials show as the in-field saved pill + masked placeholder — never the key.
+  await expect(page.getByTestId("set-saved-pill")).toContainText("Tested & saved");
+  await expect(page.getByTestId("set-field-api_key")).toHaveValue("");
+  await expect(page.getByTestId("set-field-api_key")).toHaveAttribute("placeholder", "••••••••");
 });

--- a/platform/surfaces/gui/e2e/provider-keys.spec.ts
+++ b/platform/surfaces/gui/e2e/provider-keys.spec.ts
@@ -32,6 +32,14 @@ test("Test with a bad key fails in place; a good key saves and returns to the ga
   await expect(page.getByTestId("set-provider-zai")).toContainText("✓ Connected", {
     timeout: 5_000,
   });
+
+  // State-restore regression (owner catch 2026-07-19): revisiting the just-saved provider
+  // must show the masked placeholder + saved pill — never the typed key restored as a draft
+  // (the auto-return used to stash the saved key and replay it on the next open).
+  await page.getByTestId("set-provider-zai").click();
+  await expect(page.getByTestId("set-field-api_key")).toHaveValue("");
+  await expect(page.getByTestId("set-field-api_key")).toHaveAttribute("placeholder", "••••••••");
+  await expect(page.getByTestId("set-saved-pill")).toContainText("Tested & saved");
 });
 
 test("a configured provider's form opens with the saved state, no plaintext key", async ({

--- a/platform/surfaces/gui/e2e/settings.spec.ts
+++ b/platform/surfaces/gui/e2e/settings.spec.ts
@@ -1,27 +1,29 @@
 import { test, expect } from "./fixtures";
 
-// Guards the Settings-as-page refactor (§13): the ⚙ menu opens a full-page surface with a left
-// sub-nav — not the retired modal — and each section renders.
+// Guards the Settings-as-page refactor (§13, IA per UX-021): the ⚙ menu opens a full-page
+// surface with a left sub-nav — General · Models · Voice input — and each section renders.
+// Files is a card inside General; Personas is launch-flagged off.
 test("Settings opens as a full page and navigates sections", async ({ page }) => {
   await page.goto("/");
 
   await page.getByTestId("account-row").click();
   await page.getByRole("button", { name: "Settings", exact: true }).click();
 
-  // Full-page: left sub-nav + Appearance section (no modal backdrop).
-  await expect(page.getByRole("heading", { name: "Appearance" })).toBeVisible();
+  // Full-page: left sub-nav + the General section (no modal backdrop).
+  await expect(page.getByRole("heading", { name: "General" })).toBeVisible();
   await expect(page.locator(".modal-backdrop")).toHaveCount(0);
-  for (const label of ["Appearance", "Files", "Models"]) {
+  for (const label of ["General", "Models", "Voice input"]) {
     await expect(page.getByRole("button", { name: label, exact: true })).toBeVisible();
   }
-  // Personas is launch-flagged off by default (2026-07-19) — no tab.
+  // Folded/hidden tabs: Files is a General card now; Personas is launch-flagged off.
+  await expect(page.getByRole("button", { name: "Files", exact: true })).toHaveCount(0);
   await expect(page.getByRole("button", { name: "Personas", exact: true })).toHaveCount(0);
 
-  await page.getByRole("button", { name: "Files", exact: true }).click();
-  await expect(page.getByText("Scratch location")).toBeVisible();
+  // The Files card lives inside General.
+  await expect(page.getByText("Each conversation gets its own folder")).toBeVisible();
 
   await page.getByRole("button", { name: "Models", exact: true }).click();
-  await expect(page.getByText("API models")).toBeVisible();
+  await expect(page.getByTestId("set-provider-openai")).toBeVisible();
 });
 
 // The launch flag brings the Personas tab back (the gallery/persona suites rely on it).
@@ -34,42 +36,65 @@ test("Settings: Personas tab returns behind the launch flag", async ({ page }) =
   await expect(page.getByText("Add personas")).toBeVisible();
 });
 
-// Guards the Models pane's custom provider picker: rows carry a green "key set" dot and a
-// Last-used sub-line; picking an OpenAI-compatible vendor prefills its endpoint + blurb.
-test("Models: provider picker shows key status; vendor endpoint prefills", async ({ page }) => {
+// UX-021: Settings ▸ Models is the shared provider gallery (§39 components). Cards wear
+// their own state (✓ Connected · used …); a vendor card opens the shared key form with the
+// prefilled endpoint behind the disclosure; unconfigured providers preview their models.
+test("Models: provider gallery states; vendor form previews models", async ({ page }) => {
   await page.goto("/");
   await page.getByTestId("account-row").click();
   await page.getByRole("button", { name: "Settings", exact: true }).click();
   await page.getByRole("button", { name: "Models", exact: true }).click();
 
-  await page.getByRole("button", { name: "Provider" }).click();
-  const menu = page.getByRole("listbox", { name: "Provider" });
-  // Sectioned: configured providers float to the top under "Ready to use"; the rest wait
-  // under "Needs a key".
-  await expect(menu.getByText("Ready to use")).toBeVisible();
-  await expect(menu.getByText("Needs a key")).toBeVisible();
-  await expect(menu.getByRole("option", { name: /OpenAI/ })).toContainText("Last used 2h ago");
-  await expect(menu.getByRole("option", { name: /Claude/ })).toContainText("Not used yet");
-  await expect(menu.getByTitle("Key set")).toHaveCount(2); // openai + anthropic dots; zai has none
+  // Card states from the fixtures: openai configured+used, anthropic configured, zai not.
+  await expect(page.getByTestId("set-provider-openai")).toContainText("✓ Connected · used 2h ago");
+  await expect(page.getByTestId("set-provider-anthropic")).toContainText("✓ Connected");
+  await expect(page.getByTestId("set-provider-zai")).toContainText("Not set up");
+  await expect(page.getByTestId("set-provider-ollama")).toContainText("No key needed");
 
-  // Pick the vendor: blurb + prefilled (editable) endpoint render; status is not-connected.
-  await menu.getByRole("option", { name: /Z AI/ }).click();
+  // The composer-picker card lists the curated models with provider tags.
+  const picker = page.getByTestId("composer-picker");
+  await expect(picker).toContainText("In the composer's picker");
+
+  // Vendor form: blurb renders; the prefilled endpoint hides behind the disclosure.
+  await page.getByTestId("set-provider-zai").click();
   await expect(page.getByText(/Uses Z AI's OpenAI-compatible API/)).toBeVisible();
-  await expect(page.getByLabel("Endpoint")).toHaveValue("https://api.z.ai/api/paas/v4");
-  await expect(page.getByText(/Not connected/)).toBeVisible();
+  await page.getByTestId("set-endpoint-link").click();
+  await expect(page.getByTestId("set-field-base_url")).toHaveValue("https://api.z.ai/api/paas/v4");
 
   // Unconfigured providers still preview their curated models (read-only, matrix labels).
   const preview = page.getByTestId("model-preview");
   await expect(preview).toContainText("Included models");
   await expect(preview).toContainText("GLM-5.2 · Z AI");
+
+  // Back to the gallery via the crumb.
+  await page.getByTestId("set-back").click();
+  await expect(page.getByTestId("set-provider-openai")).toBeVisible();
 });
 
-// Token savings (owner ask, 2026-07-17): the card renders under Appearance with the PDF
-// fallback segmented control + attach thresholds, and edits POST through.
+// UX-021: a configured provider's form shows the in-field saved state and the Remove key…
+// affordance; removing reverts the card to "Not set up".
+test("Models: Remove key reverts a configured provider", async ({ page }) => {
+  await page.goto("/");
+  page.on("dialog", (d) => d.accept());
+  await page.getByTestId("account-row").click();
+  await page.getByRole("button", { name: "Settings", exact: true }).click();
+  await page.getByRole("button", { name: "Models", exact: true }).click();
+
+  await page.getByTestId("set-provider-anthropic").click();
+  await expect(page.getByTestId("set-saved-pill")).toContainText("Tested & saved");
+  await page.getByTestId("set-remove-key").click();
+
+  // Back on the gallery, the card has forgotten its key.
+  await expect(page.getByTestId("set-provider-anthropic")).toContainText("Not set up");
+});
+
+// Token savings (owner ask 2026-07-17; moved under Models by UX-021): the card renders with
+// the PDF fallback segmented control + attach thresholds, and edits POST through.
 test("Settings: Token savings card edits PDF fallback and thresholds", async ({ page }) => {
   await page.goto("/");
   await page.getByTestId("account-row").click();
   await page.getByRole("button", { name: "Settings", exact: true }).click();
+  await page.getByRole("button", { name: "Models", exact: true }).click();
 
   const card = page.getByTestId("token-savings-card");
   await expect(card).toBeVisible();

--- a/platform/surfaces/gui/e2e/settings.spec.ts
+++ b/platform/surfaces/gui/e2e/settings.spec.ts
@@ -11,18 +11,27 @@ test("Settings opens as a full page and navigates sections", async ({ page }) =>
   // Full-page: left sub-nav + Appearance section (no modal backdrop).
   await expect(page.getByRole("heading", { name: "Appearance" })).toBeVisible();
   await expect(page.locator(".modal-backdrop")).toHaveCount(0);
-  for (const label of ["Appearance", "Files", "Models", "Personas"]) {
+  for (const label of ["Appearance", "Files", "Models"]) {
     await expect(page.getByRole("button", { name: label, exact: true })).toBeVisible();
   }
+  // Personas is launch-flagged off by default (2026-07-19) — no tab.
+  await expect(page.getByRole("button", { name: "Personas", exact: true })).toHaveCount(0);
 
   await page.getByRole("button", { name: "Files", exact: true }).click();
   await expect(page.getByText("Scratch location")).toBeVisible();
 
-  await page.getByRole("button", { name: "Personas", exact: true }).click();
-  await expect(page.getByText("Add personas")).toBeVisible();
-
   await page.getByRole("button", { name: "Models", exact: true }).click();
   await expect(page.getByText("API models")).toBeVisible();
+});
+
+// The launch flag brings the Personas tab back (the gallery/persona suites rely on it).
+test("Settings: Personas tab returns behind the launch flag", async ({ page }) => {
+  await page.addInitScript(() => localStorage.setItem("ocw.flag.personas", "1"));
+  await page.goto("/");
+  await page.getByTestId("account-row").click();
+  await page.getByRole("button", { name: "Settings", exact: true }).click();
+  await page.getByRole("button", { name: "Personas", exact: true }).click();
+  await expect(page.getByText("Add personas")).toBeVisible();
 });
 
 // Guards the Models pane's custom provider picker: rows carry a green "key set" dot and a

--- a/platform/surfaces/gui/src/App.tsx
+++ b/platform/surfaces/gui/src/App.tsx
@@ -165,10 +165,10 @@ export function App() {
   const [scheduledOpenId, setScheduledOpenId] = useState<string | null>(null);
   const [gateCreate, setGateCreate] = useState(false);
   // Which Settings section the full-page Settings surface opens on (§ Settings-as-page).
-  const [settingsTab, setSettingsTab] = useState<"appearance" | "files" | "models" | "voice" | "personas">(
+  const [settingsTab, setSettingsTab] = useState<"appearance" | "models" | "voice" | "personas">(
     "appearance",
   );
-  const openSettings = (tab: "appearance" | "files" | "models" | "voice" | "personas" = "appearance") => {
+  const openSettings = (tab: "appearance" | "models" | "voice" | "personas" = "appearance") => {
     setSettingsTab(tab);
     setSurface("settings");
   };

--- a/platform/surfaces/gui/src/api.ts
+++ b/platform/surfaces/gui/src/api.ts
@@ -1199,6 +1199,14 @@ export async function setProvider(
   return res.json();
 }
 
+/** Forget a provider's stored config (Settings ▸ Models "Remove key…"). */
+export async function removeProvider(name: string): Promise<{ ok: boolean; error?: string }> {
+  const res = await fetch(`${httpBase()}/v1/providers/${encodeURIComponent(name)}`, {
+    method: "DELETE",
+  });
+  return res.json();
+}
+
 /** Live read-only credential check (does NOT save the key). Triggered by the user's "Test" click. */
 export async function verifyProvider(
   name: string,

--- a/platform/surfaces/gui/src/components/IntegrationsView.tsx
+++ b/platform/surfaces/gui/src/components/IntegrationsView.tsx
@@ -34,7 +34,7 @@ export function IntegrationsView() {
 
   return (
     <main className="flex-1 min-w-0 flex bg-paper">
-      <nav className="w-[208px] shrink-0 border-r border-line bg-panel/40 px-3 py-4">
+      <nav className="page-subnav w-[208px] shrink-0 border-r border-line bg-panel/40 px-3 py-4">
         <div className="px-2 text-[13.5px] font-semibold mb-3 flex items-center gap-2">
           <Icon name="plug" size={16} /> Connectors
         </div>

--- a/platform/surfaces/gui/src/components/ManageTabs.tsx
+++ b/platform/surfaces/gui/src/components/ManageTabs.tsx
@@ -8,16 +8,15 @@ import {
   disallowUser,
   getMcpServers,
   getMcpTools,
-  getProviders,
   getSettings,
   getSubscriptions,
+  removeModel,
   resolveUnauthorized,
   unsubscribeChannel,
   patchMcpServer,
   reloadMcp,
-  setProvider,
+  setDefaultModel,
   updateConnectorTools,
-  verifyProvider,
   type CloudStatus,
   type Connector,
   type Subscription,
@@ -27,7 +26,7 @@ import {
 } from "../api";
 import { CloudSignInInline } from "./connectors/CloudSignIn";
 import { ModelChecklist } from "./ModelChecklist";
-import { SelectMenu } from "./SelectMenu";
+import { ProviderCards, ProviderForm, useProviderSetup } from "../providers/ProviderSetup";
 import { Toggle } from "./Toggle";
 
 // "2h ago"-style label for the providers' Last-used line (null when never used).
@@ -42,12 +41,6 @@ const relTime = (epoch?: number | null): string | null => {
   return `${Math.floor(hrs / 24)}d ago`;
 };
 
-const fmtDate = (iso?: string | null): string | null => {
-  if (!iso) return null;
-  const d = new Date(iso + "T00:00:00");
-  return Number.isNaN(d.getTime()) ? null : d.toLocaleDateString();
-};
-
 // Shared tab bodies for the Settings and Integrations pages (the old top-tab ManageModal was retired
 // when Settings/Activity became full-page surfaces): ModelsTab → Settings ▸ Models; ConnectorsTab +
 // McpTab → Integrations ▸ Connectors / MCP servers.
@@ -57,10 +50,6 @@ const BTN_BORDERED =
   "text-[12.5px] px-3 py-1.5 rounded-lg border border-line bg-paper hover:border-lineStrong shrink-0";
 const BTN_ACCENT = "text-[12.5px] px-3 py-1.5 rounded-lg bg-accent text-white shrink-0 disabled:opacity-50";
 const BTN_DANGER = "text-[12.5px] text-danger/80 hover:text-danger shrink-0";
-const FIELD_LABEL = "block text-[12.5px] font-medium text-ink mb-1.5";
-const FIELD_HELP = "block text-[12px] text-muted mt-1.5 leading-relaxed";
-const INPUT_W =
-  "w-full px-3 py-2 rounded-lg border border-line bg-paper text-[13px] text-ink outline-none focus:border-accent";
 
 /** Two-letter initials for a chip/avatar (first+last word, else first two chars). */
 function initials(name: string): string {
@@ -78,318 +67,164 @@ const EXAMPLE = `{
   }
 }`;
 
-// -- Configure Models tab (providers, model list, keys) -----------------------
+// -- Configure Models tab (UX-021: the shared provider gallery + key form) ----
+// Settings ▸ Models reuses onboarding §39's ProviderCards/ProviderForm so the two
+// surfaces can't drift. Settings-only extras: per-card "used Nh ago", a "Remove
+// key…" affordance, the global composer-picker card (gallery view), and the
+// per-provider ModelChecklist / read-only model preview (form view).
 export function ModelsTab() {
   const [settings, setSettings] = useState<ModelSettings | null>(null);
-  const [draft, setDraft] = useState("");
-  const [busy, setBusy] = useState(false);
-  const [msg, setMsg] = useState<string | null>(null);
-  const [providers, setProviders] = useState<ProviderInfo[]>([]);
-  const [ollamaUrl, setOllamaUrl] = useState("");
-  const [ollamaMsg, setOllamaMsg] = useState<string | null>(null);
-  // Two panes: hosted API models (key-based, per provider) and local Ollama models.
-  const [sub, setSub] = useState<"api" | "local">("api");
-  const [apiProv, setApiProv] = useState("openai");
-  const [endpoint, setEndpoint] = useState(""); // OpenAI custom endpoint (Azure, OpenRouter, …)
-  const [verify, setVerify] = useState<{ state: "idle" | "testing" | "ok" | "error"; msg?: string }>({ state: "idle" });
-
-  const refresh = () => getSettings().then(setSettings).catch(() => setSettings(null));
-  const loadProviders = () =>
-    getProviders()
-      .then((ps) => {
-        setProviders(ps);
-        const oll = ps.find((p) => p.name === "ollama");
-        if (oll?.values?.base_url) setOllamaUrl((cur) => cur || oll.values.base_url);
-        // Seed the endpoint for the selected provider: stored value, else the descriptor's
-        // pre-filled default (OpenAI-compatible vendors ship their official endpoint).
-        const sel = ps.find((p) => p.name === apiProv);
-        const seeded =
-          sel?.values?.base_url || sel?.fields.find((f) => f.key === "base_url")?.default || "";
-        if (seeded) setEndpoint((cur) => cur || seeded);
-      })
-      .catch(() => {});
+  const refreshSettings = () => getSettings().then(setSettings).catch(() => setSettings(null));
+  const ps = useProviderSetup({ onSaved: refreshSettings });
   useEffect(() => {
-    refresh();
-    loadProviders();
+    refreshSettings();
   }, []);
-
-  const saveOllama = async () => {
-    setOllamaMsg(null);
-    const res = await setProvider("ollama", { base_url: ollamaUrl.trim() });
-    if (res.ok) {
-      const rec = res.recommended_model;
-      setOllamaMsg(
-        rec
-          ? `Saved. ${rec} is the recommended model — added to your list if it's pulled (else: ollama pull ${rec}).`
-          : "Saved. Tick or add an Ollama model under “Models” below to use it.",
-      );
-      loadProviders();
-      refresh(); // pick up the auto-added recommended model in the curated list
-    } else {
-      setOllamaMsg(res.error || "Failed to save Ollama URL.");
-    }
-  };
-
-  // The provider the pane is configuring (the ModelChecklist owns add/remove/default).
-  const knownNames = providers.map((p) => p.name);
-  const provName = sub === "local" ? "ollama" : apiProv;
-  const selProv = providers.find((p) => p.name === provName);
-
-  // The provider's endpoint field, when it has one (OpenAI's optional custom endpoint + the
-  // OpenAI-compatible vendors' pre-filled one).
-  const endpointField = selProv?.fields.find((f) => f.key === "base_url");
-
-  const keyFields = (): Record<string, string> => {
-    const fields: Record<string, string> = {};
-    if (draft.trim()) fields.api_key = draft.trim();
-    if (endpointField) fields.base_url = endpoint.trim();
-    return fields;
-  };
-
-  const testKey = async () => {
-    if (!draft.trim() && !selProv?.configured) return;
-    setVerify({ state: "testing" });
-    const res = await verifyProvider(apiProv, keyFields());
-    setVerify(res.ok ? { state: "ok" } : { state: "error", msg: res.error || "Couldn't verify." });
-  };
-
-  const save = async () => {
-    if (!draft.trim() && !(endpointField && endpoint.trim())) return;
-    setBusy(true);
-    setMsg(null);
-    const res = await setProvider(apiProv, keyFields());
-    setBusy(false);
-    if (res.ok) {
-      setDraft("");
-      setVerify({ state: "idle" });
-      // set_provider auto-adds the provider's model and makes it the default if the old default
-      // wasn't usable — so the composer is ready immediately. Confirm that to the user.
-      const updated = await getSettings().catch(() => null);
-      if (updated) setSettings(updated);
-      setMsg(
-        updated
-          ? `Saved. “${updated.model}” is ready in the composer — stored locally, never sent to the model.`
-          : "Saved. The key is stored locally and never sent to the model.",
-      );
-      loadProviders();
-    } else {
-      setMsg(res.error || "Failed to save key.");
-    }
-  };
 
   if (!settings) return <div className="text-[13px] text-muted">Loading…</div>;
 
-  // The checklist shown once the pane's provider is usable (always, for keyless Ollama).
-  const checklist = (selProv?.configured || sub === "local") && (
-    <div className="mt-6">
-      <div className={SEC_H + " mb-1.5"}>Models</div>
-      <p className="text-[12px] text-muted mb-2.5 leading-relaxed">
-        {sub === "local"
-          ? "Your pulled Ollama models. Ticked ones show in the composer's picker; the black badge marks the default for new sessions."
-          : "Ticked models show in the composer's picker; the black badge marks the default for new sessions."}
-      </p>
-      <ModelChecklist
-        provider={provName}
-        knownProviders={knownNames}
-        suggested={selProv?.suggested_models || []}
-        curated={settings.models}
-        defaultModel={settings.model}
-        labels={settings.model_labels}
-        onChanged={(next) => setSettings((s) => (s ? { ...s, models: next.models, model: next.model } : s))}
-      />
-    </div>
-  );
+  const info = ps.info;
+  const knownNames = ps.providers.map((p) => p.name);
 
-  // Unconfigured providers still show their curated models as a read-only preview — what a key
-  // unlocks is part of deciding to get one at all (owner ask, 2026-07-04). Real ids in tooltips.
-  const modelPreview = sub === "api" &&
-    selProv &&
-    !selProv.configured &&
-    (selProv.suggested_models?.length || 0) > 0 && (
-      <div className="mt-6" data-testid="model-preview">
-        <div className={SEC_H + " mb-1.5"}>Included models</div>
-        <p className="text-[12px] text-muted mb-2.5 leading-relaxed">
-          Curated, agent-capable models this provider serves — add your key above to enable them.
-        </p>
-        <div className="space-y-1">
-          {(selProv.suggested_models || []).map((m) => {
-            const full = provName === "openai" ? m : `${provName}:${m}`;
-            return (
-              <div
-                key={m}
-                className="px-2.5 py-1.5 rounded-lg border border-line bg-paper text-[13px] text-muted"
-                title={full}
-              >
-                {settings.model_labels?.[full] || m}
-              </div>
-            );
-          })}
-        </div>
+  if (ps.sel === null) {
+    return (
+      <div>
+        <ProviderCards ps={ps} tp="set" gridClass="grid grid-cols-2 xl:grid-cols-3 gap-2.5" lastUsed />
+        <ComposerPickerCard settings={settings} providers={ps.providers} onChanged={refreshSettings} />
       </div>
     );
+  }
 
   return (
     <div>
-      <div className="seg mb-4" role="tablist" aria-label="Model source">
-        <button className={sub === "api" ? "active" : ""} onClick={() => setSub("api")}>
-          API models
-        </button>
-        <button className={sub === "local" ? "active" : ""} onClick={() => setSub("local")}>
-          Local models
-        </button>
-      </div>
-
-      {sub === "api" ? (
-        <div className={CARD + " p-4"}>
-          <div className="mb-4">
-            <span className={FIELD_LABEL}>Provider</span>
-            {/* Custom select, sectioned "Ready to use" / "Needs a key" (configured providers
-                float to the top). Rows carry a green "key set" dot + a Last-used sub-line, so
-                which providers are configured (and still in use) is visible at a glance. */}
-            <SelectMenu
-              ariaLabel="Provider"
-              value={apiProv}
-              options={[...providers]
-                .filter((p) => p.name !== "ollama")
-                .sort((a, b) => Number(b.configured) - Number(a.configured)) // stable: keeps registry order within each section
-                .map((p) => ({
-                  value: p.name,
-                  label: p.title,
-                  group: p.configured ? "Ready to use" : "Needs a key",
-                  dot: p.configured,
-                  sub: p.configured
-                    ? relTime(p.last_used_at)
-                      ? `Last used ${relTime(p.last_used_at)}`
-                      : "Not used yet"
-                    : undefined,
-                }))}
-              onChange={(name) => {
-                setApiProv(name);
-                setDraft("");
-                setMsg(null);
-                setVerify({ state: "idle" });
-                // Re-seed the endpoint for the newly selected provider (stored → default → blank).
-                const p = providers.find((x) => x.name === name);
-                setEndpoint(
-                  p?.values?.base_url || p?.fields.find((f) => f.key === "base_url")?.default || "",
-                );
+      <ProviderForm
+        ps={ps}
+        tp="set"
+        footer={
+          ps.credentialed ? (
+            <button
+              className="text-[12.5px] text-danger/80 hover:text-danger hover:underline underline-offset-2"
+              data-testid="set-remove-key"
+              onClick={() => {
+                if (window.confirm(`Remove the ${info?.title} key from this computer?`)) ps.removeKey();
               }}
-            />
-          </div>
-
-          {selProv?.blurb && (
-            <p className="text-[12px] text-muted -mt-2 mb-4 leading-relaxed">{selProv.blurb}</p>
-          )}
-
-          <div className="text-[12px] mb-4">
-            {selProv?.configured ? (
-              <span className="text-ok">
-                ● Connected
-                {fmtDate(selProv.key_set_at) ? ` — key added ${fmtDate(selProv.key_set_at)}` : " — key set"}
-                {provName === "openai" && settings.source === "env" ? " (from environment)" : ""}
-                <span className="text-muted">
-                  {" · "}
-                  {relTime(selProv.last_used_at) ? `last used ${relTime(selProv.last_used_at)}` : "not used yet"}
-                </span>
-              </span>
-            ) : (
-              <span className="text-danger">● Not connected — add a key below to use this provider</span>
-            )}
-          </div>
-
-          {provName === "openai" && settings.source === "env" && (
-            <p className="text-[12px] text-muted mb-4 leading-relaxed">
-              A key is set via <code>OPENAI_API_KEY</code> in this server's environment. You can override
-              it below; the stored key is used only when the environment variable is absent.
-            </p>
-          )}
-          {endpointField && (
-            <label className="block mb-4">
-              <span className={FIELD_LABEL}>{endpointField.label}</span>
-              <input
-                className={INPUT_W}
-                type="text"
-                placeholder={endpointField.placeholder}
-                value={endpoint}
-                spellCheck={false}
-                autoComplete="off"
-                onChange={(e) => setEndpoint(e.target.value)}
-              />
-              <span className={FIELD_HELP}>{endpointField.help}</span>
-            </label>
-          )}
-          <label className="block mb-4">
-            <span className={FIELD_LABEL}>
-              {selProv?.fields.find((f) => f.key === "api_key")?.label || "API key"}
-            </span>
-            <input
-              className={INPUT_W}
-              type="password"
-              placeholder={selProv?.fields.find((f) => f.key === "api_key")?.placeholder || "sk-…"}
-              value={draft}
-              spellCheck={false}
-              autoComplete="off"
-              onChange={(e) => setDraft(e.target.value)}
-              onKeyDown={(e) => e.key === "Enter" && save()}
-            />
-            <span className={FIELD_HELP}>
-              Stored locally at <code>~/.config/coworker/secrets.json</code> (0600). Required for the
-              desktop app, where the server can't read your shell environment.
-            </span>
-          </label>
-          <div className="flex items-center gap-2">
-            <button
-              className={BTN_BORDERED}
-              onClick={testKey}
-              disabled={verify.state === "testing" || (!draft.trim() && !selProv?.configured)}
-              title="Check the key works — without saving it"
             >
-              {verify.state === "testing" ? "Testing…" : "Test"}
+              Remove key…
             </button>
-            <button
-              className={BTN_ACCENT}
-              onClick={save}
-              disabled={busy || (!draft.trim() && !(apiProv === "openai" && endpoint.trim()))}
-            >
-              {busy ? "Saving…" : "Save"}
-            </button>
-          </div>
-          {verify.state === "ok" && <div className="text-[12px] text-ok mt-2.5">✓ Key verified.</div>}
-          {verify.state === "error" && <div className="text-[12px] text-danger mt-2.5">{verify.msg}</div>}
-          {msg && <div className="text-[12px] text-muted mt-2.5">{msg}</div>}
-        </div>
-      ) : (
-        <div className={CARD + " p-4"}>
-          <p className="text-[12.5px] text-muted mb-4 leading-relaxed">
-            Run models locally with <code>ollama serve</code>. OpenWorker uses Ollama's
-            OpenAI-compatible API, so tools work. No API key needed.
-          </p>
-          <label className="block mb-4">
-            <span className={FIELD_LABEL}>Ollama server URL</span>
-            <input
-              className={INPUT_W}
-              type="text"
-              placeholder="http://localhost:11434"
-              value={ollamaUrl}
-              spellCheck={false}
-              autoComplete="off"
-              onChange={(e) => setOllamaUrl(e.target.value)}
-              onKeyDown={(e) => e.key === "Enter" && saveOllama()}
-            />
-            <span className={FIELD_HELP}>
-              The OpenAI-compatible <code>/v1</code> path is added automatically. Leave blank for the
-              default. Your pulled models appear under <strong>Models</strong> below.
-            </span>
-          </label>
-          <button className={BTN_ACCENT} onClick={saveOllama}>
-            Save Ollama URL
-          </button>
-          {ollamaMsg && <div className="text-[12px] text-muted mt-2.5">{ollamaMsg}</div>}
-        </div>
+          ) : null
+        }
+      />
+
+      {ps.sel === "openai" && settings.source === "env" && (
+        <p className="text-[12px] text-muted mt-3 leading-relaxed">
+          A key is set via <code>OPENAI_API_KEY</code> in this server's environment. You can override
+          it above; the stored key is used only when the environment variable is absent.
+        </p>
       )}
 
-      {checklist}
-      {modelPreview}
+      {info?.configured ? (
+        <div className="mt-6">
+          <div className={SEC_H + " mb-1.5"}>Models</div>
+          <p className="text-[12px] text-muted mb-2.5 leading-relaxed">
+            Ticked models show in the composer's picker; the black badge marks the default for new
+            sessions.
+          </p>
+          <ModelChecklist
+            provider={ps.sel}
+            knownProviders={knownNames}
+            suggested={info?.suggested_models || []}
+            curated={settings.models}
+            defaultModel={settings.model}
+            labels={settings.model_labels}
+            onChanged={(next) => setSettings((s) => (s ? { ...s, models: next.models, model: next.model } : s))}
+          />
+        </div>
+      ) : (
+        // Unconfigured providers still show their curated models as a read-only preview — what a
+        // key unlocks is part of deciding to get one at all (owner ask, 2026-07-04).
+        (info?.suggested_models?.length || 0) > 0 && (
+          <div className="mt-6" data-testid="model-preview">
+            <div className={SEC_H + " mb-1.5"}>Included models</div>
+            <p className="text-[12px] text-muted mb-2.5 leading-relaxed">
+              Curated, agent-capable models this provider serves — add your key above to enable them.
+            </p>
+            <div className="space-y-1">
+              {(info?.suggested_models || []).map((m) => {
+                const full = ps.sel === "openai" ? m : `${ps.sel}:${m}`;
+                return (
+                  <div
+                    key={m}
+                    className="px-2.5 py-1.5 rounded-lg border border-line bg-paper text-[13px] text-muted"
+                    title={full}
+                  >
+                    {settings.model_labels?.[full] || m}
+                  </div>
+                );
+              })}
+            </div>
+          </div>
+        )
+      )}
+    </div>
+  );
+}
+
+// The gallery view's "In the composer's picker" card: every curated model across providers,
+// with its provider tag. Unticking removes it from the picker; adding happens from a
+// provider's card (the ModelChecklist there has the suggested list + free-type add).
+function ComposerPickerCard({
+  settings,
+  providers,
+  onChanged,
+}: {
+  settings: ModelSettings;
+  providers: ProviderInfo[];
+  onChanged: () => void;
+}) {
+  const names = providers.map((p) => p.name);
+  const provOf = (id: string) => {
+    const i = id.indexOf(":");
+    return i > 0 && names.includes(id.slice(0, i)) ? id.slice(0, i) : "openai";
+  };
+  const tag = (id: string) => {
+    const p = providers.find((x) => x.name === provOf(id));
+    return (p?.title || provOf(id)).split(" (")[0];
+  };
+  return (
+    <div className="mt-6" data-testid="composer-picker">
+      <div className={SEC_H + " mb-1.5"}>In the composer's picker</div>
+      <p className="text-[12px] text-muted mb-2.5 leading-relaxed">
+        The models offered when starting a session; the black badge marks the default. Add more
+        from a provider's card above.
+      </p>
+      <div className="mlist">
+        {settings.models.map((id) => {
+          const isDefault = id === settings.model;
+          return (
+            <div className="mlist-row" key={id}>
+              <label className="mlist-main">
+                <input
+                  type="checkbox"
+                  checked
+                  disabled={isDefault}
+                  title={isDefault ? "The default model is always shown — make another model default first" : "Remove from the picker"}
+                  onChange={() => removeModel(id).then((r) => r.ok && onChanged())}
+                />
+                <span className="mlist-name" title={id}>
+                  {settings.model_labels?.[id] || id}
+                </span>
+              </label>
+              <span className="text-[11px] text-faint mr-2 shrink-0">{tag(id)}</span>
+              {isDefault ? (
+                <span className="mlist-default">default</span>
+              ) : (
+                <button className="mlist-make" onClick={() => setDefaultModel(id).then(() => onChanged())}>
+                  Make default
+                </button>
+              )}
+            </div>
+          );
+        })}
+      </div>
     </div>
   );
 }

--- a/platform/surfaces/gui/src/components/Onboarding.tsx
+++ b/platform/surfaces/gui/src/components/Onboarding.tsx
@@ -1,20 +1,15 @@
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useState } from "react";
 import {
   cloudLogin,
   connectManaged,
   getCloudStatus,
   getConnectors,
-  getProviders,
   setOnboarded,
-  setProvider,
-  verifyProvider,
   type CloudStatus,
   type Connector,
-  type ProviderInfo,
 } from "../api";
-import { openExternal } from "../tauri";
 import { ConnectorBadge } from "../connectors/ConnectorIcon";
-import { PROVIDER_LOGOS, providerRank } from "../providers/logos";
+import { ProviderCards, ProviderForm, useProviderSetup } from "../providers/ProviderSetup";
 import { Spinner } from "./AutomationQuickstart";
 
 // First-run onboarding (UX-DECISIONS §24 → §29 → §39): model → your tools → go.
@@ -23,23 +18,9 @@ import { Spinner } from "./AutomationQuickstart";
 // two-state tools page whose post-sign-in body is a mini connector gallery with
 // live one-click connects. Both steps share one frame rule: the header and
 // footer never move; only the middle region swaps, at a fixed height.
-// Replayable from Settings ▸ Appearance ▸ "Run setup again".
-
-// Where a non-developer gets an API key — deep link + one line of instructions.
-const KEY_HELP: Record<string, { url: string; label: string }> = {
-  anthropic: { url: "https://console.anthropic.com/settings/keys", label: "console.anthropic.com" },
-  openai: { url: "https://platform.openai.com/api-keys", label: "platform.openai.com" },
-  gemini: { url: "https://aistudio.google.com/apikey", label: "aistudio.google.com" },
-  fireworks: { url: "https://fireworks.ai/account/api-keys", label: "fireworks.ai" },
-  together: { url: "https://api.together.xyz/settings/api-keys", label: "together.xyz" },
-  zai: { url: "https://z.ai/manage-apikey/apikey-list", label: "z.ai" },
-  kimi: { url: "https://platform.moonshot.ai/console/api-keys", label: "platform.moonshot.ai" },
-  deepseek: { url: "https://platform.deepseek.com/api_keys", label: "platform.deepseek.com" },
-  mistral: { url: "https://console.mistral.ai/api-keys", label: "console.mistral.ai" },
-  qwen: { url: "https://modelstudio.console.alibabacloud.com", label: "alibabacloud.com" },
-  minimax: { url: "https://platform.minimax.io", label: "platform.minimax.io" },
-  xai: { url: "https://console.x.ai", label: "console.x.ai" },
-};
+// The gallery/form themselves live in providers/ProviderSetup.tsx, shared with
+// Settings ▸ Models (UX-021) so the two surfaces can't drift.
+// Replayable from Settings ▸ General ▸ "Run setup again".
 
 // Step 2's mini gallery (§39): managed connectors with LIVE prod OAuth apps only.
 // gmail + google_calendar ship grayed "Coming soon" — both ride the same Google
@@ -47,125 +28,27 @@ const KEY_HELP: Record<string, { url: string; label: string }> = {
 const TOOLS_ACTIVE = ["outlook", "slack", "github", "notion", "hubspot"];
 const TOOLS_SOON = ["gmail", "google_calendar"];
 
-type Verify = { state: "idle" | "testing" | "ok" | "error"; msg?: string };
-
-/** Brand chip: always a light plate so multicolor marks read on any theme. */
-function ProviderMark({ name, title, size = 32 }: { name: string; title: string; size?: number }) {
-  const url = PROVIDER_LOGOS[name];
-  return (
-    <span
-      className="rounded-lg border border-line grid place-items-center shrink-0"
-      style={{ width: size, height: size, background: "#f6f7f8" }}
-    >
-      {url ? (
-        <img src={url} alt="" style={{ width: size * 0.6, height: size * 0.6 }} />
-      ) : (
-        <span className="text-[13px] font-semibold text-muted">{title[0]}</span>
-      )}
-    </span>
-  );
-}
-
 export function Onboarding({ onDone }: { onDone: (next?: "work" | "gallery" | "automations") => void }) {
   const [step, setStep] = useState(0);
 
-  // -- step 1: model (provider gallery ⇄ key form) -------------------------------
-  const [providers, setProviders] = useState<ProviderInfo[]>([]);
-  // null = the gallery; a provider name = that provider's key form.
-  const [sel, setSel] = useState<string | null>(null);
-  const [fields, setFields] = useState<Record<string, string>>({});
-  const [dirty, setDirty] = useState(false);
-  const [showEndpoint, setShowEndpoint] = useState(false);
-  const [verify, setVerify] = useState<Verify>({ state: "idle" });
+  // -- step 1: model (provider gallery ⇄ key form, shared machinery) ---------------
+  const ps = useProviderSetup();
   const [skipConfirm, setSkipConfirm] = useState(false);
-  // Keyless providers (Ollama) report configured without proving anything runs —
-  // a passing Detect this session is what arms Next for them.
-  const [keylessOk, setKeylessOk] = useState<Set<string>>(new Set());
-  const backTimer = useRef<number | null>(null);
-
-  const refreshProviders = () =>
-    getProviders()
-      .then(setProviders)
-      .catch(() => {});
-  useEffect(() => {
-    refreshProviders();
-    return () => {
-      if (backTimer.current) window.clearTimeout(backTimer.current);
-    };
-  }, []);
-
-  const info = providers.find((p) => p.name === sel);
-  const credentialed = !!info?.configured && !!info?.needs_key;
-
-  // Unsaved per-provider input survives switching cards (owner complaint 2026-07-16).
-  const [drafts, setDrafts] = useState<Record<string, Record<string, string>>>({});
-
-  const openProvider = (name: string) => {
-    const p = providers.find((x) => x.name === name);
-    if (sel) setDrafts((d) => ({ ...d, [sel]: fields }));
-    const draft = drafts[name];
-    const next: Record<string, string> = {};
-    for (const f of p?.fields || []) next[f.key] = draft?.[f.key] || p?.values?.[f.key] || f.default || "";
-    setSel(name);
-    setFields(next);
-    setDirty(!!draft && Object.values(draft).some(Boolean));
-    setVerify({ state: "idle" });
-    setShowEndpoint(false);
-  };
-
-  const backToGallery = () => {
-    if (sel) setDrafts((d) => ({ ...d, [sel]: fields }));
-    setSel(null);
-    setVerify({ state: "idle" });
-  };
-
-  // Test = verify AND save AND return (§39: a passing Test auto-saves and takes
-  // you back to the gallery, where the card now wears its ✓ — no extra clicks).
-  const runTestAndSave = async (): Promise<boolean> => {
-    if (!sel) return false;
-    setVerify({ state: "testing" });
-    const res = await verifyProvider(sel, fields).catch(() => ({ ok: false, error: "unreachable" }));
-    if (!res.ok) {
-      setVerify({ state: "error", msg: res.error || "couldn't verify" });
-      return false;
-    }
-    if (dirty || !info?.configured) await setProvider(sel, fields).catch(() => {});
-    if (!info?.needs_key) setKeylessOk((s) => new Set(s).add(sel));
-    setVerify({ state: "ok" });
-    setDirty(false);
-    setDrafts((d) => ({ ...d, [sel]: {} }));
-    await refreshProviders();
-    // Let the in-field "✓ Tested & saved" register, then slide home.
-    backTimer.current = window.setTimeout(backToGallery, 900);
-    return true;
-  };
 
   const anyReady =
-    providers.some((p) => p.configured && p.needs_key) || keylessOk.size > 0;
+    ps.providers.some((p) => p.configured && p.needs_key) || ps.keylessOk.size > 0;
   // In the form with typed-but-untested input, Next verifies+saves first (tester
   // catch 2026-07-12: a manual Test-then-Continue two-step reads as a puzzle).
-  const secretFilled = (info?.fields || []).every((f) => !f.secret || (fields[f.key] || "").trim());
-  const nextFromForm = !!sel && dirty && secretFilled;
+  const nextFromForm = !!ps.sel && ps.dirty && ps.secretFilled;
   const canNext = anyReady || nextFromForm;
 
   const advance = async () => {
-    if (nextFromForm && !credentialed) {
-      if (backTimer.current) window.clearTimeout(backTimer.current);
-      if (!(await runTestAndSave())) return;
+    if (nextFromForm && !ps.credentialed) {
+      ps.cancelBackTimer();
+      if (!(await ps.runTestAndSave())) return;
     }
     setStep(1);
   };
-
-  const providerStatus = (p: ProviderInfo) =>
-    p.configured && p.needs_key ? (
-      <span className="block text-[11.5px] text-ok font-medium">✓ Connected</span>
-    ) : !p.needs_key ? (
-      <span className="block text-[11.5px] text-faint">
-        {keylessOk.has(p.name) ? <span className="text-ok font-medium">✓ Running</span> : "No key needed"}
-      </span>
-    ) : (
-      <span className="block text-[11.5px] text-faint">Not set up</span>
-    );
 
   // -- step 2: connect your everyday tools (§39 two-state page) -------------------
   const [connectors, setConnectors] = useState<Connector[]>([]);
@@ -209,9 +92,6 @@ export function Onboarding({ onDone }: { onDone: (next?: "work" | "gallery" | "a
   };
 
   // -- shared bits ----------------------------------------------------------------
-  const label = "block text-[12px] text-muted mt-3 mb-1";
-  const input =
-    "w-full px-3 py-2 rounded-lg border bg-panel text-[13.5px] outline-none focus:border-accent";
   const card =
     "flex items-center gap-2.5 rounded-xl border border-line bg-panel px-3 py-2.5 text-left hover:border-lineStrong transition-colors";
   const dots = (
@@ -221,11 +101,6 @@ export function Onboarding({ onDone }: { onDone: (next?: "work" | "gallery" | "a
       ))}
     </div>
   );
-
-  const ordered = [...providers].sort((a, b) => providerRank(a.name) - providerRank(b.name));
-  // The in-field saved state (§39): green border + pill INSIDE the key box — shown
-  // for stored credentials and fresh test-passes alike; typing clears it.
-  const savedState = (credentialed && !dirty) || verify.state === "ok";
 
   return (
     <div className="fixed inset-0 z-50 bg-ink/30 grid place-items-center" data-testid="onboarding">
@@ -243,151 +118,15 @@ export function Onboarding({ onDone }: { onDone: (next?: "work" | "gallery" | "a
               key and your data stay on this Mac.
             </p>
 
-            {!sel ? (
+            {!ps.sel ? (
               /* ---- the provider GALLERY ---- */
               <div className="flex-1 min-h-0 overflow-y-auto pr-1" data-testid="ob-provider-gallery">
-                <div className="grid grid-cols-2 gap-2.5">
-                  {ordered.map((p) => (
-                    <button
-                      key={p.name}
-                      className={card}
-                      data-testid={`ob-provider-${p.name}`}
-                      onClick={() => openProvider(p.name)}
-                    >
-                      <ProviderMark name={p.name} title={p.title} />
-                      <span className="min-w-0 flex-1">
-                        <span className="block text-[13px] font-semibold leading-tight truncate">
-                          {p.title}
-                        </span>
-                        {providerStatus(p)}
-                      </span>
-                      <span className="text-faint text-[14px]">›</span>
-                    </button>
-                  ))}
-                </div>
+                <ProviderCards ps={ps} tp="ob" />
               </div>
             ) : (
               /* ---- one provider's key form, same box ---- */
               <div className="flex-1 min-h-0 overflow-y-auto pr-1">
-                <button
-                  className="text-[12.5px] text-muted hover:text-ink"
-                  onClick={backToGallery}
-                  data-testid="ob-back"
-                >
-                  ‹ All providers
-                </button>
-                <div className="flex items-center gap-3 mt-3 mb-1">
-                  <ProviderMark name={info?.name || ""} title={info?.title || ""} size={36} />
-                  <span className="min-w-0">
-                    <span className="block text-[15px] font-semibold leading-tight">{info?.title}</span>
-                    {info ? providerStatus(info) : null}
-                  </span>
-                </div>
-                {info?.blurb && <p className="text-[11.5px] text-faint mt-1">{info.blurb}</p>}
-
-                {(info?.fields || []).map((f) => {
-                  const keyed = (info?.fields || []).some((x) => x.secret);
-                  // ANY base_url on a keyed provider is an expert option: a quiet disclosure
-                  // (owner call 2026-07-18: no explainer copy — its users know what it's for).
-                  if (f.key === "base_url" && keyed && !showEndpoint) {
-                    return (
-                      <button
-                        key={f.key}
-                        className="block self-start text-[12.5px] text-muted hover:text-ink mt-4"
-                        onClick={() => setShowEndpoint(true)}
-                        data-testid="ob-endpoint-link"
-                      >
-                        Custom endpoint ⌄
-                      </button>
-                    );
-                  }
-                  const testable =
-                    (f.secret && f.key === (info?.fields || []).find((x) => x.secret)?.key) ||
-                    (!keyed && f.key === (info?.fields || [])[0]?.key);
-                  return (
-                    <div key={f.key}>
-                      <label className={label}>{f.label}</label>
-                      <div className="flex gap-2">
-                        <div className="relative flex-1 min-w-0">
-                          <input
-                            className={
-                              input +
-                              (savedState && f.secret ? " border-ok pr-32" : " border-line")
-                            }
-                            type={f.secret ? "password" : "text"}
-                            placeholder={f.secret && credentialed && !dirty ? "••••••••" : f.placeholder}
-                            value={fields[f.key] || ""}
-                            data-testid={`ob-field-${f.key}`}
-                            onChange={(e) => {
-                              setFields((cur) => ({ ...cur, [f.key]: e.target.value }));
-                              setDirty(true);
-                              setVerify({ state: "idle" });
-                            }}
-                          />
-                          {/* §39: state lives IN the field — no status lines below. */}
-                          {savedState && f.secret && (
-                            <span
-                              className="absolute right-2 top-1/2 -translate-y-1/2 text-[11px] font-medium text-ok bg-okSoft rounded-full px-2 py-0.5 pointer-events-none"
-                              data-testid="ob-saved-pill"
-                            >
-                              ✓ Tested &amp; saved
-                            </span>
-                          )}
-                          {savedState && !f.secret && testable && (
-                            <span
-                              className="absolute right-2 top-1/2 -translate-y-1/2 text-[11px] font-medium text-ok bg-okSoft rounded-full px-2 py-0.5 pointer-events-none"
-                              data-testid="ob-saved-pill"
-                            >
-                              ✓ Detected
-                            </span>
-                          )}
-                        </div>
-                        {testable && (
-                          <button
-                            className="px-4 rounded-lg border border-line text-[13px] font-medium text-ink hover:border-lineStrong shrink-0 disabled:opacity-40"
-                            onClick={() => runTestAndSave()}
-                            disabled={
-                              verify.state === "testing" || (f.secret && !secretFilled && !credentialed)
-                            }
-                            data-testid="ob-test"
-                          >
-                            {verify.state === "testing" ? "…" : info?.needs_key ? "Test" : "Detect"}
-                          </button>
-                        )}
-                      </div>
-                      {f.help && !f.secret && <p className="text-[11.5px] text-faint mt-1">{f.help}</p>}
-                    </div>
-                  );
-                })}
-
-                {info?.needs_key && KEY_HELP[sel] && (
-                  <p className="text-[11.5px] text-faint mt-2">
-                    No key yet?{" "}
-                    <button
-                      className="text-muted underline decoration-line underline-offset-2 hover:text-ink"
-                      onClick={() => openExternal(KEY_HELP[sel].url)}
-                    >
-                      Create one at {KEY_HELP[sel].label} ↗
-                    </button>{" "}
-                    — takes about a minute.
-                  </p>
-                )}
-                {info && !info.needs_key && (
-                  <p className="text-[11.5px] text-faint mt-2">
-                    No API key needed — Ollama runs models on this Mac.{" "}
-                    <button
-                      className="text-muted underline decoration-line underline-offset-2 hover:text-ink"
-                      onClick={() => openExternal("https://ollama.com/download")}
-                    >
-                      Install Ollama ↗
-                    </button>
-                  </p>
-                )}
-
-                {/* Error line: fixed height so failures never reflow the form. */}
-                <div className="mt-3 min-h-[19px] text-[12.5px]">
-                  {verify.state === "error" && <span className="text-warnInk">{verify.msg}</span>}
-                </div>
+                <ProviderForm ps={ps} tp="ob" />
               </div>
             )}
 
@@ -407,11 +146,11 @@ export function Onboarding({ onDone }: { onDone: (next?: "work" | "gallery" | "a
               )}
               <button
                 className="ml-auto px-6 py-2 rounded-full bg-ink text-panel text-[13px] disabled:opacity-40"
-                disabled={!canNext || verify.state === "testing"}
+                disabled={!canNext || ps.verify.state === "testing"}
                 onClick={advance}
                 data-testid="ob-continue"
               >
-                {verify.state === "testing" ? "Checking…" : "Next"}
+                {ps.verify.state === "testing" ? "Checking…" : "Next"}
               </button>
             </div>
             <p className="text-[11px] text-faint mt-3">

--- a/platform/surfaces/gui/src/components/Onboarding.tsx
+++ b/platform/surfaces/gui/src/components/Onboarding.tsx
@@ -22,12 +22,19 @@ import { Spinner } from "./AutomationQuickstart";
 // Settings ▸ Models (UX-021) so the two surfaces can't drift.
 // Replayable from Settings ▸ General ▸ "Run setup again".
 
-// Step 2's mini gallery (§39): managed connectors with LIVE prod OAuth apps only.
-// attio promoted from the "30+ more" footnote (owner, 2026-07-19): six active +
-// two coming-soon keeps the 2-col grid even, with the grayed pair together on the
-// last row. gmail + google_calendar ship grayed "Coming soon" — both ride the
-// same Google app, gated on Google verification/CASA; flip to ACTIVE when it lands.
-const TOOLS_ACTIVE = ["outlook", "slack", "github", "notion", "hubspot", "attio"];
+// Step 2's benefit rows (§41): managed connectors with LIVE prod OAuth apps only,
+// each framed by the job it does (detail copy stays ONE line even with a Connect
+// pill — wrap made rows jump between states). gmail + google_calendar ship as one
+// combined grayed "Coming soon" row — both ride the same Google app, gated on
+// Google verification/CASA; give them rows when it lands.
+const TOOL_ROWS = [
+  { name: "outlook", benefit: "Stay on top of email", detail: "Outlook — triage, summarize, draft, send." },
+  { name: "slack", benefit: "Keep up with Slack", detail: "Slack — catch up, answer mentions, post updates." },
+  { name: "github", benefit: "Ship code", detail: "GitHub — review PRs, watch issues, reply to @mentions." },
+  { name: "notion", benefit: "Keep your notes in reach", detail: "Notion — search pages, query databases, draft docs." },
+  { name: "hubspot", benefit: "Keep the CRM current", detail: "HubSpot — update deals, log notes, prep calls." },
+  { name: "attio", benefit: "Track every relationship", detail: "Attio — search records, read timelines, log notes." },
+];
 const TOOLS_SOON = ["gmail", "google_calendar"];
 
 export function Onboarding({ onDone }: { onDone: (next?: "work" | "gallery" | "automations") => void }) {
@@ -94,8 +101,6 @@ export function Onboarding({ onDone }: { onDone: (next?: "work" | "gallery" | "a
   };
 
   // -- shared bits ----------------------------------------------------------------
-  const card =
-    "flex items-center gap-2.5 rounded-xl border border-line bg-panel px-3 py-2.5 text-left hover:border-lineStrong transition-colors";
   const dots = (
     <div className="flex justify-center gap-2 mb-6">
       {[0, 1, 2].map((i) => (
@@ -108,7 +113,7 @@ export function Onboarding({ onDone }: { onDone: (next?: "work" | "gallery" | "a
     <div className="fixed inset-0 z-50 bg-ink/30 grid place-items-center" data-testid="onboarding">
       {/* FIXED height across all three steps (owner call 2026-07-12, reaffirmed §39: the
           modal must never resize — the gallery⇄form swap happens inside this box). */}
-      <div className="w-[600px] max-w-[92vw] h-[700px] max-h-[88vh] rounded-2xl border border-line bg-panel shadow-2xl p-8 flex flex-col">
+      <div className="w-[600px] max-w-[92vw] h-[560px] max-h-[88vh] rounded-2xl border border-line bg-panel shadow-2xl p-8 flex flex-col">
         {dots}
 
         {step === 0 && (
@@ -162,122 +167,129 @@ export function Onboarding({ onDone }: { onDone: (next?: "work" | "gallery" | "a
         )}
 
         {step === 1 && (
-          /* §39 (owner design, 2026-07-18): a two-state page. Pre-sign-in it makes the case —
-             tools are what turn a chatbot into a coworker — and asks for the sign-in that
-             makes connecting one click. Post-sign-in the SAME region becomes a mini connector
-             gallery with live one-click connects, so the headline's promise is kept on this
-             page, resolving §29's promise-with-no-action concern. */
+          /* §41 (owner design, 2026-07-19, supersedes §39's card gallery): BENEFIT ROWS are
+             the connect surface — one row set, two states, ZERO layout shift. Pre-sign-in the
+             rows make the case and a pinned band asks for sign-in; after sign-in the band's
+             slot keeps its place but flips to a green congrats, and every row grows a quiet
+             Connect pill. The gated Google pair is ONE combined grayed row. */
           <section data-testid="ob-step-tools" className="flex-1 min-h-0 flex flex-col">
             <h1 className="text-[19px] font-semibold">Connect your everyday tools</h1>
-            <p className="text-[13px] text-muted mt-0.5 mb-4">
-              A coworker that can only chat can only advise. Connected to your email, calendar,
-              CRM, and code, it can do the actual work — triage the inbox, prep the meeting,
-              update the pipeline, review the PR.
+            <p className="text-[13px] text-muted mt-0.5 mb-3">
+              Chat can only advise. Connected, your coworker does the actual work:
             </p>
 
-            {!cloud?.signed_in ? (
-              <div className="flex-1 min-h-0 overflow-y-auto pr-1">
-                <div className="flex items-center gap-2.5 mb-4">
-                  {TOOLS_ACTIVE.map((name) => {
-                    const c = connectors.find((x) => x.name === name);
-                    return c ? <ConnectorBadge key={name} connector={c} size={38} title={c.title} /> : null;
-                  })}
-                </div>
-                <div className="rounded-xl2 border border-line bg-paper px-4 py-3.5 text-[12.5px] text-muted">
-                  <span className="block text-[13px] text-ink font-medium mb-0.5">
-                    One click, keys handled
-                  </span>
-                  Sign in to OpenWorker and connecting is one click — OAuth and tokens for 20+
-                  integrations are handled for you, and tokens stay local on this Mac. No
-                  digging through dev consoles for API keys.
-                </div>
-                <div className="mt-4 min-h-[36px]">
-                  {signinPhase && (
-                    <span className="inline-flex items-center gap-2 text-[13px] text-muted">
-                      <Spinner />
-                      {signinPhase === "opening" ? "Opening browser…" : "Waiting for sign-in…"}
-                      {signinPhase === "waiting" && (
-                        <span className="text-[11.5px] text-faint">
-                          finish in your browser — this page updates by itself ·{" "}
-                          <button
-                            className="underline hover:text-muted"
-                            onClick={() => setSigninPhase(null)}
-                            data-testid="ob-signin-cancel"
-                          >
-                            Cancel
-                          </button>
-                        </span>
-                      )}
+            <div className="flex-1 min-h-0 overflow-y-auto pr-1" data-testid="ob-tool-gallery">
+              {TOOL_ROWS.map(({ name, benefit, detail }) => {
+                const c = connectors.find((x) => x.name === name);
+                if (!c) return null;
+                return (
+                  <div
+                    key={name}
+                    className="flex items-center gap-3 py-2 border-b border-paper last:border-0"
+                    data-testid={`ob-tool-${name}`}
+                  >
+                    <ConnectorBadge connector={c} size={34} title={c.title} />
+                    <span className="min-w-0 flex-1">
+                      <span className="block text-[13.5px] font-semibold leading-tight">{benefit}</span>
+                      <span className="block text-[12px] text-muted truncate">{detail}</span>
                     </span>
-                  )}
-                </div>
+                    {cloud?.signed_in &&
+                      (c.connected ? (
+                        <span className="text-[12px] text-ok font-medium shrink-0">✓ Connected</span>
+                      ) : pendingTool === name ? (
+                        <span className="text-[12px] text-muted shrink-0">Check your browser…</span>
+                      ) : (
+                        <button
+                          className="shrink-0 rounded-full border border-line px-4 py-1.5 text-[12.5px] font-medium hover:border-lineStrong"
+                          onClick={() => startTool(name)}
+                        >
+                          Connect
+                        </button>
+                      ))}
+                  </div>
+                );
+              })}
+              {/* The gated Google pair: one combined grayed row, both states (§41). */}
+              <div className="flex items-center gap-3 py-2" data-testid="ob-tool-google-soon">
+                <span className="flex gap-1.5 opacity-40 grayscale">
+                  {TOOLS_SOON.map((n) => {
+                    const c = connectors.find((x) => x.name === n);
+                    return c ? <ConnectorBadge key={n} connector={c} size={28} title={c.title} /> : null;
+                  })}
+                </span>
+                <span className="min-w-0 flex-1">
+                  <span className="block text-[13.5px] font-semibold leading-tight text-faint">
+                    Gmail &amp; Google Calendar
+                  </span>
+                  <span className="block text-[12px] text-faint truncate">
+                    Coming soon — pending Google&rsquo;s app verification.
+                  </span>
+                </span>
+                {cloud?.signed_in && <span className="text-[11.5px] text-faint shrink-0">Coming soon</span>}
+              </div>
+            </div>
+
+            {/* The band is PINNED outside the scroll area and its slot never moves: the ask
+                pre-sign-in, a green congrats after — zero layout shift at the moment the user
+                returns from the browser (§41). */}
+            {!cloud?.signed_in ? (
+              <div className="mt-3.5 rounded-xl border border-line bg-paper px-4 py-3 flex items-center gap-3.5 shrink-0">
+                <span className="flex-1 text-[12.5px] text-muted leading-snug">
+                  <span className="block text-[13px] font-semibold text-ink mb-0.5">
+                    Sign in for one-click connections
+                  </span>
+                  OpenWorker handles the OAuth for 20+ tools — no dev consoles, no pasted keys.
+                  Tokens stay on this Mac.
+                </span>
+                {signinPhase ? (
+                  <span className="inline-flex items-center gap-2 text-[12.5px] text-muted shrink-0">
+                    <Spinner />
+                    {signinPhase === "opening" ? (
+                      "Opening browser…"
+                    ) : (
+                      <>
+                        Waiting…{" "}
+                        <button
+                          className="underline hover:text-ink"
+                          onClick={() => setSigninPhase(null)}
+                          data-testid="ob-signin-cancel"
+                        >
+                          Cancel
+                        </button>
+                      </>
+                    )}
+                  </span>
+                ) : (
+                  <button
+                    className="shrink-0 px-5 py-2 rounded-full bg-ink text-panel text-[13px]"
+                    onClick={async () => {
+                      setSigninPhase("opening");
+                      await cloudLogin().catch(() => {});
+                      setSigninPhase("waiting");
+                    }}
+                    data-testid="ob-cloud-signin"
+                  >
+                    Sign in
+                  </button>
+                )}
               </div>
             ) : (
-              /* ---- signed in: the mini connector gallery (§39) ---- */
-              <div className="flex-1 min-h-0 overflow-y-auto pr-1">
-                <p className="text-[12.5px] text-ok mb-3" data-testid="ob-tools-signedin">
-                  ✓ Signed in{cloud.account ? ` as ${cloud.account}` : ""}
-                </p>
-                <div className="grid grid-cols-2 gap-2.5" data-testid="ob-tool-gallery">
-                  {[...TOOLS_ACTIVE, ...TOOLS_SOON].map((name) => {
-                    const c = connectors.find((x) => x.name === name);
-                    if (!c) return null;
-                    const soon = TOOLS_SOON.includes(name);
-                    if (soon)
-                      return (
-                        /* Grayed "Coming soon" (§39): the Google pair is gated on Google
-                           verification — present-but-gray says "coming", not "missing".
-                           The label is STATIC (owner critique 2026-07-19: hover-only read
-                           as a broken card), mirroring the active cards' status line. */
-                        <div
-                          key={name}
-                          className="flex items-center gap-2.5 rounded-xl border border-line bg-panel px-3 py-2.5"
-                          data-testid={`ob-tool-${name}`}
-                        >
-                          <span className="opacity-40 grayscale">
-                            <ConnectorBadge connector={c} size={34} title={c.title} />
-                          </span>
-                          <span className="min-w-0 flex-1">
-                            <span className="block text-[13px] font-semibold leading-tight text-faint">
-                              {c.title}
-                            </span>
-                            <span className="block text-[11.5px] text-faint">Coming soon</span>
-                          </span>
-                        </div>
-                      );
-                    return (
-                      <button
-                        key={name}
-                        className={card}
-                        data-testid={`ob-tool-${name}`}
-                        onClick={() => !c.connected && startTool(name)}
-                      >
-                        <ConnectorBadge connector={c} size={34} title={c.title} />
-                        <span className="min-w-0 flex-1">
-                          <span className="block text-[13px] font-semibold leading-tight">{c.title}</span>
-                          {c.connected ? (
-                            <span className="block text-[11.5px] text-ok font-medium">✓ Connected</span>
-                          ) : pendingTool === name ? (
-                            <span className="block text-[11.5px] text-muted">Check your browser…</span>
-                          ) : (
-                            <span className="block text-[11.5px] text-faint">One click</span>
-                          )}
-                        </span>
-                      </button>
-                    );
-                  })}
-                </div>
+              <div
+                className="mt-3.5 rounded-xl border border-line bg-okSoft px-4 py-3 shrink-0"
+                data-testid="ob-tools-signedin"
+              >
+                <span className="block text-[13px] font-semibold text-ok mb-0.5">
+                  🎉 You&rsquo;re signed in{cloud.account ? ` as ${cloud.account}` : ""}
+                </span>
+                <span className="block text-[12.5px] text-muted">
+                  Connect a tool above with one click — or add them anytime later from the
+                  Connectors page.
+                </span>
               </div>
             )}
 
-            <div className="flex items-center gap-3 pt-5">
-              <button
-                className="text-[12.5px] text-faint hover:text-muted text-left"
-                onClick={() => setStep(2)}
-                data-testid="ob-tools-skip"
-              >
-                {cloud?.signed_in ? "Set up later" : "Skip — I’ll use my own API tokens"}
-              </button>
+            {/* One footer button, one slot: quiet skip pre-sign-in, black Next after. */}
+            <div className="flex items-center mt-3.5">
               {cloud?.signed_in ? (
                 <button
                   className="ml-auto px-6 py-2 rounded-full bg-ink text-panel text-[13px] shrink-0"
@@ -288,23 +300,17 @@ export function Onboarding({ onDone }: { onDone: (next?: "work" | "gallery" | "a
                 </button>
               ) : (
                 <button
-                  className="ml-auto px-6 py-2 rounded-full bg-accent text-white text-[13px] shrink-0 disabled:opacity-40"
-                  disabled={signinPhase === "opening"}
-                  onClick={async () => {
-                    setSigninPhase("opening");
-                    await cloudLogin().catch(() => {});
-                    setSigninPhase("waiting");
-                  }}
-                  data-testid="ob-cloud-signin"
+                  className="ml-auto px-5 py-2 rounded-full border border-line text-[13px] text-muted hover:text-ink hover:border-lineStrong shrink-0"
+                  onClick={() => setStep(2)}
+                  data-testid="ob-tools-skip"
                 >
-                  Sign in
+                  Continue without sign-in
                 </button>
               )}
             </div>
             <p className="text-[11px] text-faint mt-3">
-              {cloud?.signed_in
-                ? "30+ more tools on the Connectors page — add or remove anytime."
-                : "Even signed in, your data flows vendor → this Mac — the cloud only brokers the connection."}
+              30+ more tools on the Connectors page — add or remove anytime. Tokens stay on
+              this Mac.
             </p>
           </section>
         )}

--- a/platform/surfaces/gui/src/components/Onboarding.tsx
+++ b/platform/surfaces/gui/src/components/Onboarding.tsx
@@ -23,9 +23,11 @@ import { Spinner } from "./AutomationQuickstart";
 // Replayable from Settings ▸ General ▸ "Run setup again".
 
 // Step 2's mini gallery (§39): managed connectors with LIVE prod OAuth apps only.
-// gmail + google_calendar ship grayed "Coming soon" — both ride the same Google
-// app, gated on Google verification/CASA; flip them into ACTIVE when it lands.
-const TOOLS_ACTIVE = ["outlook", "slack", "github", "notion", "hubspot"];
+// attio promoted from the "30+ more" footnote (owner, 2026-07-19): six active +
+// two coming-soon keeps the 2-col grid even, with the grayed pair together on the
+// last row. gmail + google_calendar ship grayed "Coming soon" — both ride the
+// same Google app, gated on Google verification/CASA; flip to ACTIVE when it lands.
+const TOOLS_ACTIVE = ["outlook", "slack", "github", "notion", "hubspot", "attio"];
 const TOOLS_SOON = ["gmail", "google_calendar"];
 
 export function Onboarding({ onDone }: { onDone: (next?: "work" | "gallery" | "automations") => void }) {
@@ -223,19 +225,23 @@ export function Onboarding({ onDone }: { onDone: (next?: "work" | "gallery" | "a
                     const soon = TOOLS_SOON.includes(name);
                     if (soon)
                       return (
-                        /* Grayed "Coming soon" (§39): the whole Google trio is gated on
-                           Google verification — present-but-gray says "coming", not "missing". */
+                        /* Grayed "Coming soon" (§39): the Google pair is gated on Google
+                           verification — present-but-gray says "coming", not "missing".
+                           The label is STATIC (owner critique 2026-07-19: hover-only read
+                           as a broken card), mirroring the active cards' status line. */
                         <div
                           key={name}
-                          className="group relative flex items-center gap-2.5 rounded-xl border border-line bg-panel px-3 py-2.5"
+                          className="flex items-center gap-2.5 rounded-xl border border-line bg-panel px-3 py-2.5"
                           data-testid={`ob-tool-${name}`}
                         >
                           <span className="opacity-40 grayscale">
                             <ConnectorBadge connector={c} size={34} title={c.title} />
                           </span>
-                          <span className="block text-[13px] font-semibold text-faint">{c.title}</span>
-                          <span className="absolute -top-2 right-2.5 rounded-full bg-ink text-panel text-[10.5px] px-2 py-0.5 opacity-0 group-hover:opacity-100 transition-opacity pointer-events-none">
-                            Coming soon
+                          <span className="min-w-0 flex-1">
+                            <span className="block text-[13px] font-semibold leading-tight text-faint">
+                              {c.title}
+                            </span>
+                            <span className="block text-[11.5px] text-faint">Coming soon</span>
                           </span>
                         </div>
                       );

--- a/platform/surfaces/gui/src/components/SettingsView.tsx
+++ b/platform/surfaces/gui/src/components/SettingsView.tsx
@@ -39,6 +39,7 @@ import { PanelHead } from "./IntegrationsView";
 import { ModelsTab } from "./ManageTabs";
 import { GalleryModal } from "./GalleryModal";
 import { PersonasTab } from "./PersonasTab";
+import { showPersonas } from "../flags";
 
 // Settings, restructured (Option 2) into a full-page surface that mirrors IntegrationsView's shell:
 // a left sub-nav (Appearance · Files · Models · Personas) + centered panel, replacing the old
@@ -71,15 +72,21 @@ export function SettingsView({
   initialTab?: SetTab;
   onOpenPersona?: (id: string) => void;
 }) {
-  const [tab, setTab] = useState<SetTab>(initialTab ?? "appearance");
+  // Personas is flag-gated (hidden for launch) — filter the tab AND coerce a stale
+  // deep-link to it (openSettings("personas") callers) so the page never opens on a
+  // section with no nav entry.
+  const personas = showPersonas();
+  const tabs = personas ? SET_TABS : SET_TABS.filter((t) => t.key !== "personas");
+  const wanted = initialTab && (personas || initialTab !== "personas") ? initialTab : "appearance";
+  const [tab, setTab] = useState<SetTab>(wanted);
 
   return (
     <main className="flex-1 min-w-0 flex bg-paper">
-      <nav className="w-[208px] shrink-0 border-r border-line bg-panel/40 px-3 py-4">
+      <nav className="page-subnav w-[208px] shrink-0 border-r border-line bg-panel/40 px-3 py-4">
         <div className="px-2 text-[13.5px] font-semibold mb-3 flex items-center gap-2">
           <Icon name="gear" size={16} /> Settings
         </div>
-        {SET_TABS.map((t) => {
+        {tabs.map((t) => {
           const active = tab === t.key;
           return (
             <button

--- a/platform/surfaces/gui/src/components/SettingsView.tsx
+++ b/platform/surfaces/gui/src/components/SettingsView.tsx
@@ -46,7 +46,9 @@ import { showPersonas } from "../flags";
 // top-tab ManageModal. Local/app concerns live here; anything external (Connectors, Messaging, MCP,
 // Activity) stays under Integrations. Appearance + Files are re-skinned to the mock's Tailwind idiom;
 // Models + Personas host the existing tab components inside the page shell (field re-skin to follow).
-type SetTab = "appearance" | "files" | "models" | "voice" | "personas";
+// "appearance" is the General tab's stable key — callers deep-link with it, so the
+// rename (UX-021) changed only the label. "files" folded into General as a card.
+type SetTab = "appearance" | "models" | "voice" | "personas";
 
 const CARD = "rounded-xl2 border border-line bg-panel";
 const FIELD_LABEL = "text-[12.5px] font-medium text-ink";
@@ -57,9 +59,8 @@ const BTN_ACCENT = "text-[12.5px] px-3 py-2 rounded-lg bg-accent text-white shri
 const BTN_BORDERED =
   "text-[12.5px] px-3 py-2 rounded-lg border border-line bg-paper hover:border-lineStrong shrink-0";
 
-const SET_TABS: { key: SetTab; label: string; icon: "sliders" | "folder" | "code" | "mic" | "sparkle" }[] = [
-  { key: "appearance", label: "Appearance", icon: "sliders" },
-  { key: "files", label: "Files", icon: "folder" },
+const SET_TABS: { key: SetTab; label: string; icon: "sliders" | "code" | "mic" | "sparkle" }[] = [
+  { key: "appearance", label: "General", icon: "sliders" },
   { key: "models", label: "Models", icon: "code" },
   { key: "voice", label: "Voice input", icon: "mic" },
   { key: "personas", label: "Personas", icon: "sparkle" },
@@ -107,15 +108,18 @@ export function SettingsView({
         <div className="max-w-3xl mx-auto px-7 py-6">
           {tab === "appearance" ? (
             <AppearanceSection />
-          ) : tab === "files" ? (
-            <FilesSection />
           ) : tab === "models" ? (
             <section>
               <PanelHead
                 title="Models"
-                sub="API keys and the models offered in the composer's picker. Keys are stored locally, never sent to the model."
+                sub="Providers and the models offered in the composer's picker. Keys are stored only on this computer."
               />
               <ModelsTab />
+              {/* Token savings is model-spend behavior, so it lives here (UX-021),
+                  not under General. */}
+              <div className="mt-6">
+                <TokenSavingsCard />
+              </div>
             </section>
           ) : tab === "voice" ? (
             <VoiceInputSection />
@@ -406,7 +410,7 @@ function AppearanceSection() {
 
   return (
     <section>
-      <PanelHead title="Appearance" sub="How OpenWorker looks and behaves on this machine." />
+      <PanelHead title="General" sub="How OpenWorker looks and behaves on this machine." />
 
       <div className={CARD + " p-4 mb-4"}>
         <div className={FIELD_LABEL}>Theme</div>
@@ -422,7 +426,7 @@ function AppearanceSection() {
 
       <SidebarCard />
 
-      <TokenSavingsCard />
+      <FilesCard />
 
       <TelemetryCard />
 
@@ -446,23 +450,24 @@ function AppearanceSection() {
         </div>
       )}
 
-      {/* The onboarding replay entry (§24) — every build, not just desktop: the browser dev
-          shell runs the same first-run flow, and owner testing replays it here. */}
+      {/* One card for the app-lifecycle actions (UX-021): the onboarding replay (§24 —
+          every build, the browser dev shell runs the same first-run flow) and, on
+          desktop, the manual update check (launch also checks automatically). */}
       <div className={CARD + " p-4 mt-4"}>
-        <div className={FIELD_LABEL + " mb-2"}>Setup</div>
-        <button className={BTN_BORDERED} onClick={runSetupAgain}>
-          Run setup again
-        </button>
+        <div className={FIELD_LABEL + " mb-2"}>Setup &amp; updates</div>
+        <div className="flex items-center gap-2">
+          <button className={BTN_BORDERED} onClick={runSetupAgain}>
+            Run setup again
+          </button>
+          {desktop && <UpdateInline />}
+        </div>
         <div className={FIELD_HELP}>Replays the first-run setup: model, first automation, tips.</div>
       </div>
-
-      {/* Manual update check (desktop shell only; launch also checks automatically). */}
-      {desktop && <UpdateCard />}
     </section>
   );
 }
 
-function UpdateCard() {
+function UpdateInline() {
   const [state, setState] = useState<"idle" | "checking" | "none" | "found" | "installing" | "error">("idle");
   const [version, setVersion] = useState("");
 
@@ -491,8 +496,7 @@ function UpdateCard() {
   };
 
   return (
-    <div className={CARD + " p-4 mt-4"}>
-      <div className={FIELD_LABEL + " mb-2"}>Updates</div>
+    <span className="inline-flex items-center gap-2.5">
       {state === "found" ? (
         <button className={BTN_BORDERED} onClick={install} data-testid="settings-update-install">
           Update to v{version} and restart
@@ -507,16 +511,16 @@ function UpdateCard() {
           {state === "checking" ? "Checking…" : "Check for updates"}
         </button>
       )}
-      <div className={FIELD_HELP}>
-        {state === "none"
-          ? "You're on the latest version."
-          : state === "error"
-            ? "Couldn't check right now — try again later."
-            : state === "installing"
-              ? "Downloading — OpenWorker restarts by itself when it's ready."
-              : "Updates download from OpenWorker's releases and install in place."}
-      </div>
-    </div>
+      {(state === "none" || state === "error" || state === "installing") && (
+        <span className="text-[12px] text-muted">
+          {state === "none"
+            ? "You're on the latest version."
+            : state === "error"
+              ? "Couldn't check right now — try again later."
+              : "Downloading — OpenWorker restarts by itself when it's ready."}
+        </span>
+      )}
+    </span>
   );
 }
 
@@ -689,8 +693,9 @@ function SidebarCard() {
   );
 }
 
-// -- Files (scratch location) --------------------------------------------------
-function FilesSection() {
+// -- Files (scratch location) — one card inside General (UX-021: a single option
+// doesn't earn its own tab) -----------------------------------------------------
+function FilesCard() {
   const [settings, setSettings] = useState<ModelSettings | null>(null);
   const [scratchDraft, setScratchDraft] = useState("");
   const [scratchMsg, setScratchMsg] = useState<string | null>(null);
@@ -722,16 +727,11 @@ function FilesSection() {
     if (picked) setScratchDraft(picked);
   };
 
-  if (!settings) return <div className="text-[13px] text-muted">Loading…</div>;
+  if (!settings) return null;
 
   return (
-    <section>
-      <PanelHead
-        title="Files"
-        sub="Where OpenWorker keeps the per-conversation scratch folders it saves files into by default."
-      />
-      <div className={CARD + " p-4"}>
-        <div className={FIELD_LABEL}>Scratch location</div>
+    <div className={CARD + " p-4 mb-4"}>
+      <div className={FIELD_LABEL}>Files</div>
         <div className="flex items-center gap-2 mt-2.5">
           <input
             className={INPUT}
@@ -752,12 +752,11 @@ function FilesSection() {
             Save
           </button>
         </div>
-        <div className={FIELD_HELP}>
-          Each conversation gets its own folder under this location. Existing conversations keep their current
-          folder; you can grant access to more folders inside any conversation.
-        </div>
-        {scratchMsg && <div className="text-[12.5px] text-muted mt-2.5">{scratchMsg}</div>}
+      <div className={FIELD_HELP}>
+        Each conversation gets its own folder under this location. Existing conversations keep their current
+        folder; you can grant access to more folders inside any conversation.
       </div>
-    </section>
+      {scratchMsg && <div className="text-[12.5px] text-muted mt-2.5">{scratchMsg}</div>}
+    </div>
   );
 }

--- a/platform/surfaces/gui/src/components/Sidebar.test.tsx
+++ b/platform/surfaces/gui/src/components/Sidebar.test.tsx
@@ -192,6 +192,7 @@ describe("New-session split button", () => {
   });
 
   it("primary starts the last-used persona; the menu lists enabled personas + Manage personas…", async () => {
+    localStorage.setItem("ocw.flag.personas", "1"); // Manage entry is launch-flagged off
     stubFetch([
       { match: "/v1/personas", method: "GET", json: PERSONAS },
       { match: "/v1/settings", method: "GET", json: { nav_layout: "flat" } },
@@ -220,5 +221,19 @@ describe("New-session split button", () => {
     fireEvent.click(screen.getByLabelText("Choose a persona"));
     fireEvent.click(await screen.findByText("Manage personas…"));
     expect(baseProps.onManagePersonas).toHaveBeenCalled();
+  });
+
+  it("hides Manage personas… while the launch flag is off (the default)", async () => {
+    localStorage.removeItem("ocw.flag.personas");
+    stubFetch([
+      { match: "/v1/personas", method: "GET", json: PERSONAS },
+      { match: "/v1/settings", method: "GET", json: { nav_layout: "flat" } },
+    ]);
+    render(<Sidebar {...baseProps} />);
+    await screen.findByLabelText("Group and filter conversations");
+    fireEvent.click(screen.getByLabelText("Choose a persona"));
+    const menu = (await screen.findByText("Start a session as")).closest(".newsplit-menu") as HTMLElement;
+    expect(within(menu).getByText("Ops")).toBeTruthy();
+    expect(within(menu).queryByText("Manage personas…")).toBeNull();
   });
 });

--- a/platform/surfaces/gui/src/components/Sidebar.tsx
+++ b/platform/surfaces/gui/src/components/Sidebar.tsx
@@ -23,6 +23,7 @@ import { Icon, type IconName } from "./Icon";
 import { PersonaGlyph, personaGlyph } from "./personaIcon";
 import { SearchModal } from "./SearchModal";
 import { baseName } from "../paths";
+import { showPersonas } from "../flags";
 
 // Session surfaces shown as accordions, in display order. The surfaced personas drive this list
 // (so third-party / Ops personas appear); the hardcoded set is the fallback before personas load.
@@ -1227,17 +1228,19 @@ function NewSessionSplit({
                 </span>
               </button>
             ))}
-            <div className="border-t border-line mt-1 pt-1">
-              <button
-                className="w-full px-2 py-1.5 rounded-lg hover:bg-paper text-left text-[12.5px] text-muted"
-                onClick={() => {
-                  setOpen(false);
-                  onManage();
-                }}
-              >
-                Manage personas…
-              </button>
-            </div>
+            {showPersonas() && (
+              <div className="border-t border-line mt-1 pt-1">
+                <button
+                  className="w-full px-2 py-1.5 rounded-lg hover:bg-paper text-left text-[12.5px] text-muted"
+                  onClick={() => {
+                    setOpen(false);
+                    onManage();
+                  }}
+                >
+                  Manage personas…
+                </button>
+              </div>
+            )}
           </div>
         </>
       )}

--- a/platform/surfaces/gui/src/flags.ts
+++ b/platform/surfaces/gui/src/flags.ts
@@ -1,0 +1,21 @@
+// Launch feature flags.
+//
+// A flag is read at render time (not import time) so tests and a running build can flip
+// it via localStorage without a reload race: `localStorage.setItem(key, "1")` shows the
+// feature, `"0"` force-hides it, anything else falls back to the shipped default.
+
+function flag(key: string, fallback: boolean): boolean {
+  try {
+    const v = localStorage.getItem(key);
+    if (v === "1") return true;
+    if (v === "0") return false;
+  } catch {
+    // No storage (jsdom teardown, privacy mode) — ship the default.
+  }
+  return fallback;
+}
+
+/** Personas management is hidden for launch (owner call, 2026-07-19): the Settings tab
+ * and the "Manage personas…" menu entry stay off until the persona catalog is ready.
+ * The e2e suite sets `ocw.flag.personas` to keep the hidden flows covered. */
+export const showPersonas = () => flag("ocw.flag.personas", false);

--- a/platform/surfaces/gui/src/providers/ProviderSetup.tsx
+++ b/platform/surfaces/gui/src/providers/ProviderSetup.tsx
@@ -129,7 +129,11 @@ export function useProviderSetup(opts?: { onSaved?: () => void }): ProviderSetup
   };
 
   const backToGallery = () => {
-    if (sel) setDrafts((d) => ({ ...d, [sel]: fields }));
+    // Stash only UNSAVED input. The unconditional stash used to capture the just-saved
+    // key on the post-Test auto-return, so revisiting a connected provider restored the
+    // plaintext key into the field instead of the masked placeholder + saved pill
+    // (state-restore bug, owner catch 2026-07-19). A clean form clears any stale draft.
+    if (sel) setDrafts((d) => ({ ...d, [sel]: dirty ? fields : {} }));
     setSel(null);
     setVerify({ state: "idle" });
   };
@@ -151,8 +155,15 @@ export function useProviderSetup(opts?: { onSaved?: () => void }): ProviderSetup
     setDrafts((d) => ({ ...d, [sel]: {} }));
     await refreshProviders();
     opts?.onSaved?.();
-    // Let the in-field "✓ Tested & saved" register, then slide home.
-    backTimer.current = window.setTimeout(backToGallery, 900);
+    // Let the in-field "✓ Tested & saved" register, then slide home. NOT backToGallery:
+    // the timeout would fire its stale closure (dirty/fields from before the save) and
+    // re-stash the just-saved key as a draft — the state-restore bug (owner catch
+    // 2026-07-19). This return path clears the draft unconditionally.
+    backTimer.current = window.setTimeout(() => {
+      setDrafts((d) => ({ ...d, [sel]: {} }));
+      setSel(null);
+      setVerify({ state: "idle" });
+    }, 900);
     return true;
   };
 

--- a/platform/surfaces/gui/src/providers/ProviderSetup.tsx
+++ b/platform/surfaces/gui/src/providers/ProviderSetup.tsx
@@ -302,20 +302,9 @@ export function ProviderForm({
 
       {(info?.fields || []).map((f) => {
         const keyed = (info?.fields || []).some((x) => x.secret);
-        // ANY base_url on a keyed provider is an expert option: a quiet disclosure
-        // (owner call 2026-07-18: no explainer copy — its users know what it's for).
-        if (f.key === "base_url" && keyed && !ps.showEndpoint) {
-          return (
-            <button
-              key={f.key}
-              className="block self-start text-[12.5px] text-muted hover:text-ink mt-4"
-              onClick={() => ps.setShowEndpoint(true)}
-              data-testid={`${tp}-endpoint-link`}
-            >
-              Custom endpoint ⌄
-            </button>
-          );
-        }
+        // A keyed provider's base_url is an expert option — it renders BELOW the key-help
+        // line as its own advanced section (owner nit 2026-07-19), not inside the loop.
+        if (f.key === "base_url" && keyed) return null;
         const testable =
           (f.secret && f.key === (info?.fields || []).find((x) => x.secret)?.key) ||
           (!keyed && f.key === (info?.fields || [])[0]?.key);
@@ -389,6 +378,39 @@ export function ProviderForm({
           </button>
         </p>
       )}
+
+      {/* Custom endpoint (keyed providers only): a quiet disclosure BELOW the key help,
+          with enough separation to read as its own advanced row — no explainer copy
+          (owner calls 2026-07-18 + 2026-07-19). */}
+      {(() => {
+        const keyed = (info?.fields || []).some((x) => x.secret);
+        const ep = keyed ? (info?.fields || []).find((f) => f.key === "base_url") : undefined;
+        if (!ep) return null;
+        if (!ps.showEndpoint)
+          return (
+            <button
+              className="block self-start text-[12.5px] text-muted hover:text-ink mt-4"
+              onClick={() => ps.setShowEndpoint(true)}
+              data-testid={`${tp}-endpoint-link`}
+            >
+              Custom endpoint ⌄
+            </button>
+          );
+        return (
+          <div className="mt-4">
+            <label className={label}>{ep.label}</label>
+            <input
+              className={input + " border-line"}
+              type="text"
+              placeholder={ep.placeholder}
+              value={ps.fields[ep.key] || ""}
+              data-testid={`${tp}-field-${ep.key}`}
+              onChange={(e) => ps.setFieldValue(ep.key, e.target.value)}
+            />
+            {ep.help && <p className="text-[11.5px] text-faint mt-1">{ep.help}</p>}
+          </div>
+        );
+      })()}
 
       {/* Error line: fixed height so failures never reflow the form. */}
       <div className="mt-3 min-h-[19px] text-[12.5px]">

--- a/platform/surfaces/gui/src/providers/ProviderSetup.tsx
+++ b/platform/surfaces/gui/src/providers/ProviderSetup.tsx
@@ -1,0 +1,389 @@
+import { useEffect, useRef, useState, type ReactNode } from "react";
+import {
+  getProviders,
+  removeProvider,
+  setProvider,
+  verifyProvider,
+  type ProviderInfo,
+} from "../api";
+import { openExternal } from "../tauri";
+import { PROVIDER_LOGOS, providerRank } from "./logos";
+
+// The provider gallery ⇄ key form, shared by Onboarding step 1 (§39) and
+// Settings ▸ Models (UX-021) so the two can never drift apart visually. The hook
+// owns the interaction state machine; ProviderCards/ProviderForm own the shared
+// markup. Each surface keeps its own frame (fixed-height modal vs scrolling page)
+// and passes a testid prefix so both stay independently addressable in e2e.
+
+// Where a non-developer gets an API key — deep link + one line of instructions.
+export const KEY_HELP: Record<string, { url: string; label: string }> = {
+  anthropic: { url: "https://console.anthropic.com/settings/keys", label: "console.anthropic.com" },
+  openai: { url: "https://platform.openai.com/api-keys", label: "platform.openai.com" },
+  gemini: { url: "https://aistudio.google.com/apikey", label: "aistudio.google.com" },
+  fireworks: { url: "https://fireworks.ai/account/api-keys", label: "fireworks.ai" },
+  together: { url: "https://api.together.xyz/settings/api-keys", label: "together.xyz" },
+  zai: { url: "https://z.ai/manage-apikey/apikey-list", label: "z.ai" },
+  kimi: { url: "https://platform.moonshot.ai/console/api-keys", label: "platform.moonshot.ai" },
+  deepseek: { url: "https://platform.deepseek.com/api_keys", label: "platform.deepseek.com" },
+  mistral: { url: "https://console.mistral.ai/api-keys", label: "console.mistral.ai" },
+  qwen: { url: "https://modelstudio.console.alibabacloud.com", label: "alibabacloud.com" },
+  minimax: { url: "https://platform.minimax.io", label: "platform.minimax.io" },
+  xai: { url: "https://console.x.ai", label: "console.x.ai" },
+};
+
+export type Verify = { state: "idle" | "testing" | "ok" | "error"; msg?: string };
+
+/** Brand chip: always a light plate so multicolor marks read on any theme. */
+export function ProviderMark({ name, title, size = 32 }: { name: string; title: string; size?: number }) {
+  const url = PROVIDER_LOGOS[name];
+  return (
+    <span
+      className="rounded-lg border border-line grid place-items-center shrink-0"
+      style={{ width: size, height: size, background: "#f6f7f8" }}
+    >
+      {url ? (
+        <img src={url} alt="" style={{ width: size * 0.6, height: size * 0.6 }} />
+      ) : (
+        <span className="text-[13px] font-semibold text-muted">{title[0]}</span>
+      )}
+    </span>
+  );
+}
+
+/** "2h ago"-style label for a provider's last completion (null when never used). */
+export function relTime(epoch?: number | null): string | null {
+  if (!epoch) return null;
+  const secs = Math.max(0, Math.floor(Date.now() / 1000 - epoch));
+  if (secs < 90) return "just now";
+  const mins = Math.floor(secs / 60);
+  if (mins < 60) return `${mins}m ago`;
+  const hrs = Math.floor(mins / 60);
+  if (hrs < 48) return `${hrs}h ago`;
+  return `${Math.floor(hrs / 24)}d ago`;
+}
+
+export interface ProviderSetupState {
+  providers: ProviderInfo[];
+  ordered: ProviderInfo[];
+  refreshProviders: () => Promise<void>;
+  sel: string | null;
+  info: ProviderInfo | undefined;
+  fields: Record<string, string>;
+  setFieldValue: (key: string, value: string) => void;
+  dirty: boolean;
+  verify: Verify;
+  showEndpoint: boolean;
+  setShowEndpoint: (v: boolean) => void;
+  keylessOk: Set<string>;
+  credentialed: boolean;
+  savedState: boolean;
+  secretFilled: boolean;
+  openProvider: (name: string) => void;
+  backToGallery: () => void;
+  runTestAndSave: () => Promise<boolean>;
+  removeKey: () => Promise<void>;
+  cancelBackTimer: () => void;
+  statusFor: (p: ProviderInfo, opts?: { lastUsed?: boolean }) => ReactNode;
+}
+
+export function useProviderSetup(opts?: { onSaved?: () => void }): ProviderSetupState {
+  const [providers, setProviders] = useState<ProviderInfo[]>([]);
+  // null = the gallery; a provider name = that provider's key form.
+  const [sel, setSel] = useState<string | null>(null);
+  const [fields, setFields] = useState<Record<string, string>>({});
+  const [dirty, setDirty] = useState(false);
+  const [showEndpoint, setShowEndpoint] = useState(false);
+  const [verify, setVerify] = useState<Verify>({ state: "idle" });
+  // Keyless providers (Ollama) report configured without proving anything runs —
+  // a passing Detect this session is what marks them live.
+  const [keylessOk, setKeylessOk] = useState<Set<string>>(new Set());
+  // Unsaved per-provider input survives switching cards (owner complaint 2026-07-16).
+  const [drafts, setDrafts] = useState<Record<string, Record<string, string>>>({});
+  const backTimer = useRef<number | null>(null);
+
+  const refreshProviders = () =>
+    getProviders()
+      .then(setProviders)
+      .catch(() => {});
+  useEffect(() => {
+    refreshProviders();
+    return () => {
+      if (backTimer.current) window.clearTimeout(backTimer.current);
+    };
+  }, []);
+
+  const info = providers.find((p) => p.name === sel);
+  const credentialed = !!info?.configured && !!info?.needs_key;
+
+  const openProvider = (name: string) => {
+    const p = providers.find((x) => x.name === name);
+    if (sel) setDrafts((d) => ({ ...d, [sel]: fields }));
+    const draft = drafts[name];
+    const next: Record<string, string> = {};
+    for (const f of p?.fields || []) next[f.key] = draft?.[f.key] || p?.values?.[f.key] || f.default || "";
+    setSel(name);
+    setFields(next);
+    setDirty(!!draft && Object.values(draft).some(Boolean));
+    setVerify({ state: "idle" });
+    setShowEndpoint(false);
+  };
+
+  const backToGallery = () => {
+    if (sel) setDrafts((d) => ({ ...d, [sel]: fields }));
+    setSel(null);
+    setVerify({ state: "idle" });
+  };
+
+  // Test = verify AND save AND return (§39: a passing Test auto-saves and takes
+  // you back to the gallery, where the card now wears its ✓ — no extra clicks).
+  const runTestAndSave = async (): Promise<boolean> => {
+    if (!sel) return false;
+    setVerify({ state: "testing" });
+    const res = await verifyProvider(sel, fields).catch(() => ({ ok: false, error: "unreachable" }));
+    if (!res.ok) {
+      setVerify({ state: "error", msg: res.error || "couldn't verify" });
+      return false;
+    }
+    if (dirty || !info?.configured) await setProvider(sel, fields).catch(() => {});
+    if (!info?.needs_key) setKeylessOk((s) => new Set(s).add(sel));
+    setVerify({ state: "ok" });
+    setDirty(false);
+    setDrafts((d) => ({ ...d, [sel]: {} }));
+    await refreshProviders();
+    opts?.onSaved?.();
+    // Let the in-field "✓ Tested & saved" register, then slide home.
+    backTimer.current = window.setTimeout(backToGallery, 900);
+    return true;
+  };
+
+  // Settings-only: forget the stored key; the card reverts to "Not set up".
+  const removeKey = async () => {
+    if (!sel) return;
+    await removeProvider(sel).catch(() => {});
+    setDrafts((d) => ({ ...d, [sel]: {} }));
+    setKeylessOk((s) => {
+      const next = new Set(s);
+      next.delete(sel);
+      return next;
+    });
+    await refreshProviders();
+    opts?.onSaved?.();
+    setSel(null);
+    setVerify({ state: "idle" });
+  };
+
+  const statusFor = (p: ProviderInfo, o?: { lastUsed?: boolean }) => {
+    if (p.configured && p.needs_key) {
+      const used = o?.lastUsed ? relTime(p.last_used_at) : null;
+      return (
+        <span className="block text-[11.5px] text-ok font-medium truncate">
+          ✓ Connected{used ? <span className="text-muted font-normal"> · used {used}</span> : ""}
+        </span>
+      );
+    }
+    if (!p.needs_key)
+      return (
+        <span className="block text-[11.5px] text-faint truncate">
+          {keylessOk.has(p.name) ? <span className="text-ok font-medium">✓ Running</span> : "No key needed"}
+        </span>
+      );
+    return <span className="block text-[11.5px] text-faint truncate">Not set up</span>;
+  };
+
+  return {
+    providers,
+    ordered: [...providers].sort((a, b) => providerRank(a.name) - providerRank(b.name)),
+    refreshProviders,
+    sel,
+    info,
+    fields,
+    setFieldValue: (key, value) => {
+      setFields((cur) => ({ ...cur, [key]: value }));
+      setDirty(true);
+      setVerify({ state: "idle" });
+    },
+    dirty,
+    verify,
+    showEndpoint,
+    setShowEndpoint,
+    keylessOk,
+    credentialed,
+    // The in-field saved state (§39): green border + pill INSIDE the key box — shown
+    // for stored credentials and fresh test-passes alike; typing clears it.
+    savedState: (credentialed && !dirty) || verify.state === "ok",
+    secretFilled: (info?.fields || []).every((f) => !f.secret || (fields[f.key] || "").trim()),
+    openProvider,
+    backToGallery,
+    runTestAndSave,
+    removeKey,
+    cancelBackTimer: () => {
+      if (backTimer.current) window.clearTimeout(backTimer.current);
+    },
+    statusFor,
+  };
+}
+
+/** The gallery: one card per provider, each wearing its own state. */
+export function ProviderCards({
+  ps,
+  tp,
+  gridClass = "grid grid-cols-2 gap-2.5",
+  lastUsed = false,
+}: {
+  ps: ProviderSetupState;
+  tp: string; // testid prefix ("ob" onboarding, "set" settings)
+  gridClass?: string;
+  lastUsed?: boolean;
+}) {
+  const card =
+    "flex items-center gap-2.5 rounded-xl border border-line bg-panel px-3 py-2.5 text-left hover:border-lineStrong transition-colors";
+  return (
+    <div className={gridClass}>
+      {ps.ordered.map((p) => (
+        <button
+          key={p.name}
+          className={card}
+          data-testid={`${tp}-provider-${p.name}`}
+          onClick={() => ps.openProvider(p.name)}
+        >
+          <ProviderMark name={p.name} title={p.title} />
+          <span className="min-w-0 flex-1">
+            <span className="block text-[13px] font-semibold leading-tight truncate">{p.title}</span>
+            {ps.statusFor(p, { lastUsed })}
+          </span>
+          <span className="text-faint text-[14px]">›</span>
+        </button>
+      ))}
+    </div>
+  );
+}
+
+/** One provider's key form: crumb, brand head, fields (endpoint behind a quiet
+ * disclosure), in-field saved pill, Test/Detect, key help, fixed error line.
+ * `footer` renders after the error line (Settings adds "Remove key…" there). */
+export function ProviderForm({
+  ps,
+  tp,
+  footer,
+}: {
+  ps: ProviderSetupState;
+  tp: string;
+  footer?: ReactNode;
+}) {
+  const { info, sel } = ps;
+  const label = "block text-[12px] text-muted mt-3 mb-1";
+  const input =
+    "w-full px-3 py-2 rounded-lg border bg-panel text-[13.5px] outline-none focus:border-accent";
+  if (!sel) return null;
+  return (
+    <div>
+      <button className="text-[12.5px] text-muted hover:text-ink" onClick={ps.backToGallery} data-testid={`${tp}-back`}>
+        ‹ All providers
+      </button>
+      <div className="flex items-center gap-3 mt-3 mb-1">
+        <ProviderMark name={info?.name || ""} title={info?.title || ""} size={36} />
+        <span className="min-w-0">
+          <span className="block text-[15px] font-semibold leading-tight">{info?.title}</span>
+          {info ? ps.statusFor(info) : null}
+        </span>
+      </div>
+      {info?.blurb && <p className="text-[11.5px] text-faint mt-1">{info.blurb}</p>}
+
+      {(info?.fields || []).map((f) => {
+        const keyed = (info?.fields || []).some((x) => x.secret);
+        // ANY base_url on a keyed provider is an expert option: a quiet disclosure
+        // (owner call 2026-07-18: no explainer copy — its users know what it's for).
+        if (f.key === "base_url" && keyed && !ps.showEndpoint) {
+          return (
+            <button
+              key={f.key}
+              className="block self-start text-[12.5px] text-muted hover:text-ink mt-4"
+              onClick={() => ps.setShowEndpoint(true)}
+              data-testid={`${tp}-endpoint-link`}
+            >
+              Custom endpoint ⌄
+            </button>
+          );
+        }
+        const testable =
+          (f.secret && f.key === (info?.fields || []).find((x) => x.secret)?.key) ||
+          (!keyed && f.key === (info?.fields || [])[0]?.key);
+        return (
+          <div key={f.key}>
+            <label className={label}>{f.label}</label>
+            <div className="flex gap-2">
+              <div className="relative flex-1 min-w-0">
+                <input
+                  className={input + (ps.savedState && f.secret ? " border-ok pr-32" : " border-line")}
+                  type={f.secret ? "password" : "text"}
+                  placeholder={f.secret && ps.credentialed && !ps.dirty ? "••••••••" : f.placeholder}
+                  value={ps.fields[f.key] || ""}
+                  data-testid={`${tp}-field-${f.key}`}
+                  onChange={(e) => ps.setFieldValue(f.key, e.target.value)}
+                />
+                {/* §39: state lives IN the field — no status lines below. */}
+                {ps.savedState && f.secret && (
+                  <span
+                    className="absolute right-2 top-1/2 -translate-y-1/2 text-[11px] font-medium text-ok bg-okSoft rounded-full px-2 py-0.5 pointer-events-none"
+                    data-testid={`${tp}-saved-pill`}
+                  >
+                    ✓ Tested &amp; saved
+                  </span>
+                )}
+                {ps.savedState && !f.secret && testable && (
+                  <span
+                    className="absolute right-2 top-1/2 -translate-y-1/2 text-[11px] font-medium text-ok bg-okSoft rounded-full px-2 py-0.5 pointer-events-none"
+                    data-testid={`${tp}-saved-pill`}
+                  >
+                    ✓ Detected
+                  </span>
+                )}
+              </div>
+              {testable && (
+                <button
+                  className="px-4 rounded-lg border border-line text-[13px] font-medium text-ink hover:border-lineStrong shrink-0 disabled:opacity-40"
+                  onClick={() => ps.runTestAndSave()}
+                  disabled={ps.verify.state === "testing" || (f.secret && !ps.secretFilled && !ps.credentialed)}
+                  data-testid={`${tp}-test`}
+                >
+                  {ps.verify.state === "testing" ? "…" : info?.needs_key ? "Test" : "Detect"}
+                </button>
+              )}
+            </div>
+            {f.help && !f.secret && <p className="text-[11.5px] text-faint mt-1">{f.help}</p>}
+          </div>
+        );
+      })}
+
+      {info?.needs_key && KEY_HELP[sel] && (
+        <p className="text-[11.5px] text-faint mt-2">
+          No key yet?{" "}
+          <button
+            className="text-muted underline decoration-line underline-offset-2 hover:text-ink"
+            onClick={() => openExternal(KEY_HELP[sel].url)}
+          >
+            Create one at {KEY_HELP[sel].label} ↗
+          </button>{" "}
+          — takes about a minute.
+        </p>
+      )}
+      {info && !info.needs_key && (
+        <p className="text-[11.5px] text-faint mt-2">
+          No API key needed — Ollama runs models on this Mac.{" "}
+          <button
+            className="text-muted underline decoration-line underline-offset-2 hover:text-ink"
+            onClick={() => openExternal("https://ollama.com/download")}
+          >
+            Install Ollama ↗
+          </button>
+        </p>
+      )}
+
+      {/* Error line: fixed height so failures never reflow the form. */}
+      <div className="mt-3 min-h-[19px] text-[12.5px]">
+        {ps.verify.state === "error" && <span className="text-warnInk">{ps.verify.msg}</span>}
+      </div>
+      {footer}
+    </div>
+  );
+}

--- a/platform/surfaces/gui/src/styles.css
+++ b/platform/surfaces/gui/src/styles.css
@@ -164,6 +164,11 @@ body {
 /* The session topbar's collapsed-state cluster is INLINE (§22), so only the overlay build pads
    it — to clear the traffic lights. */
 .app.nav-collapsed.tauri-overlay .main-topbar { padding-left: 84px; }
+/* Full-page sub-navs (Settings / Connectors) start at the window top; while the main nav is
+   collapsed, the fixed reveal button (and, in the overlay build, the traffic lights) float over
+   that corner — push the sub-nav header below the strip so they never overlap. */
+.app.nav-collapsed .page-subnav { padding-top: 48px; }
+.app.nav-collapsed.tauri-overlay .page-subnav { padding-top: 56px; }
 
 .tabs { display: flex; gap: 4px; background: var(--paper); padding: 4px; border-radius: 10px; }
 .tab {

--- a/platform/tests/test_cloud.py
+++ b/platform/tests/test_cloud.py
@@ -219,6 +219,19 @@ def test_logout_clears_session(secrets, config):
 # --- managed connect -------------------------------------------------------------
 
 
+def test_every_managed_connector_has_a_provider_mapping():
+    """A managed=True descriptor without a PROVIDER_FOR_CONNECTOR entry ships a
+    dead one-click button ("X has no managed OAuth path") — outlook did exactly
+    that. Wire the map in the same change that flips a connector to managed."""
+    from coworker.connectors.descriptors import DESCRIPTORS
+
+    managed = {d.name for d in DESCRIPTORS if d.managed}
+    unmapped = managed - set(cloud.PROVIDER_FOR_CONNECTOR)
+    assert (
+        not unmapped
+    ), f"managed connectors missing an OAuth provider: {sorted(unmapped)}"
+
+
 def test_begin_managed_connect_requires_sign_in(secrets, config):
     out = cloud.begin_managed_connect(secrets, config, "gmail")
     assert not out["ok"]

--- a/platform/tests/test_server.py
+++ b/platform/tests/test_server.py
@@ -660,3 +660,22 @@ def test_pick_native_folder_paths(tmp_path, monkeypatch):
     monkeypatch.setattr(subprocess, "run", boom)
     out = mgr.pick_native_folder()
     assert out["ok"] is False and "picker" in out["error"]
+
+
+def test_provider_set_and_remove_roundtrip(tmp_path):
+    """Settings ▸ Models "Remove key": DELETE /v1/providers/{name} forgets the stored
+    profile so the provider reads unconfigured again; unknown names are a clean error.
+    """
+    client = _client(tmp_path, [])
+    assert client.post(
+        "/v1/providers", json={"name": "zai", "fields": {"api_key": "zk-test"}}
+    ).json()["ok"]
+    prov = {p["name"]: p for p in client.get("/v1/providers").json()}
+    assert prov["zai"]["configured"] and prov["zai"]["key_set_at"]
+
+    assert client.delete("/v1/providers/zai").json()["ok"]
+    prov = {p["name"]: p for p in client.get("/v1/providers").json()}
+    assert not prov["zai"]["configured"]
+    assert not prov["zai"]["key_set_at"]
+
+    assert not client.delete("/v1/providers/nope").json()["ok"]


### PR DESCRIPTION
OpenWorker - Launch-hardening round.
Wires Outlook to the managed Microsoft OAuth path.
Fixes the collapsed-nav overlap on Settings/Connectors
Puts Personas behind a launch flag, rebuilds Settings as General/Models/Voice-input with the provider gallery shared with onboarding (UX-DECISIONS §40)
Redesigns the onboarding tools page as benefit rows with a stable sign-in band (§41), and fixes a state-restore bug that replayed a just-saved API key into the form.
Backend 776 tests, vitest 54, Playwright e2e 122 all green.
