### PR TITLE
OpenWorker: MCP OAuth sign-in + Granola preset

### DIFF
--- a/platform/coworker/mcp/client.py
+++ b/platform/coworker/mcp/client.py
@@ -33,10 +33,13 @@ class _Conn:
 class MCPManager:
     """Owns persistent MCP connections keyed by server name; lazy-connects on demand."""
 
-    def __init__(self) -> None:
+    def __init__(self, secrets: Any = None) -> None:
         self._conns: dict[str, _Conn] = {}
         self._tasks: dict[str, asyncio.Task] = {}
         self._lock = asyncio.Lock()
+        # SecretStore for OAuth servers' token persistence (mcp/oauth.py); lazy default
+        # so library/CLI construction without secrets keeps working.
+        self._secrets = secrets
 
     async def ensure(self, server: MCPServerDef) -> _Conn:
         """Return a live connection for `server`, connecting (once) if needed."""
@@ -82,9 +85,17 @@ class MCPManager:
                         raise ValueError(
                             f"MCP server '{server.name}' is http but has no url"
                         )
+                    auth = None
+                    if server.auth == "oauth":
+                        from ..secrets import SecretStore
+                        from .oauth import build_auth
+
+                        if self._secrets is None:
+                            self._secrets = SecretStore()
+                        auth = build_auth(server.name, server.url, self._secrets)
                     read, write, *_ = await stack.enter_async_context(
                         streamablehttp_client(
-                            server.url, headers=server.headers or None
+                            server.url, headers=server.headers or None, auth=auth
                         )
                     )
                 else:

--- a/platform/coworker/mcp/config.py
+++ b/platform/coworker/mcp/config.py
@@ -34,6 +34,9 @@ class MCPServerDef:
     include_tools: Optional[list[str]] = None
     exclude_tools: Optional[list[str]] = None
     requires_approval: bool = True
+    # "oauth" → browser OAuth 2.1 + PKCE with Dynamic Client Registration (mcp/oauth.py).
+    # HTTP transport only; tokens live in the SecretStore, never in this file.
+    auth: Optional[str] = None
 
 
 def global_mcp_path() -> Path:
@@ -71,6 +74,7 @@ def _parse(name: str, raw: dict[str, Any], secrets: SecretStore) -> MCPServerDef
         include_tools=raw.get("include_tools"),
         exclude_tools=raw.get("exclude_tools"),
         requires_approval=bool(raw.get("requires_approval", True)),
+        auth=(str(raw["auth"]).lower() if raw.get("auth") else None),
     )
 
 

--- a/platform/coworker/mcp/oauth.py
+++ b/platform/coworker/mcp/oauth.py
@@ -1,0 +1,161 @@
+"""Browser OAuth for remote MCP servers (OAuth 2.1 + PKCE + Dynamic Client Registration).
+
+The official SDK's `OAuthClientProvider` drives the whole spec flow — protected-resource
+metadata discovery, DCR, PKCE, token refresh — as an httpx auth plugged into the
+streamable-HTTP transport. We supply its three integration points:
+
+  - token persistence  → the SecretStore (profile `mcp-oauth:<server>`; 0600 file,
+    never the mcp.json config, which is plain text and paste-shareable)
+  - redirect           → open the system browser at the authorize URL
+  - callback           → the sidecar's loopback `GET /mcp/oauth/callback` resolves a
+    single-slot pending future (one interactive sign-in at a time — the flow is
+    user-driven, so concurrency is meaningless)
+
+DCR means there is no client id/secret registered anywhere up front — nothing for the
+ocw-connect broker to hold, so unlike the managed connectors this flow is fully local.
+First server: Granola (https://mcp.granola.ai/mcp).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+from typing import Any, Optional
+
+from mcp.client.auth import OAuthClientProvider, TokenStorage
+from mcp.shared.auth import OAuthClientInformationFull, OAuthClientMetadata, OAuthToken
+
+from ..secrets import SecretStore
+
+logger = logging.getLogger(__name__)
+
+PROFILE_PREFIX = "mcp-oauth:"
+CALLBACK_PATH = "/mcp/oauth/callback"
+# How long the connect waits for the user to finish the browser sign-in.
+FLOW_TIMEOUT_SECONDS = 300
+
+CLIENT_NAME = "OpenWorker"
+
+
+def redirect_base() -> str:
+    """The sidecar's own loopback origin — the DCR-registered redirect must match it."""
+    port = os.environ.get("COWORKER_PORT") or "8765"
+    return f"http://127.0.0.1:{port}"
+
+
+def _profile(name: str) -> str:
+    return PROFILE_PREFIX + name
+
+
+class SecretStoreTokenStorage(TokenStorage):
+    """SDK TokenStorage over our SecretStore: one profile per server holding the token
+    set and the DCR-issued client registration (re-used across sign-ins)."""
+
+    def __init__(self, server_name: str, secrets: SecretStore) -> None:
+        self._name = server_name
+        self._secrets = secrets
+
+    def _data(self) -> dict[str, Any]:
+        return self._secrets.get(_profile(self._name)) or {}
+
+    def _merge(self, patch: dict[str, Any]) -> None:
+        self._secrets.put(_profile(self._name), {**self._data(), **patch})
+
+    async def get_tokens(self) -> Optional[OAuthToken]:
+        raw = self._data().get("tokens")
+        if not raw:
+            return None
+        try:
+            return OAuthToken.model_validate(raw)
+        except Exception:
+            return None
+
+    async def set_tokens(self, tokens: OAuthToken) -> None:
+        self._merge({"tokens": tokens.model_dump(mode="json", exclude_none=True)})
+
+    async def get_client_info(self) -> Optional[OAuthClientInformationFull]:
+        raw = self._data().get("client_info")
+        if not raw:
+            return None
+        try:
+            return OAuthClientInformationFull.model_validate(raw)
+        except Exception:
+            return None
+
+    async def set_client_info(self, info: OAuthClientInformationFull) -> None:
+        self._merge({"client_info": info.model_dump(mode="json", exclude_none=True)})
+
+
+# -- single-slot interactive flow ------------------------------------------------
+_pending: Optional[asyncio.Future] = None
+# The last authorize URL we sent the user to — surfaced over REST so the GUI can offer
+# a "reopen sign-in page" link if the browser popup was lost.
+last_authorize_url: Optional[str] = None
+
+
+def deliver_callback(code: str, state: Optional[str]) -> bool:
+    """Called by the loopback route. Resolves the waiting flow; False if none waits."""
+    global _pending
+    pending, _pending = _pending, None
+    if pending is None or pending.done():
+        return False
+    pending.set_result((code, state))
+    return True
+
+
+async def _open_browser(url: str) -> None:
+    global last_authorize_url
+    last_authorize_url = url
+    import webbrowser
+
+    logger.info("mcp oauth: opening browser for sign-in")
+    await asyncio.get_running_loop().run_in_executor(None, webbrowser.open, url)
+
+
+async def _wait_for_callback() -> tuple[str, Optional[str]]:
+    global _pending
+    if _pending is not None and not _pending.done():
+        _pending.cancel()  # a stale flow lost its browser tab; the new one wins
+    _pending = asyncio.get_running_loop().create_future()
+    try:
+        return await asyncio.wait_for(_pending, timeout=FLOW_TIMEOUT_SECONDS)
+    except asyncio.TimeoutError:
+        raise RuntimeError(
+            "sign-in timed out — the browser window was not completed in "
+            f"{FLOW_TIMEOUT_SECONDS // 60} minutes"
+        )
+    finally:
+        _pending = None
+
+
+def build_auth(
+    server_name: str, server_url: str, secrets: SecretStore
+) -> OAuthClientProvider:
+    """The httpx auth for one OAuth MCP server (pass as streamablehttp_client(auth=…))."""
+    metadata = OAuthClientMetadata.model_validate(
+        {
+            "client_name": CLIENT_NAME,
+            "redirect_uris": [redirect_base() + CALLBACK_PATH],
+            "grant_types": ["authorization_code", "refresh_token"],
+            "response_types": ["code"],
+            # Public client: DCR issues no secret a native app could keep anyway.
+            "token_endpoint_auth_method": "none",
+        }
+    )
+    return OAuthClientProvider(
+        server_url=server_url,
+        client_metadata=metadata,
+        storage=SecretStoreTokenStorage(server_name, secrets),
+        redirect_handler=_open_browser,
+        callback_handler=_wait_for_callback,
+    )
+
+
+def has_tokens(server_name: str, secrets: SecretStore) -> bool:
+    return bool((secrets.get(_profile(server_name)) or {}).get("tokens"))
+
+
+def sign_out(server_name: str, secrets: SecretStore) -> bool:
+    """Forget tokens AND the DCR registration; next connect runs a fresh flow."""
+    return secrets.delete(_profile(server_name))

--- a/platform/coworker/server/app.py
+++ b/platform/coworker/server/app.py
@@ -597,6 +597,56 @@ def create_app(manager: SessionManager) -> FastAPI:
     async def mcp_tools(name: str) -> dict[str, Any]:
         return await manager.mcp_tools(name)
 
+    @app.post("/v1/mcp/{name}/connect")
+    async def mcp_connect(name: str) -> dict[str, Any]:
+        # Connect now. For `auth: oauth` servers the first connect opens the system
+        # browser and waits on the loopback callback — that can take minutes, so it
+        # runs as a background task; the GUI polls /v1/mcp for the status flip
+        # (authorizing → connected | needs_auth + last_error).
+        asyncio.create_task(manager.connect_mcp(name))
+        return {"ok": True, "started": True}
+
+    @app.post("/v1/mcp/{name}/signout")
+    async def mcp_signout(name: str) -> dict[str, Any]:
+        return await manager.signout_mcp(name)
+
+    @app.get("/mcp/oauth/callback")
+    async def mcp_oauth_callback(
+        code: str = "", state: str = "", error: str = ""
+    ) -> Any:
+        # Loopback landing for the MCP OAuth browser flow (mcp/oauth.py). Browser-facing:
+        # returns the same styled page as the managed-connector callbacks.
+        from fastapi.responses import HTMLResponse
+
+        from ..mcp import oauth as mcp_oauth
+
+        if error:
+            return HTMLResponse(
+                _browser_page(
+                    "Sign-in failed",
+                    "The service reported an error. Return to OpenWorker and try again.",
+                    ok=False,
+                    error=error,
+                ),
+                status_code=400,
+            )
+        if not code or not mcp_oauth.deliver_callback(code, state or None):
+            return HTMLResponse(
+                _browser_page(
+                    "Nothing waiting for this sign-in",
+                    "The sign-in may have timed out. Return to OpenWorker and start it again.",
+                    ok=False,
+                ),
+                status_code=400,
+            )
+        return HTMLResponse(
+            _browser_page(
+                "Connected",
+                "Sign-in complete. You can close this tab and return to OpenWorker.",
+                ok=True,
+            )
+        )
+
     @app.post("/v1/mcp/reload")
     async def mcp_reload() -> dict[str, Any]:
         return await manager.reload_mcp()

--- a/platform/coworker/server/manager.py
+++ b/platform/coworker/server/manager.py
@@ -137,7 +137,11 @@ class SessionManager:
             self.provider = ProviderRouter(
                 self.secrets, default_provider="openai", on_use=self._note_provider_use
             )
-        self.mcp = MCPManager()
+        self.mcp = MCPManager(secrets=self.secrets)
+        # OAuth MCP servers with a sign-in in flight / their last connect error —
+        # feeds list_mcp's status so the GUI can show "authorizing…" and failures.
+        self._mcp_authorizing: set[str] = set()
+        self._mcp_errors: dict[str, str] = {}
         self.gateway: Optional[Gateway] = None
         self._data_base = base
         # Desktop/UI prefs (default model, onboarding state) — not secrets; a plain JSON file.
@@ -807,9 +811,22 @@ class SessionManager:
 
     def list_mcp(self) -> list[dict[str, Any]]:
         """Servers from the global config + connection status (does not connect)."""
+        from ..mcp import oauth as mcp_oauth
+
         out = []
         for name, raw in read_global().items():
             connected = name in self.mcp._conns
+            is_oauth = str(raw.get("auth", "")).lower() == "oauth"
+            if connected:
+                status = "connected"
+            elif not raw.get("enabled", True):
+                status = "disabled"
+            elif name in self._mcp_authorizing:
+                status = "authorizing"
+            elif is_oauth and not mcp_oauth.has_tokens(name, self.secrets):
+                status = "needs_auth"
+            else:
+                status = "configured"
             out.append(
                 {
                     "name": name,
@@ -824,13 +841,9 @@ class SessionManager:
                         else "stdio"
                     ),
                     "requires_approval": bool(raw.get("requires_approval", True)),
-                    "status": (
-                        "connected"
-                        if connected
-                        else (
-                            "disabled" if not raw.get("enabled", True) else "configured"
-                        )
-                    ),
+                    "auth": "oauth" if is_oauth else None,
+                    "status": status,
+                    "last_error": self._mcp_errors.get(name),
                     "tool_count": (
                         len(self.mcp._conns[name].tools) if connected else None
                     ),
@@ -838,6 +851,36 @@ class SessionManager:
                 }
             )
         return out
+
+    async def connect_mcp(self, name: str) -> dict[str, Any]:
+        """Connect one server NOW — for OAuth servers this may open the browser and wait
+        for the loopback callback, so callers run it as a background task and watch
+        list_mcp for the status flip."""
+        for server in load_mcp_servers(self.default_workspace, secrets=self.secrets):
+            if server.name != name:
+                continue
+            self._mcp_authorizing.add(name)
+            self._mcp_errors.pop(name, None)
+            try:
+                conn = await self.mcp.ensure(server)
+                return {"ok": True, "tools": len(conn.tools)}
+            except Exception as exc:
+                self._mcp_errors[name] = str(exc) or exc.__class__.__name__
+                return {"ok": False, "error": self._mcp_errors[name]}
+            finally:
+                self._mcp_authorizing.discard(name)
+        return {"ok": False, "error": f"unknown MCP server: {name}"}
+
+    async def signout_mcp(self, name: str) -> dict[str, Any]:
+        """Drop the live connection (if any) and forget the stored OAuth tokens."""
+        from ..mcp import oauth as mcp_oauth
+
+        conn = self.mcp._conns.get(name)
+        if conn is not None:
+            conn.shutdown.set()
+        self._mcp_errors.pop(name, None)
+        removed = mcp_oauth.sign_out(name, self.secrets)
+        return {"ok": True, "had_tokens": removed}
 
     def add_mcp(self, name: str, config: dict[str, Any]) -> dict[str, Any]:
         put_global_server(name, config)

--- a/platform/surfaces/gui/e2e/fixtures.ts
+++ b/platform/surfaces/gui/e2e/fixtures.ts
@@ -487,6 +487,8 @@ export async function mockApi(page: import("@playwright/test").Page) {
   const providers: any[] = PROVIDERS.map((p) => ({ ...p }));
   // Automations — mutable so Run now appends a run, enable/disable toggles, and delete removes.
   const automations: any[] = [{ ...AUTOMATION }];
+  // MCP servers (empty by default; the granola OAuth quick-add test populates it).
+  const mcpServers: any[] = [];
   const automationRuns: any[] = AUTOMATION_RUNS.map((r) => ({ ...r }));
   // Per-session unattended flag — mutable so the composer's "Send to Inbox" toggle persists and
   // the app reads it back (which is what gates parking approvals to the Inbox vs an inline card).
@@ -1228,7 +1230,51 @@ export async function mockApi(page: import("@playwright/test").Page) {
     if (p.endsWith("/v1/settings/onboarded") && m === "POST") {
       return json({ ok: true, onboarded: !!(req.postDataJSON() || {}).value });
     }
-    if (p.endsWith("/v1/mcp")) return json({ servers: [] });
+    // MCP servers — mutable so the OAuth quick-add (granola) flow reflects through the
+    // UI: add → needs_auth, connect → authorizing, next poll → connected (6 tools).
+    if (p.endsWith("/v1/mcp") && m === "GET") {
+      for (const s2 of mcpServers) {
+        if (s2.status === "authorizing" && s2._flip) {
+          s2.status = "connected";
+          s2.tool_count = 6;
+        }
+        if (s2.status === "authorizing") s2._flip = true;
+      }
+      return json({ servers: mcpServers.map(({ _flip, ...s2 }) => s2) });
+    }
+    if (p.endsWith("/v1/mcp") && m === "POST") {
+      const b = req.postDataJSON();
+      mcpServers.push({
+        name: b.name,
+        enabled: true,
+        transport: b.config?.url ? "http" : "stdio",
+        requires_approval: true,
+        auth: b.config?.auth === "oauth" ? "oauth" : null,
+        status: b.config?.auth === "oauth" ? "needs_auth" : "configured",
+        last_error: null,
+        tool_count: null,
+        config: b.config || {},
+      });
+      return json({ ok: true, name: b.name });
+    }
+    {
+      const mc = p.match(/\/v1\/mcp\/([^/]+)\/connect$/);
+      if (mc && m === "POST") {
+        const s2 = mcpServers.find((x) => x.name === decodeURIComponent(mc[1]));
+        if (s2) s2.status = "authorizing";
+        return json({ ok: true, started: true });
+      }
+      const ms = p.match(/\/v1\/mcp\/([^/]+)\/signout$/);
+      if (ms && m === "POST") {
+        const s2 = mcpServers.find((x) => x.name === decodeURIComponent(ms[1]));
+        if (s2) {
+          s2.status = "needs_auth";
+          s2.tool_count = null;
+          s2._flip = false;
+        }
+        return json({ ok: true });
+      }
+    }
     if (p.endsWith("/v1/unrouted")) return json([]);
 
     // channel subscriptions — mutable so add/remove reflect through the UI

--- a/platform/surfaces/gui/e2e/mcp-oauth.spec.ts
+++ b/platform/surfaces/gui/e2e/mcp-oauth.spec.ts
@@ -1,0 +1,37 @@
+// MCP OAuth quick-add (first server: Granola): the MCP tab offers a curated Connect
+// card; connecting adds the server, kicks off the browser sign-in ("signing in…"),
+// and the tab's poll flips the row to connected. Sign out returns it to needs_auth.
+import { expect } from "@playwright/test";
+import { test } from "./fixtures";
+
+async function openMcpTab(page) {
+  await page.goto("/");
+  await page.getByTestId("account-row").click();
+  await page.getByRole("button", { name: "Connectors", exact: true }).click();
+  await page.getByRole("button", { name: "MCP servers", exact: true }).click();
+}
+
+test("granola: quick-add card → sign-in flow → connected → sign out", async ({ page }) => {
+  await openMcpTab(page);
+
+  // Curated card renders while granola isn't configured.
+  const preset = page.getByTestId("mcp-preset-granola");
+  await expect(preset).toContainText("Granola");
+  await expect(preset).toContainText("Meeting notes");
+
+  // Connect: adds the server with OAuth pending and starts the browser flow.
+  await preset.getByRole("button", { name: "Connect" }).click();
+  await expect(page.getByTestId("mcp-preset-granola")).toHaveCount(0);
+  const row = page.locator(".space-y-2 > div").filter({ hasText: "granola" }).first();
+  await expect(row).toContainText("signing in…");
+
+  // The 2s status poll flips the mock to connected with its 6 tools.
+  await expect(row).toContainText("connected", { timeout: 10_000 });
+  await expect(row).toContainText("6 tools");
+  await expect(row).toContainText("oauth");
+
+  // Sign out forgets tokens; the row needs auth again and offers Sign in.
+  await row.getByTestId("mcp-signout-granola").click();
+  await expect(row).toContainText("needs auth");
+  await expect(row.getByTestId("mcp-signin-granola")).toBeVisible();
+});

--- a/platform/surfaces/gui/src/api.ts
+++ b/platform/surfaces/gui/src/api.ts
@@ -208,7 +208,11 @@ export interface McpServer {
   enabled: boolean;
   transport: string;
   requires_approval: boolean;
+  // "connected" | "configured" | "disabled" | and for auth:"oauth" servers:
+  // "needs_auth" (no tokens yet) | "authorizing" (browser sign-in in flight)
   status: string;
+  auth?: "oauth" | null;
+  last_error?: string | null;
   tool_count: number | null;
   config: Record<string, any>;
 }
@@ -250,6 +254,23 @@ export async function getMcpTools(
 
 export async function reloadMcp() {
   const res = await fetch(`${httpBase()}/v1/mcp/reload`, { method: "POST" });
+  return res.json();
+}
+
+/** Connect one MCP server now. For OAuth servers this opens the system browser;
+ * poll getMcpServers() for the status flip (authorizing → connected / needs_auth). */
+export async function connectMcp(name: string): Promise<{ ok: boolean; started?: boolean }> {
+  const res = await fetch(`${httpBase()}/v1/mcp/${encodeURIComponent(name)}/connect`, {
+    method: "POST",
+  });
+  return res.json();
+}
+
+/** Drop the connection and forget the stored OAuth tokens. */
+export async function signoutMcp(name: string): Promise<{ ok: boolean }> {
+  const res = await fetch(`${httpBase()}/v1/mcp/${encodeURIComponent(name)}/signout`, {
+    method: "POST",
+  });
   return res.json();
 }
 

--- a/platform/surfaces/gui/src/components/ManageTabs.tsx
+++ b/platform/surfaces/gui/src/components/ManageTabs.tsx
@@ -4,10 +4,12 @@ import {
   allowUser,
   connectConnector,
   connectManaged,
+  connectMcp,
   deleteMcpServer,
   disallowUser,
   getMcpServers,
   getMcpTools,
+  signoutMcp,
   getSettings,
   getSubscriptions,
   removeModel,
@@ -229,6 +231,17 @@ function ComposerPickerCard({
   );
 }
 
+// Curated OAuth quick-adds: remote MCP servers with browser sign-in (OAuth 2.1 + DCR) —
+// no keys to paste, tokens stay in the local secret store. First: Granola.
+const MCP_PRESETS: { name: string; label: string; blurb: string; config: Record<string, any> }[] = [
+  {
+    name: "granola",
+    label: "Granola",
+    blurb: "Meeting notes & transcripts — sign in with your Granola account.",
+    config: { type: "http", url: "https://mcp.granola.ai/mcp", auth: "oauth" },
+  },
+];
+
 export function McpTab() {
   const [servers, setServers] = useState<McpServer[]>([]);
   const [adding, setAdding] = useState(false);
@@ -238,6 +251,15 @@ export function McpTab() {
   useEffect(() => {
     refresh();
   }, []);
+
+  // While a browser sign-in is in flight, poll so the row flips to connected (or
+  // surfaces the error) without the user having to touch anything.
+  const authorizing = servers.some((s) => s.status === "authorizing");
+  useEffect(() => {
+    if (!authorizing) return;
+    const t = window.setInterval(refresh, 2000);
+    return () => window.clearInterval(t);
+  }, [authorizing]);
 
   const toggle = async (s: McpServer) => {
     await patchMcpServer(s.name, { enabled: !s.enabled });
@@ -272,10 +294,36 @@ export function McpTab() {
       ) : (
         <div className="space-y-2">
           {servers.map((s) => (
-            <McpRow key={s.name} server={s} onToggle={() => toggle(s)} onRemove={() => remove(s)} />
+            <McpRow
+              key={s.name}
+              server={s}
+              onToggle={() => toggle(s)}
+              onRemove={() => remove(s)}
+              onRefresh={refresh}
+            />
           ))}
         </div>
       )}
+
+      {/* One-click OAuth presets not yet configured. */}
+      {MCP_PRESETS.filter((p) => !servers.some((s) => s.name === p.name)).map((p) => (
+        <div key={p.name} className={CARD + " p-3.5 flex items-center gap-3"} data-testid={`mcp-preset-${p.name}`}>
+          <div className="flex-1 min-w-0">
+            <div className="text-[14px] font-medium">{p.label}</div>
+            <div className="text-[11.5px] text-faint">{p.blurb}</div>
+          </div>
+          <button
+            className={BTN_ACCENT}
+            onClick={async () => {
+              await addMcpServer(p.name, p.config);
+              await connectMcp(p.name); // opens the browser sign-in right away
+              refresh();
+            }}
+          >
+            Connect
+          </button>
+        </div>
+      ))}
 
       {adding ? (
         <AddForm
@@ -304,14 +352,27 @@ function McpRow({
   server,
   onToggle,
   onRemove,
+  onRefresh,
 }: {
   server: McpServer;
   onToggle: () => void;
   onRemove: () => void;
+  onRefresh: () => void;
 }) {
   const [tools, setTools] = useState<{ name: string; description: string }[] | null>(null);
   const [busy, setBusy] = useState(false);
   const [toolErr, setToolErr] = useState<string | null>(null);
+
+  const isOauth = server.auth === "oauth";
+  const authorizing = server.status === "authorizing";
+  const signIn = async () => {
+    await connectMcp(server.name); // browser opens; the tab's poll flips the status
+    onRefresh();
+  };
+  const signOut = async () => {
+    await signoutMcp(server.name);
+    onRefresh();
+  };
 
   const loadTools = async () => {
     if (tools) {
@@ -333,11 +394,28 @@ function McpRow({
         <div className="flex-1 min-w-0">
           <div className="text-[14px] font-medium">{server.name}</div>
           <div className="text-[11.5px] text-faint">
-            {server.transport} · {server.status}
+            {server.transport} · {authorizing ? "signing in…" : server.status.replace("_", " ")}
             {server.tool_count != null ? ` · ${server.tool_count} tools` : ""}
             {server.requires_approval ? " · asks" : ""}
+            {isOauth ? " · oauth" : ""}
           </div>
         </div>
+        {isOauth &&
+          (server.status === "needs_auth" ? (
+            <button className={BTN_ACCENT} onClick={signIn} data-testid={`mcp-signin-${server.name}`}>
+              Sign in
+            </button>
+          ) : authorizing ? (
+            <span className="text-[12px] text-muted shrink-0">waiting for browser…</span>
+          ) : server.status === "connected" ? (
+            <button
+              className="text-[12px] text-muted hover:text-ink shrink-0"
+              onClick={signOut}
+              data-testid={`mcp-signout-${server.name}`}
+            >
+              sign out
+            </button>
+          ) : null)}
         <button
           className="text-[12px] text-muted hover:text-ink shrink-0"
           onClick={loadTools}
@@ -349,6 +427,9 @@ function McpRow({
           remove
         </button>
       </div>
+      {server.last_error && server.status !== "connected" && (
+        <div className="text-[12.5px] text-danger mt-1.5">{server.last_error}</div>
+      )}
       {toolErr && <div className="text-[12.5px] text-danger mt-1.5">{toolErr}</div>}
       {tools && (
         <div className="mt-2.5 pt-2.5 border-t border-line flex flex-wrap gap-1.5">

--- a/platform/tests/test_mcp_oauth.py
+++ b/platform/tests/test_mcp_oauth.py
@@ -1,0 +1,174 @@
+"""MCP OAuth (browser sign-in for remote servers, mcp/oauth.py): config parsing, token
+persistence in the SecretStore, callback plumbing, status surfacing, and the loopback
+route. No live OAuth server — the SDK's flow itself is upstream-tested; these guard OUR
+integration points."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+
+import pytest
+from fastapi.testclient import TestClient
+from mcp.shared.auth import OAuthClientInformationFull, OAuthToken
+
+from coworker.mcp import oauth as mcp_oauth
+from coworker.mcp.config import load_mcp_servers
+from coworker.secrets import SecretStore
+from coworker.server.app import create_app
+from coworker.server.manager import SessionManager
+
+GRANOLA = {"type": "http", "url": "https://mcp.granola.ai/mcp", "auth": "oauth"}
+
+
+def _state(tmp_path, monkeypatch, servers=None):
+    monkeypatch.setenv("COWORKER_STATE_DIR", str(tmp_path / "state"))
+    path = tmp_path / "state" / "mcp.json"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps({"mcpServers": servers or {}}), encoding="utf-8")
+
+
+@pytest.fixture(autouse=True)
+def _no_pending():
+    mcp_oauth._pending = None
+    yield
+    mcp_oauth._pending = None
+
+
+# -- config --------------------------------------------------------------------
+
+
+def test_config_parses_auth_field(tmp_path, monkeypatch):
+    _state(
+        tmp_path, monkeypatch, {"granola": GRANOLA, "plain": {"url": "https://x/mcp"}}
+    )
+    servers = {s.name: s for s in load_mcp_servers()}
+    assert servers["granola"].auth == "oauth"
+    assert servers["granola"].transport == "http"
+    assert servers["plain"].auth is None
+
+
+# -- token storage ---------------------------------------------------------------
+
+
+def test_token_storage_roundtrip(tmp_path, monkeypatch):
+    _state(tmp_path, monkeypatch)
+    secrets = SecretStore()
+    storage = mcp_oauth.SecretStoreTokenStorage("granola", secrets)
+
+    async def run():
+        assert await storage.get_tokens() is None
+        await storage.set_tokens(
+            OAuthToken.model_validate(
+                {"access_token": "at", "token_type": "Bearer", "refresh_token": "rt"}
+            )
+        )
+        await storage.set_client_info(
+            OAuthClientInformationFull.model_validate(
+                {
+                    "client_id": "dcr-123",
+                    "redirect_uris": ["http://127.0.0.1:8765/mcp/oauth/callback"],
+                }
+            )
+        )
+        tokens = await storage.get_tokens()
+        info = await storage.get_client_info()
+        return tokens, info
+
+    tokens, info = asyncio.run(run())
+    assert tokens.access_token == "at" and tokens.refresh_token == "rt"
+    assert info.client_id == "dcr-123"  # DCR registration survives restarts
+    assert mcp_oauth.has_tokens("granola", secrets)
+    assert mcp_oauth.sign_out("granola", secrets)
+    assert not mcp_oauth.has_tokens("granola", secrets)
+
+
+# -- callback plumbing -----------------------------------------------------------
+
+
+def test_deliver_without_waiter_is_rejected():
+    assert mcp_oauth.deliver_callback("code", "state") is False
+
+
+def test_wait_then_deliver_resolves():
+    async def run():
+        task = asyncio.create_task(mcp_oauth._wait_for_callback())
+        await asyncio.sleep(0)  # let the waiter install its future
+        assert mcp_oauth.deliver_callback("c0de", "st4te") is True
+        return await task
+
+    assert asyncio.run(run()) == ("c0de", "st4te")
+
+
+# -- status surfacing over REST ---------------------------------------------------
+
+
+def test_list_mcp_oauth_statuses(tmp_path, monkeypatch):
+    _state(tmp_path, monkeypatch, {"granola": GRANOLA})
+    manager = SessionManager(data_dir=tmp_path / "data")
+    client = TestClient(create_app(manager))
+
+    row = client.get("/v1/mcp").json()["servers"][0]
+    assert row["auth"] == "oauth" and row["status"] == "needs_auth"
+
+    manager._mcp_authorizing.add("granola")
+    assert client.get("/v1/mcp").json()["servers"][0]["status"] == "authorizing"
+    manager._mcp_authorizing.discard("granola")
+
+    manager._mcp_errors["granola"] = "sign-in timed out"
+    row = client.get("/v1/mcp").json()["servers"][0]
+    assert row["last_error"] == "sign-in timed out"
+
+    manager.secrets.put("mcp-oauth:granola", {"tokens": {"access_token": "at"}})
+    assert client.get("/v1/mcp").json()["servers"][0]["status"] == "configured"
+
+    assert client.post("/v1/mcp/granola/signout").json()["ok"] is True
+    assert not mcp_oauth.has_tokens("granola", manager.secrets)
+    assert client.get("/v1/mcp").json()["servers"][0]["status"] == "needs_auth"
+
+
+def test_connect_endpoint_starts_background_flow(tmp_path, monkeypatch):
+    _state(tmp_path, monkeypatch, {"granola": GRANOLA})
+    manager = SessionManager(data_dir=tmp_path / "data")
+
+    seen = {}
+
+    async def fake_connect(name):
+        seen["name"] = name
+        return {"ok": True}
+
+    monkeypatch.setattr(manager, "connect_mcp", fake_connect)
+    client = TestClient(create_app(manager))
+    assert client.post("/v1/mcp/granola/connect").json() == {
+        "ok": True,
+        "started": True,
+    }
+    assert seen["name"] == "granola"
+
+
+# -- loopback route ----------------------------------------------------------------
+
+
+def test_callback_route(tmp_path, monkeypatch):
+    _state(tmp_path, monkeypatch)
+    manager = SessionManager(data_dir=tmp_path / "data")
+    client = TestClient(create_app(manager))
+
+    # Provider error → failure page.
+    r = client.get("/mcp/oauth/callback", params={"error": "access_denied"})
+    assert r.status_code == 400 and "failed" in r.text.lower()
+
+    # No flow waiting → stale-tab page.
+    r = client.get("/mcp/oauth/callback", params={"code": "x"})
+    assert r.status_code == 400 and "waiting" in r.text.lower()
+
+    # A waiting flow gets the code and the browser sees the success page.
+    loop = asyncio.new_event_loop()
+    try:
+        future = loop.create_future()
+        mcp_oauth._pending = future
+        r = client.get("/mcp/oauth/callback", params={"code": "c1", "state": "s1"})
+        assert r.status_code == 200 and "close this tab" in r.text.lower()
+        assert future.result() == ("c1", "s1")
+    finally:
+        loop.close()


### PR DESCRIPTION
Support for remote MCP server with OAuth (OAuth 2.1 + PKCE + Dynamic Client Registration)
Tested with Granola