### PR TITLE
OpenWorker Connectors - JIRA and Monday.com

### DIFF
--- a/platform/coworker/connectors/catalog_copy.py
+++ b/platform/coworker/connectors/catalog_copy.py
@@ -47,6 +47,13 @@ ABOUT: dict[str, str] = {
     "meetings and answer pipeline questions, and log notes as you work.",
     "google_drive": "Search, browse, and read files across your Drive. "
     "Multiple accounts connect side by side.",
+    "monday": "Work with your monday.com boards — read items, summarize and "
+    "aggregate board data, create items, and post updates. One-click sign-in "
+    "runs entirely on this Mac against monday.com's own agent service; agents "
+    "get a small curated set of its tools, never the full catalog.",
+    "asana": "Keep up with your Asana work — search and read tasks and "
+    "projects, create tasks, and comment. Connects with a personal access "
+    "token from the Asana developer console.",
 }
 
 # What connecting actually grants, as short honest bullets. Write powers always
@@ -95,7 +102,15 @@ ACCESS: dict[str, list[str]] = {
     ],
     "jira": [
         "Reads and searches issues your account can see.",
-        "Creates issues as you.",
+        "Creates, updates, and transitions issues; comments as you.",
+    ],
+    "monday": [
+        "Reads boards, items, and updates your account can see.",
+        "Creates items, changes item values, and posts updates as you.",
+    ],
+    "asana": [
+        "Reads and searches tasks your account can see.",
+        "Creates tasks as you.",
     ],
     "confluence": [
         "Reads and searches spaces and pages your account can see.",
@@ -120,10 +135,6 @@ ACCESS: dict[str, list[str]] = {
     "stripe": [
         "Reads customers, charges, and invoices — read-only.",
         "A restricted read-only key means write access isn't even possible.",
-    ],
-    "asana": [
-        "Reads and searches tasks your account can see.",
-        "Creates tasks as you.",
     ],
     "hubspot": [
         "Reads contacts, companies, deals, and tickets.",

--- a/platform/coworker/connectors/descriptors.py
+++ b/platform/coworker/connectors/descriptors.py
@@ -65,6 +65,13 @@ class ConnectorDescriptor:
     # Extra search terms for the catalog typeahead — capability words the title
     # doesn't carry (e.g. "calendar" must surface Outlook, not just Google Calendar).
     aliases: tuple = ()
+    # Vendor-hosted MCP server URL → this connector is MCP-BACKED: one-click connect
+    # runs the local MCP OAuth flow (DCR, tokens on this Mac — no broker), and the
+    # tool surface is the PINNED subset in tool_defs (names `mcp__<name>__<tool>`),
+    # never the vendor's full catalog (drift can only shrink capability, not grow it).
+    # A connector may carry BOTH mcp_url and manual fields (jira): the profile's
+    # mode decides which tool set is live.
+    mcp_url: str = ""
     # Experimental connectors are hidden unless the user enables them in settings, require an
     # explicit risk acknowledgment to connect, and ship in a separate package
     # (connectors/experimental/) that release builds exclude entirely.
@@ -658,6 +665,8 @@ DESCRIPTORS: list[ConnectorDescriptor] = [
         two_way=False,
         brand_color="#0052cc",
         logo="jira",
+        aliases=("issues", "tickets", "atlassian", "project management"),
+        mcp_url="https://mcp.atlassian.com/v1/mcp",
         fields=[
             Field(
                 "base_url",
@@ -669,8 +678,26 @@ DESCRIPTORS: list[ConnectorDescriptor] = [
             Field("api_token", "API token", secret=True, help="Atlassian API token."),
         ],
         instructions=[
-            "Create an Atlassian API token for your account.",
-            "Paste your site URL, account email, and API token below.",
+            "One click connects via Atlassian sign-in in your browser (recommended).",
+            "Manual: create an Atlassian API token and paste your site URL, account email, and token below.",
+        ],
+        available=True,
+    ),
+    ConnectorDescriptor(
+        name="monday",
+        title="monday.com",
+        icon="▦",
+        blurb="Read boards and items, track work, create items and post updates.",
+        auth="oauth",
+        two_way=False,
+        brand_color="#6161ff",
+        logo="monday",
+        aliases=("project management", "tasks", "boards", "work management"),
+        mcp_url="https://mcp.monday.com/mcp",
+        fields=[],
+        instructions=[
+            "One click connects via monday.com sign-in in your browser.",
+            "Sign-in is fully local — tokens stay on this Mac.",
         ],
         available=True,
     ),
@@ -830,11 +857,17 @@ DESCRIPTORS: list[ConnectorDescriptor] = [
         name="asana",
         title="Asana",
         icon="⊙",
-        blurb="Search tasks, read details, and create tasks.",
+        blurb="Search and read tasks and projects; create, update, and comment.",
         auth="token",
         two_way=False,
         brand_color="#f06a6a",
         logo="asana",
+        aliases=("project management", "tasks", "work management"),
+        # NO mcp_url (2026-07-20): Asana's V2 MCP server rejects Dynamic Client
+        # Registration — it needs a pre-registered "MCP app" with an EXACT redirect
+        # URI, which our dynamic sidecar port can't provide. One-click returns when
+        # the broker-routed callback lands; the pinned mcp__asana__* defs sit
+        # dormant until then. Manual token stays the connect path.
         fields=[
             Field(
                 "token",

--- a/platform/coworker/connectors/setup.py
+++ b/platform/coworker/connectors/setup.py
@@ -43,6 +43,14 @@ def _profile_connected(descriptor, profile: dict[str, Any]) -> bool:
     return bool(profile) and all(bool(profile.get(k)) for k in required)
 
 
+def _mcp_tokens_present(secrets: SecretStore, name: str) -> bool:
+    # Lazy import: the mcp package pulls in the MCP SDK, which connector listing
+    # shouldn't pay for unless an MCP-backed profile actually exists.
+    from ..mcp.oauth import has_tokens
+
+    return has_tokens(name, secrets)
+
+
 def connector_list(secrets: SecretStore) -> list[dict[str, Any]]:
     show_experimental = experimental_enabled(secrets)
     out: list[dict[str, Any]] = []
@@ -53,7 +61,12 @@ def connector_list(secrets: SecretStore) -> list[dict[str, Any]]:
         if d.experimental and not show_experimental:
             continue
         profile = secrets.get(f"{d.name}:default") or {}
-        connected = _profile_connected(d, profile)
+        if d.mcp_url and profile.get("mode") == "mcp":
+            # MCP-backed connect: the profile is just a marker — connected-ness
+            # lives with the OAuth tokens (mcp-oauth:<name> in the SecretStore).
+            connected = _mcp_tokens_present(secrets, d.name)
+        else:
+            connected = _profile_connected(d, profile)
         entry = {
             "name": d.name,
             "title": d.title,
@@ -70,6 +83,9 @@ def connector_list(secrets: SecretStore) -> list[dict[str, Any]]:
             "brand_color": d.brand_color,
             "logo": d.logo,
             "aliases": list(d.aliases),
+            # MCP-backed one-click (vendor-hosted MCP server + local OAuth) —
+            # distinct from `managed` (broker OAuth): no cloud sign-in needed.
+            "mcp": bool(d.mcp_url),
             "fields": [f.to_dict() for f in d.fields],
             "instructions": d.instructions,
             "connected": connected,
@@ -463,4 +479,13 @@ def disconnect_connector(secrets: SecretStore, name: str) -> dict[str, Any]:
                 secrets.delete(github_installs.PREFIX + installation_id)
                 or dropped_accounts
             )
+    profile = secrets.get(f"{name}:default") or {}
+    if profile.get("mode") == "mcp":
+        # MCP-backed connect: forget the OAuth tokens + DCR registration and remove
+        # the seeded server entry, so a reconnect runs a fresh flow.
+        from ..mcp import config as mcp_config
+        from ..mcp import oauth as mcp_oauth
+
+        dropped_accounts = mcp_oauth.sign_out(name, secrets) or dropped_accounts
+        mcp_config.delete_global_server(name)
     return {"ok": secrets.delete(f"{name}:default") or dropped_accounts}

--- a/platform/coworker/connectors/tool_defs.py
+++ b/platform/coworker/connectors/tool_defs.py
@@ -302,6 +302,196 @@ TOOL_DEFS: tuple[ConnectorToolDef, ...] = (
     ConnectorToolDef(
         "jira", "jira_create_issue", "Create issue", "write", "Create a Jira issue."
     ),
+    # -- jira via the Atlassian hosted MCP server (one-click path) ---------------
+    # PINNED allowlist (UX-DECISIONS §42): tool names are `mcp__<connector>__<vendor
+    # tool>` exactly as mcp/tools.py builds them; anything the vendor ships that is
+    # not listed here never reaches a session. Which set is live (these vs the
+    # jira_* REST tools above) follows the profile's mode — see tool_dicts.
+    ConnectorToolDef(
+        "jira",
+        "mcp__jira__getVisibleJiraProjects",
+        "List projects",
+        "read",
+        "List Jira projects you can access.",
+    ),
+    ConnectorToolDef(
+        "jira",
+        "mcp__jira__searchJiraIssuesUsingJql",
+        "Search issues",
+        "read",
+        "Search Jira issues using JQL.",
+    ),
+    ConnectorToolDef(
+        "jira",
+        "mcp__jira__getJiraIssue",
+        "Read issue",
+        "read",
+        "Read a Jira issue.",
+    ),
+    ConnectorToolDef(
+        "jira",
+        "mcp__jira__getTransitionsForJiraIssue",
+        "List transitions",
+        "read",
+        "List available workflow transitions for an issue.",
+    ),
+    ConnectorToolDef(
+        "jira",
+        "mcp__jira__createJiraIssue",
+        "Create issue",
+        "write",
+        "Create a Jira issue.",
+    ),
+    ConnectorToolDef(
+        "jira",
+        "mcp__jira__editJiraIssue",
+        "Update issue",
+        "write",
+        "Update fields on an existing issue.",
+    ),
+    ConnectorToolDef(
+        "jira",
+        "mcp__jira__addCommentToJiraIssue",
+        "Comment",
+        "write",
+        "Add a comment to an issue.",
+    ),
+    ConnectorToolDef(
+        "jira",
+        "mcp__jira__transitionJiraIssue",
+        "Transition issue",
+        "write",
+        "Move an issue through its workflow.",
+    ),
+    # -- monday.com (MCP-backed only; pinned subset of their 60+ tool catalog) ----
+    ConnectorToolDef(
+        "monday",
+        "mcp__monday__get_user_context",
+        "Who am I",
+        "read",
+        "Read the signed-in user, account, and their boards.",
+    ),
+    ConnectorToolDef(
+        "monday",
+        "mcp__monday__search",
+        "Search",
+        "read",
+        "Search boards, docs, forms, and folders.",
+    ),
+    ConnectorToolDef(
+        "monday",
+        "mcp__monday__get_board_info",
+        "Read board",
+        "read",
+        "Read a board's columns, groups, views, and owners.",
+    ),
+    ConnectorToolDef(
+        "monday",
+        "mcp__monday__get_board_items_page",
+        "List items",
+        "read",
+        "Page through the items on a board.",
+    ),
+    ConnectorToolDef(
+        "monday",
+        "mcp__monday__board_insights",
+        "Board insights",
+        "read",
+        "Aggregate, filter, and group board data.",
+    ),
+    ConnectorToolDef(
+        "monday",
+        "mcp__monday__get_updates",
+        "Read updates",
+        "read",
+        "Read updates (comments) from an item or board.",
+    ),
+    ConnectorToolDef(
+        "monday",
+        "mcp__monday__create_item",
+        "Create item",
+        "write",
+        "Create an item on a board.",
+    ),
+    ConnectorToolDef(
+        "monday",
+        "mcp__monday__change_item_column_values",
+        "Update item",
+        "write",
+        "Change column values on an item.",
+    ),
+    ConnectorToolDef(
+        "monday",
+        "mcp__monday__create_update",
+        "Post update",
+        "write",
+        "Post a comment or reply on an item.",
+    ),
+    # -- asana via their hosted V2 MCP server (one-click path; the asana_* REST
+    # tools below stay the manual-token set — profile mode picks, as with jira) ---
+    ConnectorToolDef(
+        "asana",
+        "mcp__asana__get_me",
+        "Who am I",
+        "read",
+        "Read the signed-in Asana user.",
+    ),
+    ConnectorToolDef(
+        "asana",
+        "mcp__asana__search_tasks",
+        "Search tasks",
+        "read",
+        "Search tasks across the workspace.",
+    ),
+    ConnectorToolDef(
+        "asana",
+        "mcp__asana__get_task",
+        "Read task",
+        "read",
+        "Read a task with its fields and comments.",
+    ),
+    ConnectorToolDef(
+        "asana",
+        "mcp__asana__get_my_tasks",
+        "My tasks",
+        "read",
+        "List the signed-in user's tasks.",
+    ),
+    ConnectorToolDef(
+        "asana",
+        "mcp__asana__get_project",
+        "Read project",
+        "read",
+        "Read a project's details.",
+    ),
+    ConnectorToolDef(
+        "asana",
+        "mcp__asana__get_status_overview",
+        "Status overview",
+        "read",
+        "Read status updates for projects and portfolios.",
+    ),
+    ConnectorToolDef(
+        "asana",
+        "mcp__asana__create_tasks",
+        "Create tasks",
+        "write",
+        "Create one or more tasks.",
+    ),
+    ConnectorToolDef(
+        "asana",
+        "mcp__asana__update_tasks",
+        "Update tasks",
+        "write",
+        "Update fields on existing tasks.",
+    ),
+    ConnectorToolDef(
+        "asana",
+        "mcp__asana__add_comment",
+        "Comment",
+        "write",
+        "Add a comment to a task.",
+    ),
     ConnectorToolDef(
         "confluence",
         "confluence_search",
@@ -969,10 +1159,37 @@ def patch_tool_settings(
     return {"ok": True, "tools": current}
 
 
+def mcp_tool_defs(connector: str) -> list[ConnectorToolDef]:
+    """The connector's PINNED MCP tools (names `mcp__<connector>__<vendor tool>`)."""
+    return [
+        t for t in TOOLS_BY_CONNECTOR.get(connector, []) if t.name.startswith("mcp__")
+    ]
+
+
+def mcp_pinned_tools(connector: str) -> list[str]:
+    """Vendor-side tool names of the pinned allowlist (prefix stripped) — what goes
+    into the seeded server config's `include_tools`."""
+    prefix = f"mcp__{connector}__"
+    return [t.name.removeprefix(prefix) for t in mcp_tool_defs(connector)]
+
+
+def active_tool_defs(secrets: SecretStore, connector: str) -> list[ConnectorToolDef]:
+    """The defs live for this connector's CURRENT profile. A connector with both an
+    API tool set and a pinned MCP set (jira) exposes exactly one of them, following
+    the profile's mode; single-set connectors are unaffected."""
+    defs = TOOLS_BY_CONNECTOR.get(connector, [])
+    mcp = [t for t in defs if t.name.startswith("mcp__")]
+    api = [t for t in defs if not t.name.startswith("mcp__")]
+    if not mcp or not api:
+        return defs
+    profile = secrets.get(f"{connector}:default") or {}
+    return mcp if profile.get("mode") == "mcp" else api
+
+
 def tool_dicts(secrets: SecretStore, connector: str) -> list[dict[str, Any]]:
     overrides = load_tool_settings(secrets, connector)
     out = []
-    for tool in TOOLS_BY_CONNECTOR.get(connector, []):
+    for tool in active_tool_defs(secrets, connector):
         out.append(
             {
                 "name": tool.name,

--- a/platform/coworker/server/app.py
+++ b/platform/coworker/server/app.py
@@ -683,6 +683,19 @@ def create_app(manager: SessionManager) -> FastAPI:
             await _refresh_listeners_if_two_way(name)
         return result
 
+    @app.post("/v1/connectors/{name}/mcp-connect")
+    async def connector_mcp_connect(name: str) -> dict[str, Any]:
+        # One-click connect for an MCP-backed connector: the browser OAuth flow can
+        # take minutes, so it runs in the background; the GUI polls /v1/connectors
+        # until the card flips to connected (mode "mcp").
+        from ..connectors.descriptors import get_descriptor
+
+        d = get_descriptor(name)
+        if d is None or not d.mcp_url:
+            return {"ok": False, "error": f"{name} has no MCP connect path"}
+        asyncio.create_task(manager.mcp_connect_connector(name))
+        return {"ok": True, "started": True}
+
     @app.post("/v1/connectors/{name}/disconnect")
     async def connector_disconnect(name: str) -> dict[str, Any]:
         # Managed profiles: best-effort flip of the cloud metadata record first

--- a/platform/coworker/server/manager.py
+++ b/platform/coworker/server/manager.py
@@ -785,36 +785,73 @@ class SessionManager:
         """
         if session_id in self._engines:
             return []
+        from ..connectors.descriptors import get_descriptor
+        from ..connectors.tool_defs import (
+            approval_for_tool,
+            mcp_tool_defs,
+            tool_enabled,
+        )
+
         ws = self.engine_workspace(session_id, workspace=workspace, agent=agent)
         loop = asyncio.get_running_loop()
+        effective: Optional[set[str]] = None  # computed lazily, once
         out: list[Any] = []
         for server in load_mcp_servers(ws, secrets=self.secrets):
             if not server.enabled:
                 continue
+            descriptor = get_descriptor(server.name)
+            backed = descriptor is not None and bool(descriptor.mcp_url)
+            if backed:
+                # Connector-backed server: obey the same gates as connector tools —
+                # the session's effective connector set and the per-tool toggles.
+                # The descriptor's PIN is authoritative over whatever the config
+                # file says (drift can only ever shrink the surface).
+                if effective is None:
+                    effective = self.effective_connectors(session_id, agent)
+                if server.name not in effective:
+                    continue
+                prefix = f"mcp__{server.name}__"
+                server.include_tools = [
+                    t.name.removeprefix(prefix)
+                    for t in mcp_tool_defs(server.name)
+                    if tool_enabled(self.secrets, server.name, t.name)
+                ]
             try:
                 conn = await self.mcp.ensure(server)
             except (
                 Exception
             ):  # bad command / unreachable url — skip, don't break the session
                 continue
-            out.extend(
-                build_callables(
-                    server,
-                    conn.tools,
-                    lambda tool, args, name=server.name: self.mcp.call(
-                        name, tool, args
-                    ),
-                    loop,
-                )
+            callables = build_callables(
+                server,
+                conn.tools,
+                lambda tool, args, name=server.name: self.mcp.call(name, tool, args),
+                loop,
             )
+            if backed:
+                # Per-tool approval from the pinned read/write classification
+                # (server-level requires_approval is off for backed servers);
+                # anything unclassified stays approval-gated — fail closed.
+                for fn in callables:
+                    fn.__aisuite_tool_metadata__.requires_approval = approval_for_tool(
+                        fn.__aisuite_tool_metadata__.name, default=True
+                    )
+            out.extend(callables)
         return out
 
     def list_mcp(self) -> list[dict[str, Any]]:
         """Servers from the global config + connection status (does not connect)."""
         from ..mcp import oauth as mcp_oauth
 
+        from ..connectors.descriptors import get_descriptor
+
         out = []
         for name, raw in read_global().items():
+            d = get_descriptor(name)
+            if d is not None and d.mcp_url:
+                # Connector-backed server: surfaced on the Connectors page (its
+                # connect/disconnect lifecycle lives there), not in the MCP tab.
+                continue
             connected = name in self.mcp._conns
             is_oauth = str(raw.get("auth", "")).lower() == "oauth"
             if connected:
@@ -870,6 +907,37 @@ class SessionManager:
             finally:
                 self._mcp_authorizing.discard(name)
         return {"ok": False, "error": f"unknown MCP server: {name}"}
+
+    async def mcp_connect_connector(self, name: str) -> dict[str, Any]:
+        """One-click connect for an MCP-BACKED connector (descriptor.mcp_url): seed
+        the global server entry pinned to the curated allowlist, run the browser
+        OAuth flow, and mark the connector profile `mode: "mcp"` on success."""
+        from ..connectors.descriptors import get_descriptor
+        from ..connectors.tool_defs import mcp_pinned_tools
+
+        d = get_descriptor(name)
+        if d is None or not d.mcp_url:
+            return {"ok": False, "error": f"{name} has no MCP connect path"}
+        put_global_server(
+            name,
+            {
+                "url": d.mcp_url,
+                "auth": "oauth",
+                # Server-level approval off: writes gate per-tool via the pinned
+                # read/write classification (prepare_mcp_tools); unknown vendor
+                # tools never load at all (include_tools).
+                "requires_approval": False,
+                "include_tools": mcp_pinned_tools(name),
+                "enabled": True,
+            },
+        )
+        result = await self.connect_mcp(name)
+        if result.get("ok"):
+            profile = self.secrets.get(f"{name}:default") or {}
+            self.secrets.put(
+                f"{name}:default", {**profile, "mode": "mcp", "enabled": True}
+            )
+        return result
 
     async def signout_mcp(self, name: str) -> dict[str, Any]:
         """Drop the live connection (if any) and forget the stored OAuth tokens."""
@@ -966,6 +1034,10 @@ class SessionManager:
         return set_experimental_enabled(self.secrets, value)
 
     def disconnect_connector(self, name: str) -> dict[str, Any]:
+        # MCP-backed profile: drop the live server connection before the tokens go.
+        conn = self.mcp._conns.get(name)
+        if conn is not None:
+            conn.shutdown.set()
         return disconnect_connector(self.secrets, name)
 
     def update_connector_tools(

--- a/platform/docs/UX-DECISIONS.md
+++ b/platform/docs/UX-DECISIONS.md
@@ -1053,8 +1053,47 @@ and footer never move — only the middle region swaps, at a fixed height** (ext
   **"Custom endpoint ⌄" renders below the key-help line** as its own advanced row (both
   surfaces — the disclosure lives in the shared ProviderForm).
 
+## 42. Connectors are backing-agnostic: hosted-MCP connectors with a pinned tool allowlist  *(Decided 2026-07-19 by owner → Built 2026-07-19; no mock — extends §21's grammar; monday.com / Asana / Jira first)*
+
+The user's decision: "leverage MCP+OAuth wherever possible, but still show it in the
+Connectors section — from a UX perspective it shouldn't matter whether the connector is an
+app or MCP." A connector is a product concept (card, copy, consent, approval posture); the
+backing (broker OAuth app, vendor-hosted MCP server, manual token, relay) is plumbing.
+
+- **MCP-backed connector** = descriptor with `mcp_url` + a **pinned allowlist** of tools in
+  `tool_defs` (names `mcp__<connector>__<vendor tool>`). The pin is a whitelist that FAILS
+  CLOSED: only pinned tools ever reach a session or the Access bullets — the vendor shipping
+  new tools cannot silently expand agent capability (the owner's drift worry). Missing pins
+  degrade; unknown tools never load (`include_tools` on the seeded server config, re-derived
+  from the pin at session build so stale config can't widen it).
+- **Connect is one click and FULLY LOCAL**: the sidecar runs the MCP OAuth 2.1 flow (DCR —
+  no client secret, no broker, no OpenWorker sign-in). The modal says so ("no OpenWorker
+  account needed; sign-in runs entirely on this computer"). Connectors with a manual path
+  too (jira, asana) keep the §21 One click | Manual pills; MCP-only connectors (monday)
+  render the one-click pane directly. The profile's `mode: "mcp"` decides which tool set is
+  live — MCP pin vs the manual REST tools — one at a time, never both.
+- **Per-tool approval follows the pin's read/write classification** (reads run free, writes
+  ask first), not the MCP layer's server-level flag; unclassified defaults to ask. Session
+  gating matches connector tools exactly: effective-connector set (§4.3) + per-tool toggles.
+- **Placement**: MCP-backed connectors are cards on the Connectors page with §38 detail
+  pages; they are HIDDEN from the Settings ▸ MCP tab (that tab stays for arbitrary/community
+  servers). Disconnect forgets tokens + DCR registration + the seeded config.
+- First wave: **monday.com** (`mcp.monday.com/mcp`, MCP-only) and **Jira** via the
+  Atlassian server (`mcp.atlassian.com/v1/mcp`, + manual API token) — both accept DCR, so
+  no vendor app registrations, no review queues, no broker changes. **Asana was pulled
+  from the wave on 2026-07-20** (live test): their V2 server rejects DCR and requires a
+  pre-registered "MCP app" with an exact-match redirect URI, which the desktop's
+  dynamically-chosen sidecar port can't satisfy — one-click returns via a broker-routed
+  callback later; its pinned defs sit dormant and the manual PAT path stays.
+
 ## Change log (requests, newest first)
 
+- **2026-07-19 (26)** — Owner: "leverage MCP+OAuth wherever possible but still add it in the
+  Connectors section — UX-wise it shouldn't matter if the connector is an App or MCP"; and
+  "selectively allow only certain tool calls from the MCP connectors" (drift worry: vendors
+  changing their exposed functions) → §42 (pinned-allowlist MCP-backed connectors; monday.com
+  + Asana + Jira built same day). Tool-def scaling (caching audit, deferred tools + search)
+  noted on the launch punchlist for a later discussion.
 - **2026-07-19 (25)** — Owner critique of the built §39 flow (from DMG walkthrough screenshots):
   hover-only Coming soon, scattered grayed cards, blue-vs-black primaries, 700px void, key
   state-restore bug, endpoint placement → fixes + full step-2 redesign through three mock

--- a/platform/surfaces/gui/e2e/fixtures.ts
+++ b/platform/surfaces/gui/e2e/fixtures.ts
@@ -137,6 +137,11 @@ const CONNECTORS = {
     { name: "outlook", title: "Outlook", icon: "◎", blurb: "Microsoft 365 mail and calendar: search, draft, and send email; manage events and respond to invites.", aliases: ["calendar", "email", "mail", "microsoft", "office"], auth: "oauth", two_way: false, channels: false, available: true, brand_color: "#0078d4", logo: "outlook", fields: [{ key: "access_token", label: "OAuth access token", secret: true, required: true, help: "", placeholder: "" }], instructions: [], connected: false, account: null, enabled: false, allowed_users: [], tools: [], managed: true, managed_profile: false },
     // Sixth active card in the onboarding gallery (promoted 2026-07-19 to even the grid).
     { name: "attio", title: "Attio", icon: "▣", blurb: "Search and read Attio CRM records; log notes.", auth: "oauth", two_way: false, channels: false, available: true, brand_color: "#2d6ae0", logo: "attio", fields: [{ key: "access_token", label: "OAuth access token", secret: true, required: true, help: "", placeholder: "" }], instructions: [], connected: false, account: null, enabled: false, allowed_users: [], tools: [], managed: true, managed_profile: false },
+    // MCP-BACKED connectors (§42): vendor-hosted MCP + local OAuth, pinned tool subset.
+    // monday is one-click ONLY (no manual fields); jira also has a manual token path
+    // (two-mode modal). Neither needs cloud sign-in.
+    { name: "monday", title: "monday.com", icon: "▦", blurb: "Read boards and items, track work, create items and post updates.", aliases: ["project management", "tasks", "boards"], auth: "oauth", two_way: false, channels: false, available: true, brand_color: "#6161ff", logo: "monday", mcp: true, fields: [], instructions: ["One click connects via monday.com sign-in in your browser.", "Sign-in is fully local — tokens stay on this Mac."], connected: false, account: null, enabled: false, allowed_users: [], tools: [{ name: "mcp__monday__get_board_info", label: "Read board", kind: "read", description: "Read a board's columns and groups.", enabled: true, requires_approval: false }, { name: "mcp__monday__create_item", label: "Create item", kind: "write", description: "Create an item on a board.", enabled: true, requires_approval: true }], managed: false, managed_profile: false },
+    { name: "jira", title: "Jira", icon: "◆", blurb: "Search, summarize, create, and update issues.", aliases: ["issues", "tickets", "atlassian"], auth: "api_token", two_way: false, channels: false, available: true, brand_color: "#0052cc", logo: "jira", mcp: true, fields: [{ key: "base_url", label: "Atlassian site URL", secret: false, required: true, help: "", placeholder: "" }, { key: "email", label: "Account email", secret: false, required: true, help: "", placeholder: "" }, { key: "api_token", label: "API token", secret: true, required: true, help: "", placeholder: "" }], instructions: [], connected: false, account: null, enabled: false, allowed_users: [], tools: [], managed: false, managed_profile: false },
   ],
 };
 
@@ -420,6 +425,18 @@ export async function mockApi(page: import("@playwright/test").Page) {
   // Outlook — email-keyed managed accounts (mirrors outlook:account:<email> profiles).
   const outlookState = {
     accounts: [] as { account_id: string; name: string; default: boolean; managed: boolean }[],
+  };
+  // MCP-backed connectors (§42) — per-test connect state; the mock "browser flow"
+  // completes instantly so the modal's poll picks it up.
+  const mcpState = { monday: false, jira: false };
+  const mcpConnector = (name: "monday" | "jira") => {
+    const base = CONNECTORS.connectors.find((c: any) => c.name === name);
+    return {
+      ...base,
+      connected: mcpState[name],
+      enabled: mcpState[name],
+      mode: mcpState[name] ? "mcp" : "",
+    };
   };
   const outlookConnector = () => {
     const base = CONNECTORS.connectors.find((c: any) => c.name === "outlook");
@@ -976,7 +993,9 @@ export async function mockApi(page: import("@playwright/test").Page) {
                     ? notionConnector()
                     : c.name === "outlook"
                       ? outlookConnector()
-                      : { ...c },
+                      : c.name === "monday" || c.name === "jira"
+                        ? mcpConnector(c.name)
+                        : { ...c },
           ),
         ],
       });
@@ -992,6 +1011,17 @@ export async function mockApi(page: import("@playwright/test").Page) {
     if (p.endsWith("/v1/cloud/logout") && m === "POST") {
       Object.assign(CLOUD_STATE, { signed_in: false, account: "", user_id: "" });
       return json({ ok: true, signed_in: false });
+    }
+    if (/\/v1\/connectors\/[^/]+\/mcp-connect$/.test(p) && m === "POST") {
+      // Local MCP OAuth flow — no cloud sign-in required; completes instantly here.
+      const name = p.match(/\/v1\/connectors\/([^/]+)\/mcp-connect$/)?.[1] as
+        | "monday"
+        | "jira";
+      if (name in mcpState) {
+        mcpState[name] = true;
+        return json({ ok: true, started: true });
+      }
+      return json({ ok: false, error: `${name} has no MCP connect path` });
     }
     if (/\/v1\/connectors\/[^/]+\/connect-managed$/.test(p) && m === "POST") {
       if (!CLOUD_STATE.signed_in) return json({ ok: false, error: "not signed in" });

--- a/platform/surfaces/gui/e2e/mcp-connectors.spec.ts
+++ b/platform/surfaces/gui/e2e/mcp-connectors.spec.ts
@@ -1,0 +1,71 @@
+// MCP-backed connectors (UX-DECISIONS §42): monday/asana/jira connect through the
+// vendor's hosted MCP server via a fully LOCAL OAuth flow — one-click without any
+// cloud sign-in — and agents get only the PINNED tool subset, surfaced on the
+// connector detail page like any other curated tool set.
+import { expect } from "@playwright/test";
+import { test } from "./fixtures";
+
+async function openConnectors(page) {
+  await page.goto("/");
+  await page.getByTestId("account-row").click();
+  await page.getByRole("button", { name: "Connectors", exact: true }).click();
+}
+
+test("monday: one-click MCP connect without cloud sign-in; card flips connected", async ({
+  page,
+}) => {
+  await openConnectors(page);
+
+  // Signed OUT (fixtures default) — the MCP one-click needs no OpenWorker account.
+  await page
+    .getByTestId("connector-monday")
+    .getByRole("button", { name: "Connect" })
+    .click();
+  const modal = page.getByTestId("add-connection-modal");
+  await expect(modal).toBeVisible();
+  // Single-mode: no One click | Manual pills, no cloud sign-in gate — just the button.
+  await expect(modal.getByTestId("modal-pane-manual")).toHaveCount(0);
+  await expect(modal.getByTestId("inline-cloud-sign-in")).toHaveCount(0);
+  await expect(modal.getByText("sign-in runs entirely on this computer")).toBeVisible();
+
+  await modal.getByTestId("modal-mcp-one-click").click();
+  await expect(modal.getByText("Check your browser…")).toBeVisible();
+  // The mock flow completes instantly; the modal's poll closes it and the card flips.
+  await expect(page.getByTestId("add-connection-modal")).toHaveCount(0, {
+    timeout: 10_000,
+  });
+  await expect(page.getByTestId("connector-monday")).toContainText("Connected");
+});
+
+test("jira: two modes — MCP one-click pane plus the manual token form", async ({
+  page,
+}) => {
+  await openConnectors(page);
+  // jira sits past the available-list fold.
+  await page.getByRole("button", { name: "show all" }).click();
+  await page
+    .getByTestId("connector-jira")
+    .getByRole("button", { name: "Connect" })
+    .click();
+  const modal = page.getByTestId("add-connection-modal");
+
+  // One click pane is the MCP flow (no cloud sign-in gate).
+  await expect(modal.getByTestId("modal-pane-one")).toBeVisible();
+  await expect(modal.getByTestId("modal-mcp-one-click")).toBeVisible();
+
+  // Manual keeps the existing Atlassian token fields.
+  await modal.getByTestId("modal-pane-manual").click();
+  await expect(modal.getByText("Atlassian site URL")).toBeVisible();
+  await expect(modal.getByText("API token")).toBeVisible();
+});
+
+test("monday detail page shows the pinned tool subset with approval badges", async ({
+  page,
+}) => {
+  await openConnectors(page);
+  await page.getByTestId("connector-monday").click();
+  await expect(page.getByText("2 tools this connector adds")).toBeVisible();
+  await page.getByText("View", { exact: true }).click();
+  await expect(page.getByText("Read board", { exact: true })).toBeVisible();
+  await expect(page.getByText("Create item", { exact: true })).toBeVisible();
+});

--- a/platform/surfaces/gui/src/api.ts
+++ b/platform/surfaces/gui/src/api.ts
@@ -380,6 +380,7 @@ export interface Connector {
   brand_color: string; // hex brand color, e.g. "#611f69" (fallback gray "#6b7280")
   logo: string; // stable logo id keyed into the frontend registry (empty → fallback glyph)
   aliases?: string[]; // extra typeahead terms ("calendar" surfaces Outlook)
+  mcp?: boolean; // MCP-backed one-click (vendor-hosted MCP + local OAuth — no cloud sign-in)
   allowed_users: string[]; // the allow-list (managed inline in the Connectors tab)
   allowed_user_names?: Record<string, string | null>; // id → display name (people directory)
   recent?: RecentSender[]; // recently-seen senders on a connected two-way connector
@@ -479,6 +480,17 @@ export async function connectManaged(
         ...(options?.access ? { access: options.access } : {}),
       }),
     },
+  );
+  return res.json();
+}
+
+/** One-click connect for an MCP-backed connector (monday, asana, jira): the sidecar
+ * opens the vendor's sign-in in the browser (local OAuth, no cloud account needed);
+ * poll getConnectors until the card flips to connected. */
+export async function connectMcpBacked(name: string): Promise<{ ok: boolean; error?: string }> {
+  const res = await fetch(
+    `${httpBase()}/v1/connectors/${encodeURIComponent(name)}/mcp-connect`,
+    { method: "POST" },
   );
   return res.json();
 }

--- a/platform/surfaces/gui/src/components/ManageTabs.tsx
+++ b/platform/surfaces/gui/src/components/ManageTabs.tsx
@@ -4,6 +4,7 @@ import {
   allowUser,
   connectConnector,
   connectManaged,
+  connectMcpBacked,
   connectMcp,
   deleteMcpServer,
   disallowUser,
@@ -799,9 +800,29 @@ export function ConnectSetup({
     else setError(res.error || "could not start managed connect");
   };
 
+  const mcpOneClick = async () => {
+    setError(null);
+    const res = await connectMcpBacked(c.name);
+    // Completion likewise arrives via the poll — the sidecar flips the connector
+    // to connected once the local OAuth flow lands.
+    if (res.ok) setWaiting(true);
+    else setError(res.error || "could not start the connect");
+  };
+
   return (
     <div className="border-t border-line px-3.5 py-3 space-y-3">
-      {c.managed && !manualOnly && (
+      {c.mcp && !manualOnly && (
+        /* MCP-backed one-click needs no cloud sign-in — the OAuth flow is local. */
+        <div className="space-y-2" data-testid="mcp-connect">
+          <button className={BTN_ACCENT} onClick={mcpOneClick} disabled={waiting}>
+            {waiting ? "Check your browser…" : `Connect ${c.title} with one click`}
+          </button>
+          {c.fields.length > 0 && (
+            <div className="text-[11.5px] text-faint">or connect manually:</div>
+          )}
+        </div>
+      )}
+      {c.managed && !c.mcp && !manualOnly && (
         <div className="space-y-2" data-testid="managed-connect">
           {cloud?.signed_in ? (
             <button className={BTN_ACCENT} onClick={oneClick} disabled={waiting}>

--- a/platform/surfaces/gui/src/components/connectors/AddConnectionModal.tsx
+++ b/platform/surfaces/gui/src/components/connectors/AddConnectionModal.tsx
@@ -1,5 +1,12 @@
 import { useEffect, useState } from "react";
-import { connectConnector, connectManaged, type CloudStatus, type Connector } from "../../api";
+import {
+  connectConnector,
+  connectManaged,
+  connectMcpBacked,
+  getConnectors,
+  type CloudStatus,
+  type Connector,
+} from "../../api";
 import { ConnectorBadge } from "../../connectors/ConnectorIcon";
 import { ConnectSetup } from "../ManageTabs";
 import { CloudSignInInline } from "./CloudSignIn";
@@ -26,12 +33,17 @@ export function AddConnectionModal({
   onClose: () => void;
   onChanged: () => void;
 }) {
+  // MCP-backed one-click (§42): local OAuth against the vendor's hosted MCP server —
+  // with manual fields alongside (jira, asana) it's a second mode; alone (monday)
+  // it IS the connect flow.
+  const mcpBacked = !!c.mcp;
   const twoModes =
     c.name === "slack" ||
     c.name === "hubspot" ||
     c.name === "github" ||
     c.name === "notion" ||
-    c.name === "attio";
+    c.name === "attio" ||
+    (mcpBacked && c.fields.length > 0);
   const [pane, setPane] = useState<"one" | "manual">("one");
 
   useEffect(() => {
@@ -78,7 +90,9 @@ export function AddConnectionModal({
               </div>
             </div>
             {pane === "one" ? (
-              c.name === "hubspot" ? (
+              mcpBacked ? (
+                <McpOneClick c={c} onConnected={() => { onChanged(); onClose(); }} />
+              ) : c.name === "hubspot" ? (
                 <HubSpotOneClick c={c} cloud={cloud} />
               ) : c.name === "github" ? (
                 <GithubOneClick c={c} cloud={cloud} />
@@ -95,6 +109,9 @@ export function AddConnectionModal({
               </div>
             )}
           </>
+        ) : mcpBacked ? (
+          /* MCP-backed with no manual fields (monday): one-click IS the flow. */
+          <McpOneClick c={c} onConnected={() => { onChanged(); onClose(); }} />
         ) : (
           <div className="px-1.5 pb-2">
             {/* Existing combined setup (managed button + manual fields) for everything else. */}
@@ -102,6 +119,55 @@ export function AddConnectionModal({
           </div>
         )}
       </div>
+    </div>
+  );
+}
+
+// One-click pane for MCP-BACKED connectors (monday, asana, jira — §42): the sidecar
+// runs a fully LOCAL OAuth flow against the vendor's hosted MCP server (DCR — no
+// client secret, no broker, no OpenWorker sign-in required). Poll until the card
+// flips to connected, then close.
+function McpOneClick({ c, onConnected }: { c: Connector; onConnected: () => void }) {
+  const [waiting, setWaiting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  useEffect(() => {
+    if (!waiting) return;
+    const t = setInterval(async () => {
+      try {
+        const list = await getConnectors();
+        if (list.find((x) => x.name === c.name)?.connected) onConnected();
+      } catch {
+        /* keep polling */
+      }
+    }, 2000);
+    return () => clearInterval(t);
+  }, [waiting, c.name, onConnected]);
+  const go = async () => {
+    setError(null);
+    const res = await connectMcpBacked(c.name);
+    if (res.ok) setWaiting(true);
+    else setError(res.error || "could not start the connect");
+  };
+  return (
+    <div className="px-5 py-4 space-y-3">
+      <p className="text-[13px] text-muted">
+        Opens {c.title} in your browser — sign in and approve access there. No tokens
+        typed, and no OpenWorker account needed: the sign-in runs entirely on this
+        computer.
+      </p>
+      <button
+        className={PILL_ACCENT + " w-full !py-2"}
+        data-testid="modal-mcp-one-click"
+        onClick={go}
+        disabled={waiting}
+      >
+        {waiting ? "Check your browser…" : `Connect ${c.title}`}
+      </button>
+      {error && <div className="text-[12.5px] text-danger">{error}</div>}
+      <p className="text-[12px] text-faint text-center flex items-center justify-center gap-1.5">
+        <span className={TAG_ACCENT}>Recommended</span> agents get a curated set of{" "}
+        {c.title} tools · tokens stay on this computer
+      </p>
     </div>
   );
 }

--- a/platform/surfaces/gui/src/connectors/registry.tsx
+++ b/platform/surfaces/gui/src/connectors/registry.tsx
@@ -126,6 +126,13 @@ const AttioLogo = strokeLogo(
   </>,
 );
 
+// monday.com's mark is three staggered capsule bars; no simple-icons mono mark exists.
+const MondayLogo = strokeLogo(
+  <>
+    <path d="M4.5 7.5h9M4.5 12h15M4.5 16.5h6.5" />
+  </>,
+);
+
 const AmplitudeLogo = strokeLogo(
   <>
     <path d="M2.5 13.5h4l3-8 4.5 13 3-8h4.5" />
@@ -217,6 +224,7 @@ export const CONNECTORS: Record<string, ConnectorRegistryEntry> = {
   canva: { label: "Canva", logo: pathLogo(CANVA_PATH) },
   // No published monochrome mark — custom glyphs, tinted with the real brand color.
   attio: { label: "Attio", logo: AttioLogo },
+  monday: { label: "monday.com", logo: MondayLogo },
   descript: { label: "Descript", logo: DescriptLogo },
   clay: { label: "Clay", logo: ClayLogo },
   close: { label: "Close", logo: CloseLogo },

--- a/platform/tests/test_mcp_connectors.py
+++ b/platform/tests/test_mcp_connectors.py
@@ -1,0 +1,181 @@
+"""MCP-backed connectors (UX-DECISIONS §42): a descriptor carries a vendor-hosted MCP
+URL and a PINNED tool allowlist in tool_defs. One-click connect seeds the server
+config from the pin + runs the local OAuth flow; the Connectors page owns the whole
+lifecycle (the Settings MCP tab hides these servers); sessions gate the tools by the
+effective connector set, per-tool toggles, and the read/write approval classification.
+The vendor's catalog can drift under us — every gate here fails CLOSED."""
+
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+
+from coworker.connectors.setup import (
+    connector_list,
+    disconnect_connector,
+    update_connector_tools,
+)
+from coworker.connectors.descriptors import list_descriptors
+from coworker.connectors.tool_defs import mcp_pinned_tools, mcp_tool_defs, tool_dicts
+from coworker.mcp.config import put_global_server, read_global
+from coworker.secrets import SecretStore
+from coworker.server.manager import SessionManager
+
+
+def _state(tmp_path, monkeypatch):
+    monkeypatch.setenv("COWORKER_STATE_DIR", str(tmp_path / "state"))
+    (tmp_path / "state").mkdir(parents=True, exist_ok=True)
+
+
+def test_every_mcp_backed_descriptor_pins_tools():
+    """The guard that keeps 'MCP-backed' meaning 'curated': a descriptor with an
+    mcp_url must pin at least one tool, and every pin is classified read/write."""
+    backed = [d for d in list_descriptors() if d.mcp_url]
+    assert {d.name for d in backed} >= {"monday", "jira"}
+    # asana is deliberately NOT backed (2026-07-20): their V2 server rejects DCR —
+    # needs a pre-registered MCP app + exact redirect URI vs our dynamic sidecar
+    # port. Its mcp__asana__* pins sit dormant until the broker-routed callback.
+    assert "asana" not in {d.name for d in backed}
+    for d in backed:
+        pins = mcp_pinned_tools(d.name)
+        assert pins, f"{d.name} is MCP-backed but pins no tools"
+        for t in mcp_tool_defs(d.name):
+            assert t.name.startswith(f"mcp__{d.name}__")
+            assert t.kind in ("read", "write")
+
+
+def test_tool_dicts_follow_the_profile_mode(tmp_path, monkeypatch):
+    """jira has BOTH a manual REST tool set and a pinned MCP set — exactly one is
+    live, decided by the profile mode. MCP-only connectors always show their pin."""
+    _state(tmp_path, monkeypatch)
+    secrets = SecretStore()
+
+    names = [t["name"] for t in tool_dicts(secrets, "jira")]
+    assert "jira_search_issues" in names
+    assert not any(n.startswith("mcp__") for n in names)
+
+    secrets.put("jira:default", {"mode": "mcp"})
+    names = [t["name"] for t in tool_dicts(secrets, "jira")]
+    assert names and all(n.startswith("mcp__jira__") for n in names)
+
+    names = [t["name"] for t in tool_dicts(secrets, "monday")]
+    assert names and all(n.startswith("mcp__monday__") for n in names)
+
+    # asana mirrors jira: manual token → asana_* REST tools; mcp → the pin.
+    names = [t["name"] for t in tool_dicts(secrets, "asana")]
+    assert "asana_search_tasks" in names
+    secrets.put("asana:default", {"mode": "mcp"})
+    names = [t["name"] for t in tool_dicts(secrets, "asana")]
+    assert names and all(n.startswith("mcp__asana__") for n in names)
+
+
+def test_mcp_connect_seeds_pinned_config_and_profile(tmp_path, monkeypatch):
+    _state(tmp_path, monkeypatch)
+    manager = SessionManager(data_dir=tmp_path / "data")
+
+    async def fake_connect(name):
+        return {"ok": True, "tools": 9}
+
+    monkeypatch.setattr(manager, "connect_mcp", fake_connect)
+    out = asyncio.run(manager.mcp_connect_connector("monday"))
+    assert out["ok"]
+
+    raw = read_global()["monday"]
+    assert raw["url"] == "https://mcp.monday.com/mcp"
+    assert raw["auth"] == "oauth"
+    # Server-level approval is OFF — per-tool classification gates writes instead.
+    assert raw["requires_approval"] is False
+    assert set(raw["include_tools"]) == set(mcp_pinned_tools("monday"))
+    assert manager.secrets.get("monday:default")["mode"] == "mcp"
+
+    # A connector without an MCP path fails closed.
+    out = asyncio.run(manager.mcp_connect_connector("notion"))
+    assert not out["ok"]
+
+
+def test_connected_follows_tokens_and_disconnect_forgets_everything(
+    tmp_path, monkeypatch
+):
+    _state(tmp_path, monkeypatch)
+    secrets = SecretStore()
+    secrets.put("monday:default", {"mode": "mcp", "enabled": True})
+    put_global_server("monday", {"url": "https://mcp.monday.com/mcp", "auth": "oauth"})
+
+    # Profile alone is just a marker — no tokens, not connected.
+    row = {c["name"]: c for c in connector_list(secrets)}["monday"]
+    assert row["mcp"] is True and row["connected"] is False
+
+    secrets.put("mcp-oauth:monday", {"tokens": {"access_token": "at"}})
+    row = {c["name"]: c for c in connector_list(secrets)}["monday"]
+    assert row["connected"] is True and row["mode"] == "mcp"
+
+    # Disconnect forgets tokens + DCR registration, the seeded config, and the profile.
+    out = disconnect_connector(secrets, "monday")
+    assert out["ok"]
+    assert secrets.get("mcp-oauth:monday") is None
+    assert "monday" not in read_global()
+    row = {c["name"]: c for c in connector_list(secrets)}["monday"]
+    assert row["connected"] is False
+
+
+def test_connector_backed_servers_hidden_from_mcp_tab(tmp_path, monkeypatch):
+    _state(tmp_path, monkeypatch)
+    manager = SessionManager(data_dir=tmp_path / "data")
+    put_global_server("monday", {"url": "https://mcp.monday.com/mcp", "auth": "oauth"})
+    put_global_server("granola", {"url": "https://mcp.granola.ai/mcp", "auth": "oauth"})
+    names = [s["name"] for s in manager.list_mcp()]
+    assert "granola" in names and "monday" not in names
+
+
+def _fake_tool(name):
+    return SimpleNamespace(
+        name=name, description=f"vendor {name}", inputSchema={"type": "object"}
+    )
+
+
+def test_prepare_mcp_tools_gates_by_session_pin_and_toggles(tmp_path, monkeypatch):
+    """The engine path: descriptor pin overrides stale config, per-tool toggles
+    subtract, session gating skips connectors outside the effective set, and
+    approval follows the read/write classification."""
+    _state(tmp_path, monkeypatch)
+    manager = SessionManager(data_dir=tmp_path / "data")
+    manager.secrets.put("monday:default", {"mode": "mcp", "enabled": True})
+    # Stale config: include_tools claims a tool we never pinned.
+    put_global_server(
+        "monday",
+        {
+            "url": "https://mcp.monday.com/mcp",
+            "auth": "oauth",
+            "include_tools": ["manage_agent"],
+            "enabled": True,
+        },
+    )
+    update_connector_tools(manager.secrets, "monday", {"mcp__monday__search": False})
+
+    seen = {}
+
+    async def fake_ensure(server):
+        seen["include_tools"] = list(server.include_tools or [])
+        allow = set(server.include_tools or [])
+        tools = [_fake_tool(n) for n in ["get_board_info", "create_item", "search"]]
+        return SimpleNamespace(tools=[t for t in tools if t.name in allow])
+
+    monkeypatch.setattr(manager.mcp, "ensure", fake_ensure)
+    monkeypatch.setattr(
+        manager, "effective_connectors", lambda sid, agent=None: {"monday"}
+    )
+
+    tools = asyncio.run(manager.prepare_mcp_tools("s1"))
+    # Pin is authoritative (no manage_agent), the toggled-off search is gone.
+    assert set(seen["include_tools"]) == set(mcp_pinned_tools("monday")) - {"search"}
+    by_name = {t.__aisuite_tool_metadata__.name: t for t in tools}
+    assert "mcp__monday__search" not in by_name
+    # Reads run free; writes ask first.
+    read = by_name["mcp__monday__get_board_info"].__aisuite_tool_metadata__
+    write = by_name["mcp__monday__create_item"].__aisuite_tool_metadata__
+    assert read.requires_approval is False
+    assert write.requires_approval is True
+
+    # Session gating: a session whose effective set excludes monday gets nothing.
+    monkeypatch.setattr(manager, "effective_connectors", lambda sid, agent=None: set())
+    assert asyncio.run(manager.prepare_mcp_tools("s2")) == []


### PR DESCRIPTION
Adds MCP-backed connectors (UX-DECISIONS §42)
- fully local OAuth 2.1 + DCR flow from the Granola work - no broker involvement.
- Agents never see the vendor's full tool catalog: each connector pins a curated allowlist that fails closed — the pin is re-derived at session build so config drift or vendor catalog changes can only shrink the surface
- Reads run free while writes stay approval-gated per the pin's classification
- First wave: monday.com (new, one-click only, 9 pinned tools) and Jira via Atlassian's server (8 pins, keeping the manual API-token path — the profile mode picks which tool set is live);
- Asana's pins ship dormant since their V2 server rejects DCR (one-click will follow via a broker-routed callback).
- Verified live against monday.com and Atlassian.