### PR TITLE
Openworker: Batch of UX/UI changes: updater polish, stream scroll pinning, sidebar kebab, auto-titles

### DIFF
--- a/platform/coworker/conversations.py
+++ b/platform/coworker/conversations.py
@@ -30,6 +30,14 @@ def _load_roots(raw: Optional[str]) -> list[dict]:
     return value if isinstance(value, list) else []
 
 
+def _display_title(row: sqlite3.Row) -> Optional[str]:
+    """Title precedence for every read path: a manual rename (renamed=1) always wins,
+    then the generated auto_title, then the first-line snapshot `save()` wrote."""
+    if row["renamed"]:
+        return row["title"]
+    return row["auto_title"] or row["title"]
+
+
 def title_from(messages: list[dict]) -> str:
     from .attachments import content_to_text
 
@@ -58,6 +66,7 @@ class ConversationStore:
                 title TEXT, agent TEXT DEFAULT 'code', n_msgs INTEGER DEFAULT 0, messages TEXT,
                 extra_roots TEXT, pinned INTEGER DEFAULT 0, archived INTEGER DEFAULT 0,
                 origin TEXT, origin_label TEXT,
+                auto_title TEXT, renamed INTEGER DEFAULT 0,
                 updated_at TEXT DEFAULT CURRENT_TIMESTAMP
             );
             CREATE TABLE IF NOT EXISTS workspaces (
@@ -73,6 +82,8 @@ class ConversationStore:
             "ALTER TABLE sessions ADD COLUMN archived INTEGER DEFAULT 0",
             "ALTER TABLE sessions ADD COLUMN origin TEXT",
             "ALTER TABLE sessions ADD COLUMN origin_label TEXT",
+            "ALTER TABLE sessions ADD COLUMN auto_title TEXT",
+            "ALTER TABLE sessions ADD COLUMN renamed INTEGER DEFAULT 0",
         ):
             try:
                 self._conn.execute(ddl)
@@ -210,7 +221,7 @@ class ConversationStore:
             model=row["model"],
             mode=row["mode"],
             messages=messages,
-            title=row["title"],
+            title=_display_title(row),
             agent=row["agent"] or "code",
             message_count=len(messages),
             updated_at=row["updated_at"],
@@ -251,7 +262,7 @@ class ConversationStore:
                 model=r["model"],
                 mode=r["mode"],
                 messages=[],
-                title=r["title"],
+                title=_display_title(r),
                 agent=r["agent"] or "code",
                 message_count=r["n_msgs"] or 0,
                 updated_at=r["updated_at"],
@@ -321,12 +332,41 @@ class ConversationStore:
         if not clean:
             return False
         with self._lock:
+            # renamed=1 makes the manual title final: auto-titling skips the session and
+            # `_display_title` ignores any auto_title already there.
             cur = self._conn.execute(
-                "UPDATE sessions SET title = ?, updated_at = CURRENT_TIMESTAMP WHERE session_id = ?",
+                "UPDATE sessions SET title = ?, renamed = 1, updated_at = CURRENT_TIMESTAMP WHERE session_id = ?",
                 (clean, session_id),
             )
             self._conn.commit()
         return cur.rowcount > 0
+
+    def set_auto_title(self, session_id: str, title: str) -> bool:
+        """Store a generated title. Its own column — never `title` — so a manual rename
+        (past or future) always wins; doesn't touch updated_at (a title landing after the
+        turn must not reorder the session list)."""
+        clean = " ".join((title or "").split())[:60]
+        if not clean:
+            return False
+        with self._lock:
+            cur = self._conn.execute(
+                "UPDATE sessions SET auto_title = ? WHERE session_id = ? AND renamed = 0",
+                (clean, session_id),
+            )
+            self._conn.commit()
+        return cur.rowcount > 0
+
+    def title_state(self, session_id: str) -> Optional[dict]:
+        """The auto-title guard inputs: whether the user renamed and whether a generated
+        title already exists. None when the session has no row yet."""
+        with self._lock:
+            row = self._conn.execute(
+                "SELECT renamed, auto_title FROM sessions WHERE session_id = ?",
+                (session_id,),
+            ).fetchone()
+        if row is None:
+            return None
+        return {"renamed": bool(row["renamed"]), "auto_title": row["auto_title"]}
 
     def set_flags(
         self,

--- a/platform/coworker/engine.py
+++ b/platform/coworker/engine.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import time
 from dataclasses import dataclass
 from enum import Enum
 from typing import Any, AsyncIterator, Awaitable, Callable, Optional
@@ -128,7 +129,12 @@ class TurnEngine:
         # `source` (a MessageSource dict) is a display-only sidecar for connector messages: it
         # rides on the persisted user message + the TURN_START event, but is stripped before the
         # message reaches a provider (see `_outbound_messages`). `content` stays the framed text.
-        message: dict[str, Any] = {"role": "user", "content": user_input}
+        # `ts` (unix seconds, stamped on every appended message) is the same kind of sidecar.
+        message: dict[str, Any] = {
+            "role": "user",
+            "content": user_input,
+            "ts": time.time(),
+        }
         if source is not None:
             message["source"] = source
         self.messages.append(message)
@@ -675,7 +681,11 @@ class TurnEngine:
 
     def _inject_steering(self) -> None:
         for text, source in self._steering:
-            message: dict[str, Any] = {"role": "user", "content": text}
+            message: dict[str, Any] = {
+                "role": "user",
+                "content": text,
+                "ts": time.time(),
+            }
             if source is not None:
                 message["source"] = source
             self.messages.append(message)
@@ -684,16 +694,17 @@ class TurnEngine:
     def _outbound_messages(self) -> list[dict[str, Any]]:
         """`self.messages` prepared for the provider. The SOLE provider feed (see `_astream`).
 
-        Every message is stripped of the display-only sidecars — `source` and `_display` —
-        (providers reject unknown keys), unconditionally — whether or not a `<system-context>`
-        block is added. When a context
+        Every message is stripped of the display-only sidecars — `source`, `_display`, and
+        `ts` — (providers reject unknown keys), unconditionally — whether or not a
+        `<system-context>` block is added. When a context
         provider yields a non-empty string, an ephemeral `<system-context>` block is appended to the
         last user message. Never mutates `self.messages`, so neither the strip nor the block is
         persisted/replayed.
         """
-        # Strip the display-only sidecars — `source` (connector cards) and `_display`
-        # (e.g. filter-hidden counts) — copying only messages that carry one.
-        _SIDECARS = ("source", "_display")
+        # Strip the display-only sidecars — `source` (connector cards), `_display`
+        # (e.g. filter-hidden counts), and `ts` (append-time timestamps) — copying only
+        # messages that carry one.
+        _SIDECARS = ("source", "_display", "ts")
         out = [
             (
                 {k: v for k, v in msg.items() if k not in _SIDECARS}
@@ -751,7 +762,11 @@ class TurnEngine:
 
 
 def _assistant_message(turn: AssistantTurn) -> dict[str, Any]:
-    message: dict[str, Any] = {"role": "assistant", "content": turn.text or ""}
+    message: dict[str, Any] = {
+        "role": "assistant",
+        "content": turn.text or "",
+        "ts": time.time(),
+    }
     if turn.tool_calls:
         message["tool_calls"] = [
             {
@@ -766,7 +781,12 @@ def _assistant_message(turn: AssistantTurn) -> dict[str, Any]:
 
 def _tool_result_message(tool_call: ToolCall, result: Any) -> dict[str, Any]:
     content = result if isinstance(result, str) else json.dumps(result, default=str)
-    return {"role": "tool", "tool_call_id": tool_call.id, "content": content}
+    return {
+        "role": "tool",
+        "tool_call_id": tool_call.id,
+        "content": content,
+        "ts": time.time(),
+    }
 
 
 def _tool_error_message(tool_call: ToolCall, reason: str) -> dict[str, Any]:
@@ -774,6 +794,7 @@ def _tool_error_message(tool_call: ToolCall, reason: str) -> dict[str, Any]:
         "role": "tool",
         "tool_call_id": tool_call.id,
         "content": json.dumps({"error": "tool call not executed", "reason": reason}),
+        "ts": time.time(),
     }
 
 

--- a/platform/coworker/server/manager.py
+++ b/platform/coworker/server/manager.py
@@ -129,6 +129,10 @@ class SessionManager:
         self._running_sessions: set[str] = (
             set()
         )  # sessions with an in-flight turn (busy)
+        # Sessions with an auto-title LLM call in flight (FB-010) — one call at a time.
+        self._autotitle_inflight: set[str] = set()
+        self._autotitle_tasks: set[asyncio.Task] = set()
+        self._autotitle_attempts: dict[str, int] = {}
         self.secrets = SecretStore()
         # No explicit provider injected → route by the model's `provider:` prefix (OpenAI default,
         # Ollama, …). Tests inject a provider directly and bypass the router. The same router is
@@ -2379,6 +2383,10 @@ class SessionManager:
 
     def mark_idle(self, session_id: str) -> None:
         self._running_sessions.discard(session_id)
+        # Every turn path (WS, background delivery, durable resume) marks idle when it
+        # finishes — the one shared post-turn moment, so auto-titling hooks in here and
+        # can never add latency to the response itself.
+        self._maybe_autotitle(session_id)
 
     def is_running(self, session_id: str) -> bool:
         return session_id in self._running_sessions
@@ -2865,6 +2873,110 @@ class SessionManager:
             {"path": str(r.path), "writable": bool(r.writable), "label": r.label}
             for r in roots[1:]
         ]
+
+    # -- LLM auto-titles (FB-010) -------------------------------------------------
+    _AUTOTITLE_PROMPT = (
+        "You title chat sessions. Given the user's opening message(s), reply with ONLY "
+        "a 4-5 word title for the session — no quotes or punctuation wrapping it. If "
+        'the opening is merely a greeting or small-talk with no topic ("hey", '
+        '"how are you", "hi there"), reply with exactly: small-talk'
+    )
+
+    def _maybe_autotitle(self, session_id: str) -> None:
+        """Kick off title generation after a turn completes, fire-and-forget. Only while
+        the session has neither a manual rename nor a generated title, at most twice:
+        attempt 1 rides turn 1, and the second window exists solely for the small-talk
+        retry (with both openers). Attempts are counted in memory rather than derived
+        from the user-message count — steering injections also land as role "user", and
+        counting them would silently suppress titling on a steered first turn. A restart
+        forgetting the counter is harmless: renamed/auto_title still gate re-titling."""
+        if session_id.startswith("__"):
+            return
+        engine = self._engines.get(session_id)
+        if engine is None or session_id in self._autotitle_inflight:
+            return
+        if self.task_store.task_for_run_session(session_id) is not None:
+            return  # automation runs are titled by their task
+        if self._autotitle_attempts.get(session_id, 0) >= 2:
+            return
+        users = [m for m in engine.messages if m.get("role") == "user"]
+        if not users:
+            return
+        state = self.session_store.title_state(session_id)
+        if state is None or state["renamed"] or state["auto_title"]:
+            return
+        from ..attachments import content_to_text
+
+        openers = [
+            text
+            for m in users
+            if (text := content_to_text(m.get("content"), image_placeholder="").strip())
+        ][:2]
+        if not openers:
+            return
+        self._autotitle_attempts[session_id] = (
+            self._autotitle_attempts.get(session_id, 0) + 1
+        )
+        try:
+            loop = asyncio.get_running_loop()
+        except RuntimeError:
+            return  # no loop to ride (sync caller) — skip, never block
+        self._autotitle_inflight.add(session_id)
+        # Retain the task: the loop holds only a weak ref, and a GC'd task would both
+        # kill the title mid-flight and strand the inflight guard.
+        task = loop.create_task(self._generate_autotitle(session_id, engine, openers))
+        self._autotitle_tasks.add(task)
+        task.add_done_callback(self._autotitle_tasks.discard)
+
+    async def _generate_autotitle(
+        self, session_id: str, engine: TurnEngine, openers: list[str]
+    ) -> None:
+        """One cheap non-streaming completion on the session's own provider/model. Every
+        failure (provider error, empty, absurdly long) is swallowed — the title_from
+        fallback stays; the small-talk sentinel leaves auto_title unset so the turn-2
+        retry can run."""
+        try:
+            turn = await asyncio.to_thread(
+                engine.provider.complete,
+                model=engine.model,
+                messages=[
+                    {"role": "system", "content": self._AUTOTITLE_PROMPT},
+                    {"role": "user", "content": "\n\n".join(openers)},
+                ],
+                temperature=0.2,
+                # Reasoning-routed models spend hidden tokens BEFORE emitting text; a
+                # tight cap plus default effort yields an empty completion and a silent
+                # no-op. Effort "none" reaches only the OpenAI-compat path (the native
+                # providers whitelist their settings), and 64 leaves headroom either way.
+                max_tokens=64,
+                reasoning_effort="none",
+            )
+            raw = (getattr(turn, "text", None) or "").strip()
+            # Sanitize: surrounding quotes off, whitespace collapsed, capped at 60.
+            title = " ".join(raw.strip("\"'“”‘’`").split())
+            # Sentinel tolerance: models riff on the exact token ("Small talk.", quoted,
+            # trailing period) — normalize before comparing, else the riff becomes the title.
+            if title.lower().strip(".!,;:'\"").replace(" ", "-").replace("_", "-") in (
+                "small-talk",
+                "smalltalk",
+            ):
+                return
+            if not title or len(title) > 80:
+                return
+            if self.session_store.set_auto_title(session_id, title[:60]):
+                # Best-effort nudge for any live viewer; the sidebar's poll and
+                # post-turn refresh pick the new title up regardless.
+                await self.broadcast_session(
+                    session_id,
+                    {
+                        "type": "session_title",
+                        "data": {"session_id": session_id, "title": title[:60]},
+                    },
+                )
+        except Exception:
+            pass  # a failed title must never surface as a session error
+        finally:
+            self._autotitle_inflight.discard(session_id)
 
     # -- session roots (orphan Cowork: scratch + added folders) ------------------
     def get_roots(self, session_id: str) -> list[dict[str, Any]]:

--- a/platform/surfaces/gui/e2e/access-section.spec.ts
+++ b/platform/surfaces/gui/e2e/access-section.spec.ts
@@ -39,23 +39,31 @@ test("no topbar opener; the Access header IS the ambient glance; expanding edits
   await expect(body.getByText("GitHub", { exact: true })).toBeVisible();
 });
 
-test("+ Add a source: catalog typeahead → connect-in-context; connected sources never match", async ({
+test("+ Add a source: full catalog on focus, filter as you type → connect-in-context; connected sources never match", async ({
   page,
 }) => {
   await page.goto("/");
   await page.getByText("Draft the launch note").first().click();
   await page.getByTestId("access-toggle").click();
 
-  // The quiet row becomes a typeahead (search-only — no browsable list renders unprompted).
+  // Focusing the empty input shows the FULL catalog (FB-012) — every available connector
+  // minus the already-connected three, before any typing.
   await page.getByTestId("access-add-source").click();
   const search = page.getByTestId("access-add-search");
-  await expect(page.getByTestId("access-add-notion")).toHaveCount(0); // nothing unprompted
+  await expect(search).toBeFocused();
+  const rows = page.locator('[data-testid^="access-add-"]:not([data-testid="access-add-search"])');
+  await expect(rows).toHaveCount(9); // 12 in the catalog − browser/slack/github (connected)
+  await expect(page.getByTestId("access-add-notion")).toBeVisible();
 
   // Already-connected sources don't match (Slack and GitHub are connected in fixtures)…
   await search.fill("slack");
   await expect(page.getByText("No match — see all on the Connectors page below.")).toBeVisible();
   await search.fill("github");
   await expect(page.getByText("No match — see all on the Connectors page below.")).toBeVisible();
+
+  // …and clearing the query restores the full list ("filter as you type", not search-only).
+  await search.fill("");
+  await expect(rows).toHaveCount(9);
 
   // Capability aliases match too: "calendar" surfaces Outlook (title alone never would).
   await search.fill("calendar");

--- a/platform/surfaces/gui/e2e/cloud-status-pending.spec.ts
+++ b/platform/surfaces/gui/e2e/cloud-status-pending.spec.ts
@@ -1,0 +1,53 @@
+// FB-013: a signed-in user opened the rail's connect pane and was told to sign in —
+// the rail's single cloud-status fetch rendered PENDING (and any failure) as signed-out,
+// with nothing that could ever flip it back. Contract now: unknown status shows a neutral
+// "checking" line, never the sign-in ask; the pane polls while open; and completing
+// sign-in from the inline prompt flips the pane itself (no other section's poll needed).
+import { expect } from "@playwright/test";
+import { test } from "./fixtures";
+
+const openGmailPane = async (page: import("@playwright/test").Page) => {
+  await page.goto("/");
+  await page.getByText("Draft the launch note").first().click();
+  await page.getByTestId("access-toggle").click();
+  await page.getByTestId("access-add-source").click();
+  await page.getByTestId("access-add-gmail").click();
+};
+
+test("pending status shows 'checking', never the sign-in ask; resolves to one-click", async ({
+  page,
+}) => {
+  // Hold every /v1/cloud/status response (test routes outrank the fixture's) — the user
+  // IS signed in, the app just doesn't know yet.
+  let release!: () => void;
+  const gate = new Promise<void>((r) => (release = r));
+  await page.route("**/v1/cloud/status", async (route) => {
+    await gate;
+    await route.fulfill({
+      json: { signed_in: true, account: "her@example.com", user_id: "u1", telemetry_enabled: true },
+    });
+  });
+
+  await openGmailPane(page);
+  await expect(page.getByTestId("cloud-status-pending")).toBeVisible();
+  await expect(page.getByTestId("inline-cloud-sign-in")).toHaveCount(0);
+
+  release();
+  await expect(page.getByRole("button", { name: "Connect Gmail with one click" })).toBeVisible();
+  await expect(page.getByTestId("cloud-status-pending")).toHaveCount(0);
+});
+
+test("signing in from the rail prompt flips the pane to one-click", async ({ page }) => {
+  // Fixture default: signed out — the resolved signed-out state legitimately asks.
+  await openGmailPane(page);
+  const ask = page.getByTestId("inline-cloud-sign-in");
+  await expect(ask).toBeVisible();
+  await expect(page.getByTestId("cloud-status-pending")).toHaveCount(0);
+
+  // The mock login flips CLOUD_STATE instantly; the inline button's own post-login poll
+  // plus the CLOUD_CHANGED broadcast must flip THIS pane without any other page open.
+  await ask.click();
+  await expect(page.getByRole("button", { name: "Connect Gmail with one click" })).toBeVisible({
+    timeout: 5_000,
+  });
+});

--- a/platform/surfaces/gui/e2e/fixtures.ts
+++ b/platform/surfaces/gui/e2e/fixtures.ts
@@ -610,6 +610,23 @@ export async function mockApi(page: import("@playwright/test").Page) {
           });
           return;
         }
+        // A deliberately SLOW multi-second stream (~40 ticks × 120ms) so specs can
+        // interact mid-turn — the follow/pin scroll contract (FB-004) is untestable
+        // against the instant echo below.
+        if (/stream the epic/i.test(msg.text)) {
+          let ticks = 0;
+          const line = "The epic scrolls ever onward, line upon line upon line. ";
+          const timer = setInterval(() => {
+            ticks += 1;
+            send("assistant_delta", { text: line.repeat(3) + "\n\n" });
+            if (ticks >= 40) {
+              clearInterval(timer);
+              send("assistant_message", { text: ("The epic concludes. " + line).repeat(20) });
+              send("turn_done");
+            }
+          }, 120);
+          return;
+        }
         send("assistant_delta", { text: "Echo: " });
         send("assistant_delta", { text: msg.text });
         // Echo the model the message carried — pins the model-per-message contract (the

--- a/platform/surfaces/gui/e2e/sidebar-sessions.spec.ts
+++ b/platform/surfaces/gui/e2e/sidebar-sessions.spec.ts
@@ -1,8 +1,9 @@
 import { test, expect } from "./fixtures";
 
 // Sidebar session lifecycle (owner testing pass, 2026-07-03): the peek cap (sessions_peek=5 →
-// "Show more (2)" with 7 sessions), one-click reversible archive with the Archived disclosure,
-// and the two-step delete (× arms the row → "Delete?" confirms).
+// "Show more (2)" with 7 sessions), reversible archive with the Archived disclosure, and the
+// two-step delete (Delete arms → "Delete?" confirms). All row actions sit behind the per-row
+// ⋮ kebab (FB-011), so each flow goes hover → kebab → menu item.
 
 test("session list caps at the peek count with Show more", async ({ page }) => {
   await page.goto("/");
@@ -16,13 +17,14 @@ test("session list caps at the peek count with Show more", async ({ page }) => {
   await expect(page.getByTitle("Weekly plan 7")).toBeVisible();
 });
 
-test("archive is one click and reversible via the Archived disclosure", async ({ page }) => {
+test("archive via the row menu is reversible via the Archived disclosure", async ({ page }) => {
   await page.goto("/");
   const row = page.getByTitle("Weekly plan 2");
   await expect(row).toBeVisible();
 
   await row.hover();
-  await row.getByTitle("Archive (reversible)").click();
+  await row.getByTestId("row-menu").click();
+  await row.getByTestId("row-menu-archive").click();
 
   // Gone from the main list; parked under the Archived disclosure.
   await expect(page.getByTitle("Weekly plan 2")).toHaveCount(0);
@@ -30,9 +32,12 @@ test("archive is one click and reversible via the Archived disclosure", async ({
   const archivedRow = page.getByTitle("Weekly plan 2");
   await expect(archivedRow).toBeVisible();
 
-  // Unarchive brings it straight back; the disclosure disappears with its last item.
+  // Unarchive (same menu slot on an archived row) brings it straight back; the disclosure
+  // disappears with its last item.
   await archivedRow.hover();
-  await archivedRow.getByTitle("Unarchive").click();
+  await archivedRow.getByTestId("row-menu").click();
+  await expect(archivedRow.getByTestId("row-menu-archive")).toHaveText("Unarchive");
+  await archivedRow.getByTestId("row-menu-archive").click();
   await expect(page.getByRole("button", { name: /Archived/ })).toHaveCount(0);
   await expect(page.getByTitle("Weekly plan 2")).toBeVisible();
 });
@@ -59,17 +64,42 @@ test("mention-spawned sessions collapse under From Slack with the platform icon 
   await expect(page.getByTitle("#general — check the deploy?")).toHaveCount(1);
 });
 
-test("delete is two-step: × arms the row, Delete? confirms", async ({ page }) => {
+test("pin via the row menu moves the session to the Pinned band and back", async ({ page }) => {
+  await page.goto("/");
+  const row = page.getByTitle("Weekly plan 4");
+  await expect(row).toBeVisible();
+
+  await row.hover();
+  await row.getByTestId("row-menu").click();
+  await expect(row.getByTestId("row-menu-pin")).toHaveText("Pin");
+  await row.getByTestId("row-menu-pin").click();
+
+  // Pinned rows live ONLY in the cross-persona Pinned band — no duplicate in the body.
+  const pinnedBand = page.getByText("Pinned", { exact: true }).locator("..");
+  await expect(pinnedBand.getByTitle("Weekly plan 4")).toBeVisible();
+  await expect(page.getByTitle("Weekly plan 4")).toHaveCount(1);
+
+  const pinnedRow = pinnedBand.getByTitle("Weekly plan 4");
+  await pinnedRow.hover();
+  await pinnedRow.getByTestId("row-menu").click();
+  await expect(pinnedRow.getByTestId("row-menu-pin")).toHaveText("Unpin");
+  await pinnedRow.getByTestId("row-menu-pin").click();
+  await expect(pinnedBand.getByTitle("Weekly plan 4")).toHaveCount(0);
+  await expect(page.getByTitle("Weekly plan 4")).toHaveCount(1);
+});
+
+test("delete is two-step: the menu's Delete arms, Delete? confirms", async ({ page }) => {
   await page.goto("/");
   const row = page.getByTitle("Weekly plan 3");
   await expect(row).toBeVisible();
 
   await row.hover();
-  await row.getByTitle("Delete permanently").click();
-  // First click only ARMS — the row is still there, now showing the confirm affordance.
-  await expect(row.getByTitle("Click to permanently delete")).toBeVisible();
+  await row.getByTestId("row-menu").click();
+  await row.getByTestId("row-menu-delete").click();
+  // First click only ARMS — the menu stays open showing the confirm affordance, the row remains.
+  await expect(row.getByTestId("row-menu-delete")).toHaveText("Delete?");
   await expect(page.getByTitle("Weekly plan 3")).toHaveCount(1);
 
-  await row.getByTitle("Click to permanently delete").click();
+  await row.getByTestId("row-menu-delete").click();
   await expect(page.getByTitle("Weekly plan 3")).toHaveCount(0);
 });

--- a/platform/surfaces/gui/e2e/transcript-scroll.spec.ts
+++ b/platform/surfaces/gui/e2e/transcript-scroll.spec.ts
@@ -1,0 +1,83 @@
+// FB-004/FB-005: the transcript follows a streaming turn only while the reader is at the
+// bottom — scrolling up PINS the viewport (reading must never be yanked away) and surfaces
+// a jump-to-latest pill; bubbles grow hover affordances (copy + timestamp) that reveal
+// without shifting layout. Driven against the fixtures' slow "stream the epic" turn.
+import { expect } from "@playwright/test";
+import { test } from "./fixtures";
+
+// The copy test asserts real clipboard writes — grant instead of relying on defaults.
+test.use({ permissions: ["clipboard-write"] });
+
+const scrollerState = `(() => {
+  const el = document.querySelector(".main-scroll");
+  return el ? { top: el.scrollTop, height: el.scrollHeight, client: el.clientHeight } : null;
+})()`;
+
+test("scrolling up mid-stream pins the viewport; jump-to-latest re-engages", async ({ page }) => {
+  await page.goto("/");
+  await page.getByText("Draft the launch note").first().click();
+  const box = page.getByPlaceholder(/Ask the coworker/);
+  await box.fill("stream the epic");
+  await box.press("Enter");
+
+  // Let the stream outgrow the viewport, then read something "above".
+  await page.waitForFunction(
+    () => {
+      const el = document.querySelector(".main-scroll");
+      return !!el && el.scrollHeight > el.clientHeight + 400;
+    },
+    { timeout: 10_000 },
+  );
+  await page.locator(".main-scroll").evaluate((el) => (el.scrollTop = 0));
+
+  // The stream keeps growing below…
+  const h1 = (await page.evaluate(scrollerState))!.height;
+  await page.waitForFunction(
+    (prev) => {
+      const el = document.querySelector(".main-scroll");
+      return !!el && el.scrollHeight > prev;
+    },
+    h1,
+    { timeout: 5_000 },
+  );
+  // …but the viewport stays where the reader put it (the old behavior yanked to bottom
+  // on every delta), and the pill offers the way back.
+  const pinned = (await page.evaluate(scrollerState))!;
+  expect(pinned.top).toBeLessThan(50);
+  await expect(page.getByTestId("jump-to-latest")).toBeVisible();
+
+  await page.getByTestId("jump-to-latest").click();
+  await page.waitForFunction(
+    () => {
+      const el = document.querySelector(".main-scroll");
+      return !!el && el.scrollHeight - el.scrollTop - el.clientHeight < 80;
+    },
+    { timeout: 5_000 },
+  );
+  await expect(page.getByTestId("jump-to-latest")).toHaveCount(0);
+
+  // Re-engaged: the follow survives the rest of the stream to the turn's end.
+  await expect(page.getByText("The epic concludes.").first()).toBeVisible({ timeout: 10_000 });
+  const done = (await page.evaluate(scrollerState))!;
+  expect(done.height - done.top - done.client).toBeLessThan(80);
+});
+
+test("bubbles carry hover copy + timestamp without layout shift", async ({ page }) => {
+  await page.goto("/");
+  await page.getByText("Draft the launch note").first().click();
+  const box = page.getByPlaceholder(/Ask the coworker/);
+  await box.fill("hello meta");
+  await box.press("Enter");
+  await expect(page.getByText("Echo: hello meta", { exact: false }).first()).toBeVisible();
+
+  // Live items are stamped client-side, so both bubbles expose the affordance strip.
+  const userBubble = page.locator(".bubble-user").last();
+  await userBubble.hover();
+  const meta = page.getByTestId("bubble-copy");
+  await expect(meta.first()).toBeVisible();
+  await expect(page.getByTestId("bubble-ts").first()).toBeVisible();
+
+  // Copy actually copies (the fixture page runs with clipboard permission in Chromium).
+  await meta.first().click();
+  await expect(page.getByText("Copied").first()).toBeVisible();
+});

--- a/platform/surfaces/gui/src-tauri/src/lib.rs
+++ b/platform/surfaces/gui/src-tauri/src/lib.rs
@@ -478,10 +478,11 @@ fn show_main(app: &tauri::AppHandle) {
 }
 
 // --- Auto-update (tauri-plugin-updater) -------------------------------------------
-// The GUI drives updates through these two commands (same invoke bridge as everything
-// else — no global plugin JS). Update artifacts are minisign-verified against the
-// pubkey in tauri.conf.json before anything is installed; the manifest lives at the
-// endpoints configured there (download.openworker.com → GitHub Releases).
+// The GUI drives updates through these commands (same invoke bridge as everything
+// else — no global plugin JS): check, background pre-download, install. Update
+// artifacts are minisign-verified against the pubkey in tauri.conf.json before
+// anything is installed; the manifest lives at the endpoints configured there
+// (download.openworker.com → GitHub Releases).
 
 #[derive(serde::Serialize)]
 struct UpdateInfo {
@@ -500,17 +501,71 @@ async fn check_for_update(app: tauri::AppHandle) -> Result<Option<UpdateInfo>, S
     }))
 }
 
+/// Update bytes pre-fetched by `download_update`, keyed by version. The GUI kicks the
+/// download off as soon as a release is offered, so clicking "Restart to update" installs
+/// from memory instead of sitting on a multi-minute download behind a spinner.
+struct PendingUpdate(Mutex<Option<(String, Vec<u8>)>>);
+
 #[tauri::command]
-async fn install_update(app: tauri::AppHandle) -> Result<(), String> {
+async fn download_update(
+    app: tauri::AppHandle,
+    pending: tauri::State<'_, PendingUpdate>,
+) -> Result<(), String> {
     use tauri_plugin_updater::UpdaterExt;
     let updater = app.updater().map_err(|e| e.to_string())?;
     let Some(update) = updater.check().await.map_err(|e| e.to_string())? else {
         return Err("no update available".into());
     };
-    update
-        .download_and_install(|_, _| {}, || {})
+    // Periodic re-checks re-invoke this for the same release — the cached bytes stand.
+    // (Guard scope stays sync: a std MutexGuard must not live across an await.)
+    {
+        let slot = pending.0.lock().unwrap();
+        if slot.as_ref().map(|(v, _)| v == &update.version).unwrap_or(false) {
+            return Ok(());
+        }
+    }
+    let bytes = update
+        .download(|_, _| {}, || {})
         .await
         .map_err(|e| e.to_string())?;
+    *pending.0.lock().unwrap() = Some((update.version.clone(), bytes));
+    Ok(())
+}
+
+/// Drop the pre-fetched bundle. Invoked on "Later": a dismissed release would
+/// otherwise pin tens of MB in memory for the rest of an app run that can last
+/// weeks. Changing one's mind just re-downloads.
+#[tauri::command]
+fn clear_pending_update(pending: tauri::State<'_, PendingUpdate>) {
+    *pending.0.lock().unwrap() = None;
+}
+
+#[tauri::command]
+async fn install_update(
+    app: tauri::AppHandle,
+    pending: tauri::State<'_, PendingUpdate>,
+) -> Result<(), String> {
+    use tauri_plugin_updater::UpdaterExt;
+    let updater = app.updater().map_err(|e| e.to_string())?;
+    let Some(update) = updater.check().await.map_err(|e| e.to_string())? else {
+        return Err("no update available".into());
+    };
+    // Pre-fetched bytes for this exact version install instantly; a stale or missing
+    // cache falls back to the original blocking download-and-install.
+    let cached = {
+        let mut slot = pending.0.lock().unwrap();
+        match slot.take() {
+            Some((v, bytes)) if v == update.version => Some(bytes),
+            _ => None,
+        }
+    };
+    match cached {
+        Some(bytes) => update.install(bytes).map_err(|e| e.to_string())?,
+        None => update
+            .download_and_install(|_, _| {}, || {})
+            .await
+            .map_err(|e| e.to_string())?,
+    }
     // Windows never reaches here (the NSIS installer takes over and relaunches).
     // macOS: the .app was swapped in place — restart into the new version. The tray
     // Exit path's sidecar kill runs via RunEvent, so no orphaned coworker-server.
@@ -556,6 +611,8 @@ pub fn run() {
             delete_dictation_model,
             dictation_level,
             check_for_update,
+            download_update,
+            clear_pending_update,
             install_update
         ])
         .setup(move |app| {
@@ -614,6 +671,7 @@ pub fn run() {
                 None
             };
             app.manage(KeepAwake(Mutex::new(ka)));
+            app.manage(PendingUpdate(Mutex::new(None)));
             // Voice recordings are transient; only the explicitly installed local Whisper model
             // lives in the existing application state directory.
             app.manage(Arc::new(Dictation::new(state_dir().join("models"))));

--- a/platform/surfaces/gui/src/App.tsx
+++ b/platform/surfaces/gui/src/App.tsx
@@ -531,7 +531,7 @@ export function App() {
               const last = p[p.length - 1];
               return last && last.kind === "user" && last.text === d.input
                 ? p
-                : [...p, { kind: "user", text: d.input as string }];
+                : [...p, { kind: "user", text: d.input as string, ts: Date.now() / 1000 }];
             });
           }
           break;
@@ -539,7 +539,7 @@ export function App() {
           setStreaming((s) => s + (d.text || ""));
           break;
         case "assistant_message":
-          if (d.text) setItems((p) => [...p, { kind: "assistant", text: d.text }]);
+          if (d.text) setItems((p) => [...p, { kind: "assistant", text: d.text, ts: Date.now() / 1000 }]);
           setStreaming(""); // finalized into items (or empty tool-only turn)
           break;
         case "tool_proposed":
@@ -641,7 +641,7 @@ export function App() {
         const p = pendingPromptRef.current;
         if (p) {
           pendingPromptRef.current = null;
-          setItems((prev) => [...prev, { kind: "user", text: p }]);
+          setItems((prev) => [...prev, { kind: "user", text: p, ts: Date.now() / 1000 }]);
           sessionRef.current?.userMessage(p);
         }
       },
@@ -659,8 +659,53 @@ export function App() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [booting, sessionId, agent, refreshSessions]);
 
+  // Stream-following (FB-004): auto-scroll only while the user is AT the bottom, so scrolling
+  // up to read during a streaming turn sticks. `atBottomRef` is the live truth (per scroll
+  // event, no re-render); `following` mirrors it into state for the jump-to-latest pill.
+  // Programmatic smooth-scrolls fire scroll events of their own — while one is in flight
+  // (`autoScrollingRef`) they must not read as "the user scrolled up", or every stream tick
+  // would disengage its OWN follow. The animation only moves down, so a decreasing scrollTop
+  // mid-flight can only be the user taking over.
+  const atBottomRef = useRef(true);
+  const autoScrollingRef = useRef(false);
+  const lastScrollTopRef = useRef(0);
+  const [following, setFollowing] = useState(true);
+  const scrollToBottom = () => {
+    const el = scrollRef.current;
+    if (!el) return;
+    autoScrollingRef.current = true;
+    el.scrollTo({ top: el.scrollHeight, behavior: "smooth" });
+  };
+  const followLatest = () => {
+    atBottomRef.current = true;
+    setFollowing(true);
+    scrollToBottom();
+  };
+  const handleScroll = () => {
+    const el = scrollRef.current;
+    if (!el) return;
+    const top = el.scrollTop;
+    const atBottom = el.scrollHeight - top - el.clientHeight < 48;
+    if (autoScrollingRef.current) {
+      if (atBottom) autoScrollingRef.current = false; // landed
+      else if (top >= lastScrollTopRef.current) {
+        lastScrollTopRef.current = top; // still animating down — not the user
+        return;
+      } else autoScrollingRef.current = false; // moved UP mid-flight — user takeover
+    }
+    lastScrollTopRef.current = top;
+    atBottomRef.current = atBottom;
+    setFollowing(atBottom);
+  };
+  // A different session is a fresh viewport — never inherit a scrolled-up state. Declared
+  // BEFORE the auto-scroll effect: when a session switch and its hydrated items land in one
+  // commit, the reset must run first or the stale ref would skip the initial bottom-scroll.
   useEffect(() => {
-    scrollRef.current?.scrollTo({ top: scrollRef.current.scrollHeight, behavior: "smooth" });
+    atBottomRef.current = true;
+    setFollowing(true);
+  }, [sessionId]);
+  useEffect(() => {
+    if (atBottomRef.current) scrollToBottom();
   }, [items, streaming]);
 
   // Track produced-file count for the topbar "Artifacts" affordance (works even when the rail is
@@ -687,9 +732,10 @@ export function App() {
   }, [surface, sessionId, browserRefreshKey, markUnattended]);
 
   const send = (text: string, attachments?: Attachment[]) => {
-    setItems((p) => [...p, { kind: "user", text, attachments }]);
+    setItems((p) => [...p, { kind: "user", text, attachments, ts: Date.now() / 1000 }]);
     // The visible model rides along with the message (single source of truth per turn).
     sessionRef.current?.userMessage(text, attachments, model);
+    followLatest(); // sending always re-engages stream-following, wherever the user had scrolled
   };
   // Resolving a LIVE prompt also resolves its parked Inbox mirror server-side, but the polled
   // `sessionInbox` copy stays "pending" for up to a poll cycle — long enough for the docked
@@ -986,7 +1032,7 @@ export function App() {
           <span /><span /><span />
         </div>
       )}
-      {/* Desktop-only auto-update prompt (checks once, 15s after boot; inert in browser). */}
+      {/* Desktop-only auto-update prompt (15s after boot, then every 30 min; inert in browser). */}
       <UpdateBanner />
       {/* When collapsed, a thin left-edge zone peeks the nav back as a floating overlay. */}
       {navCollapsed && (
@@ -1217,7 +1263,7 @@ export function App() {
                 </button>
               </div>
             )}
-            <div className="main-scroll" ref={scrollRef}>
+            <div className="main-scroll" ref={scrollRef} onScroll={handleScroll}>
               {idle ? (
                 agent === "cowork" ? (
                   <SessionIntro
@@ -1270,6 +1316,22 @@ export function App() {
                 </>
               )}
             </div>
+
+            {/* Scrolled up while the transcript is still growing → offer the way back down.
+                Zero-height strip keeps the pill floating over the scroll area, above the
+                composer, without reserving layout space. */}
+            {!following && (running || !!streaming) && (
+              <div className="relative h-0 z-10">
+                <button
+                  className="absolute bottom-3 left-1/2 -translate-x-1/2 flex items-center gap-1.5 px-3 py-1.5 rounded-full border border-line bg-panel shadow-md text-[12px] text-muted hover:text-ink cursor-pointer whitespace-nowrap"
+                  data-testid="jump-to-latest"
+                  onClick={followLatest}
+                >
+                  <Icon name="chevronDown" size={13} />
+                  Jump to latest
+                </button>
+              </div>
+            )}
 
             <Composer
               mode={mode}

--- a/platform/surfaces/gui/src/components/AccessSection.tsx
+++ b/platform/surfaces/gui/src/components/AccessSection.tsx
@@ -11,6 +11,7 @@
 
 import { useCallback, useEffect, useRef, useState } from "react";
 import {
+  CLOUD_CHANGED,
   getCloudStatus,
   getConnectors,
   getRecentChannels,
@@ -110,8 +111,9 @@ export function AccessSection({
   // Child views (connect-in-context / channels drill-down) replace the section body inline.
   const [channelsFor, setChannelsFor] = useState<string | null>(null);
   const [connectFor, setConnectFor] = useState<Connector | null>(null);
-  // "+ Add a source…" (§32 addendum): search the FULL catalog in-session — search-only, never a
-  // browsable list (browsing stays on the global Connectors page, or the rail turns into it).
+  // "+ Add a source…" (§32 addendum): the FULL catalog in-session. The list shows on focus,
+  // before any typing (FB-012: typing-to-see was a hidden step), and the query filters it
+  // live; rich browsing (detail pages, connect states) stays on the global Connectors page.
   const [adding, setAdding] = useState(false);
   const [query, setQuery] = useState("");
   // The add flow guarantees the new source is live HERE: the user asked for it in this
@@ -121,7 +123,20 @@ export function AccessSection({
   const [addingFolder, setAddingFolder] = useState(false);
   const [cloud, setCloud] = useState<CloudStatus | null>(null);
   useEffect(() => {
-    if (connectFor) getCloudStatus().then(setCloud).catch(() => setCloud(null));
+    if (!connectFor) return;
+    // null means UNKNOWN (renders as "checking"), never signed-out: a single failed
+    // fetch here used to demand sign-in from a signed-in user with no way to recover
+    // (FB-013). Poll while the connect pane is open, keep last-good on failure, and
+    // listen for the sign-in broadcast so the pane flips the moment login lands.
+    const load = () => getCloudStatus().then(setCloud).catch(() => {});
+    load();
+    const t = setInterval(load, 5000);
+    window.addEventListener(CLOUD_CHANGED, load);
+    return () => {
+      clearInterval(t);
+      window.removeEventListener(CLOUD_CHANGED, load);
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [!!connectFor]);
   const [subs, setSubs] = useState<Subscription[]>([]);
   const [recent, setRecent] = useState<RecentChannel[]>([]);
@@ -174,23 +189,24 @@ export function AccessSection({
   const recommended = conns?.recommended ?? [];
   const live = connected.filter((c) => c.enabled);
 
-  // Catalog search: available, not already in the Connected list (those have toggles above),
-  // matched on title/name/aliases ("calendar" must surface Outlook, not just Google
-  // Calendar). Capped — this is a typeahead, not a directory.
+  // Catalog list: available, not already in the Connected list (those have toggles above).
+  // Empty query = the whole catalog (FB-012 — the list renders before any typing); a query
+  // narrows it on title/name/aliases ("calendar" must surface Outlook, not just Google
+  // Calendar). Alphabetical so filtering never reorders; the container height-caps it, so
+  // no count cap here.
   const connectedSet = new Set(connected.map((c) => c.connector));
   const q = query.trim().toLowerCase();
-  const results = !q
-    ? []
-    : Object.values(byName)
-        .filter(
-          (c) =>
-            c.available &&
-            !connectedSet.has(c.name) &&
-            (c.title.toLowerCase().includes(q) ||
-              c.name.toLowerCase().includes(q) ||
-              (c.aliases ?? []).some((a) => a.toLowerCase().includes(q))),
-        )
-        .slice(0, 6);
+  const results = Object.values(byName)
+    .filter(
+      (c) =>
+        c.available &&
+        !connectedSet.has(c.name) &&
+        (!q ||
+          c.title.toLowerCase().includes(q) ||
+          c.name.toLowerCase().includes(q) ||
+          (c.aliases ?? []).some((a) => a.toLowerCase().includes(q))),
+    )
+    .sort((a, b) => a.title.localeCompare(b.title));
 
   // The header summary — the §23 glance, permanent: live source names + the folder fact.
   const names = live.map((c) => labelFor(c.connector, byName));
@@ -307,8 +323,9 @@ export function AccessSection({
                     Off mutes it for <b>this session only</b> — the connector stays connected.
                   </p>
                 )}
-                {/* §32 addendum (owner ask 2026-07-13): the catalog's long tail, in-session.
-                    A quiet row that becomes a typeahead — search-only, no browsable list. */}
+                {/* §32 addendum (owner ask 2026-07-13; FB-012): the catalog's long tail,
+                    in-session. A quiet row that becomes a typeahead: full list on focus,
+                    filter as you type. */}
                 {adding ? (
                   <div className="mt-1.5">
                     <input
@@ -325,12 +342,14 @@ export function AccessSection({
                       autoFocus
                       data-testid="access-add-search"
                     />
-                    {q && results.length === 0 && (
+                    {results.length === 0 && (
+                      // Also covers a failed/empty catalog fetch: an open picker must never
+                      // be silently blank — point at the Connectors page either way.
                       <div className="text-[11.5px] text-faint mt-1.5 px-0.5">
                         No match — see all on the Connectors page below.
                       </div>
                     )}
-                    <div className="mt-1">
+                    <div className="mt-1 max-h-64 overflow-y-auto">
                       {results.map((c) => (
                         <button
                           key={c.name}

--- a/platform/surfaces/gui/src/components/ManageTabs.tsx
+++ b/platform/surfaces/gui/src/components/ManageTabs.tsx
@@ -27,7 +27,7 @@ import {
   type ModelSettings,
   type ProviderInfo,
 } from "../api";
-import { CloudSignInInline } from "./connectors/CloudSignIn";
+import { CloudSignInInline, CloudStatusPending } from "./connectors/CloudSignIn";
 import { ModelChecklist } from "./ModelChecklist";
 import { ProviderCards, ProviderForm, useProviderSetup } from "../providers/ProviderSetup";
 import { Toggle } from "./Toggle";
@@ -828,10 +828,14 @@ export function ConnectSetup({
             <button className={BTN_ACCENT} onClick={oneClick} disabled={waiting}>
               {waiting ? "Check your browser…" : `Connect ${c.title} with one click`}
             </button>
-          ) : (
+          ) : cloud ? (
             <CloudSignInInline
               blurb={`Sign-in unlocks the one-click ${c.title} connect — or connect manually below.`}
             />
+          ) : (
+            // Status unknown (fetch pending/failed): never show the sign-in ask to a
+            // possibly-signed-in user (FB-013); the host keeps polling.
+            <CloudStatusPending />
           )}
           {cloud?.signed_in && (
             <div className="text-[11.5px] text-faint">or connect manually:</div>

--- a/platform/surfaces/gui/src/components/Sidebar.test.tsx
+++ b/platform/surfaces/gui/src/components/Sidebar.test.tsx
@@ -106,8 +106,11 @@ describe("Sidebar group/filter control", () => {
   });
 });
 
-describe("Chronological list row actions", () => {
-  it("flat-layout rows offer rename / archive / delete (not just pin)", async () => {
+describe("Chronological list row actions (⋮ menu)", () => {
+  // The Recent list sorts by updated_at desc with store order breaking ties, so index 0 = s-ops-1.
+  const openOpsMenu = () => fireEvent.click(screen.getAllByTestId("row-menu")[0]);
+
+  it("rename / pin / archive / two-step delete all live behind the row's single kebab", async () => {
     stubFetch([
       { match: "/v1/personas", method: "GET", json: PERSONAS },
       { match: "/v1/settings", method: "GET", json: { nav_layout: "flat" } },
@@ -115,21 +118,49 @@ describe("Chronological list row actions", () => {
     render(<Sidebar {...baseProps} />);
     await screen.findByText("incident watch"); // flat Recent list rendered
 
-    // Rename: pencil → inline input → Enter commits.
-    fireEvent.click(screen.getAllByTitle("Rename")[0]);
+    // Rename: menu item → inline input → Enter commits.
+    openOpsMenu();
+    fireEvent.click(screen.getByTestId("row-menu-rename"));
     const input = screen.getByDisplayValue("incident watch");
     fireEvent.change(input, { target: { value: "war room" } });
     fireEvent.keyDown(input, { key: "Enter" });
     expect(baseProps.onRenameSession).toHaveBeenCalledWith("s-ops-1", "war room");
 
+    // Pin moved inside the menu (unpinned session → "Pin").
+    openOpsMenu();
+    fireEvent.click(screen.getByTestId("row-menu-pin"));
+    expect(baseProps.onTogglePin).toHaveBeenCalledWith("s-ops-1", true);
+
     // Archive.
-    fireEvent.click(screen.getAllByTitle("Archive (reversible)")[0]);
+    openOpsMenu();
+    fireEvent.click(screen.getByTestId("row-menu-archive"));
     expect(baseProps.onArchiveSession).toHaveBeenCalledWith("s-ops-1", true);
 
-    // Delete is two-step: × arms, "Delete?" confirms.
-    fireEvent.click(screen.getAllByTitle("Delete permanently")[0]);
-    fireEvent.click(screen.getByTitle("Click to permanently delete"));
+    // Delete is two-step: first click arms ("Delete?"), the second deletes.
+    openOpsMenu();
+    fireEvent.click(screen.getByTestId("row-menu-delete"));
+    expect(baseProps.onDeleteSession).not.toHaveBeenCalled();
+    expect(screen.getByTestId("row-menu-delete").textContent).toContain("Delete?");
+    fireEvent.click(screen.getByTestId("row-menu-delete"));
     expect(baseProps.onDeleteSession).toHaveBeenCalledWith("s-ops-1");
+  });
+
+  it("the kebab and its menu never select the row; Escape closes the menu", async () => {
+    stubFetch([
+      { match: "/v1/personas", method: "GET", json: PERSONAS },
+      { match: "/v1/settings", method: "GET", json: { nav_layout: "flat" } },
+    ]);
+    render(<Sidebar {...baseProps} />);
+    await screen.findByText("incident watch");
+
+    openOpsMenu();
+    fireEvent.click(screen.getByTestId("row-menu-pin"));
+    expect(baseProps.onSelectSession).not.toHaveBeenCalled();
+
+    openOpsMenu();
+    expect(screen.getByTestId("row-menu-rename")).toBeTruthy();
+    fireEvent.keyDown(window, { key: "Escape" });
+    expect(screen.queryByTestId("row-menu-rename")).toBeNull();
   });
 });
 

--- a/platform/surfaces/gui/src/components/Sidebar.tsx
+++ b/platform/surfaces/gui/src/components/Sidebar.tsx
@@ -180,9 +180,52 @@ export function Sidebar(props: Props) {
   }, []);
   const [editingId, setEditingId] = useState<string | null>(null);
   const [editValue, setEditValue] = useState("");
-  // Two-step delete: first click arms the row (× → "Delete?"), second click deletes.
+  // Two-step delete inside the row's ⋮ menu: Delete arms ("Delete?"), a second click deletes.
   // Archive is the primary way to put a conversation away — one click, reversible.
   const [confirmDelId, setConfirmDelId] = useState<string | null>(null);
+  // The open row-actions ⋮ menu (one at a time). Fixed-position, not absolute: the expanded
+  // accordion group clips overflow (its rounded fill), so an absolute popover on its lower rows
+  // would be cut off — same constraint as SlackDetail's person picker.
+  const [rowMenu, setRowMenu] = useState<{
+    id: string;
+    top: number;
+    left: number;
+    anchor: HTMLElement;
+  } | null>(null);
+  const closeRowMenu = () => {
+    setRowMenu(null);
+    setConfirmDelId(null);
+  };
+  const openRowMenu = (id: string, anchor: HTMLElement) => {
+    const r = anchor.getBoundingClientRect();
+    const MENU_W = 160; // w-40
+    const MENU_H = 150; // ~4 items + divider; only used to flip upward near the window bottom
+    setConfirmDelId(null);
+    setRowMenu({
+      id,
+      top: r.bottom + 4 + MENU_H > window.innerHeight ? r.top - MENU_H : r.bottom + 4,
+      left: Math.max(8, r.right - MENU_W),
+      anchor,
+    });
+  };
+  useEffect(() => {
+    if (!rowMenu) return;
+    const onKey = (e: KeyboardEvent) => e.key === "Escape" && closeRowMenu();
+    // Scrolling an ANCESTOR of the anchor row detaches the fixed menu from it — dismiss.
+    // Filter by containment: unrelated scrollers (the transcript auto-follow during a
+    // streaming turn fires constantly) must not close the menu.
+    const onScroll = (e: Event) => {
+      const t = e.target;
+      if (t === document || (t instanceof Node && t.contains(rowMenu.anchor))) closeRowMenu();
+    };
+    window.addEventListener("keydown", onKey);
+    window.addEventListener("scroll", onScroll, true);
+    return () => {
+      window.removeEventListener("keydown", onKey);
+      window.removeEventListener("scroll", onScroll, true);
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [rowMenu]);
   const [showArchived, setShowArchived] = useState(false);
   // Surfaced + enabled personas drive the surface list + family-aware behavior.
   // Refetched on the personas-changed event so an enable/install/delete in Settings
@@ -357,68 +400,100 @@ export function Sidebar(props: Props) {
     .filter(matches)
     .sort((a, b) => (b.updated_at || "").localeCompare(a.updated_at || ""));
 
-  // Hover action cluster (pin / rename / archive / delete) shared by BOTH row styles — the
-  // chronological cardRow must offer the same actions as the persona accordion's sessionRow
-  // (owner ask 2026-07-09; it previously had pin only).
-  const rowActions = (s: SessionInfo, title: string) => (
-    <span
-      className="hidden group-hover:flex items-center gap-0.5 shrink-0"
-      onClick={(e) => e.stopPropagation()}
-    >
+  // Row actions live behind ONE ⋮ kebab per row (FB-011: four hover icons read as clutter) —
+  // the menu offers Rename · Pin/Unpin · Archive/Unarchive · Delete, with the two-step delete
+  // confirm kept inside it. Shared by BOTH row styles, so the chronological cardRow offers the
+  // same actions as the persona accordion's sessionRow (owner ask 2026-07-09).
+  const rowActions = (s: SessionInfo, title: string) => {
+    const menuOpen = rowMenu?.id === s.session_id;
+    const item = (testid: string, icon: IconName, label: string, onClick: () => void) => (
       <button
-        title={s.pinned ? "Unpin" : "Pin to top"}
-        className={
-          "w-5 h-5 grid place-items-center rounded hover:bg-paper " +
-          (s.pinned ? "text-accent" : "text-faint hover:text-ink")
-        }
-        onClick={() => props.onTogglePin(s.session_id, !s.pinned)}
-      >
-        <Icon name="pin" size={12} />
-      </button>
-      <button
-        title="Rename"
-        className="w-5 h-5 grid place-items-center rounded text-faint hover:text-ink hover:bg-paper"
+        className="w-full flex items-center gap-2 px-2.5 py-1.5 text-[12.5px] text-left hover:bg-paper"
+        data-testid={testid}
+        role="menuitem"
         onClick={() => {
-          setEditingId(s.session_id);
-          setEditValue(title);
+          closeRowMenu();
+          onClick();
         }}
       >
-        <Icon name="pencil" size={12} />
+        <Icon name={icon} size={13} className="shrink-0 text-muted" />
+        <span className="flex-1">{label}</span>
       </button>
-      <button
-        title={s.archived ? "Unarchive" : "Archive (reversible)"}
-        className="w-5 h-5 grid place-items-center rounded text-faint hover:text-ink hover:bg-paper"
-        onClick={() => props.onArchiveSession(s.session_id, !s.archived)}
+    );
+    return (
+      <span
+        // Stay visible while this row's menu is open — the pointer may be on the menu, off the row.
+        className={(menuOpen ? "flex" : "hidden group-hover:flex") + " items-center shrink-0"}
+        onClick={(e) => e.stopPropagation()}
       >
-        <Icon name="archive" size={12} />
-      </button>
-      {confirmDelId === s.session_id ? (
         <button
-          title="Click to permanently delete"
-          className="px-1.5 h-5 grid place-items-center rounded bg-danger text-white text-[10.5px] font-medium"
-          onBlur={() => setConfirmDelId(null)}
-          onMouseLeave={() => setConfirmDelId(null)}
-          onClick={() => {
-            setConfirmDelId(null);
-            props.onDeleteSession(s.session_id);
-          }}
+          title="Session actions"
+          aria-label="Session actions"
+          aria-haspopup="menu"
+          aria-expanded={menuOpen}
+          data-testid="row-menu"
+          className={
+            "w-5 h-5 grid place-items-center rounded hover:bg-paper " +
+            (menuOpen ? "text-ink bg-paper" : "text-faint hover:text-ink")
+          }
+          onClick={(e) => (menuOpen ? closeRowMenu() : openRowMenu(s.session_id, e.currentTarget))}
         >
-          Delete?
+          {/* Vertical kebab = the horizontal glyph rotated — no extra icon needed. */}
+          <Icon name="moreHorizontal" size={14} className="rotate-90" />
         </button>
-      ) : (
-        <button
-          title="Delete permanently"
-          className="w-5 h-5 grid place-items-center rounded text-faint hover:text-danger hover:bg-paper leading-none"
-          onClick={() => setConfirmDelId(s.session_id)}
-        >
-          ×
-        </button>
-      )}
-    </span>
-  );
+        {menuOpen && (
+          <>
+            <div className="fixed inset-0 z-40" onClick={closeRowMenu} />
+            <div
+              className="fixed z-50 w-40 rounded-xl border border-line bg-panel shadow-xl py-1"
+              style={{ top: rowMenu!.top, left: rowMenu!.left }}
+              role="menu"
+            >
+              {item("row-menu-rename", "pencil", "Rename", () => {
+                setEditingId(s.session_id);
+                setEditValue(title);
+              })}
+              {item("row-menu-pin", "pin", s.pinned ? "Unpin" : "Pin", () =>
+                props.onTogglePin(s.session_id, !s.pinned),
+              )}
+              {item("row-menu-archive", "archive", s.archived ? "Unarchive" : "Archive", () =>
+                props.onArchiveSession(s.session_id, !s.archived),
+              )}
+              <div className="h-px bg-line my-1 mx-2" />
+              {confirmDelId === s.session_id ? (
+                <button
+                  title="Click again to permanently delete"
+                  className="w-full flex items-center gap-2 px-2.5 py-1.5 text-[12.5px] text-left font-medium text-danger hover:bg-paper"
+                  data-testid="row-menu-delete"
+                  role="menuitem"
+                  onClick={() => {
+                    closeRowMenu();
+                    props.onDeleteSession(s.session_id);
+                  }}
+                >
+                  <Icon name="trash" size={13} className="shrink-0" />
+                  <span className="flex-1">Delete?</span>
+                </button>
+              ) : (
+                <button
+                  className="w-full flex items-center gap-2 px-2.5 py-1.5 text-[12.5px] text-left text-danger hover:bg-paper"
+                  data-testid="row-menu-delete"
+                  role="menuitem"
+                  onClick={() => setConfirmDelId(s.session_id)}
+                >
+                  <Icon name="trash" size={13} className="shrink-0" />
+                  <span className="flex-1">Delete</span>
+                </button>
+              )}
+            </div>
+          </>
+        )}
+      </span>
+    );
+  };
 
   // A compact session row (mock §141 grouped/recent rows): one-line title + right-side indicators,
-  // with the pin/rename/delete actions revealed on hover. Used in accordion bodies + grouped cards.
+  // with the ⋮ actions kebab revealed on hover. Used in accordion bodies + grouped cards.
   const sessionRow = (s: SessionInfo, opts: { showTime?: boolean } = {}) => {
     const title = s.title || s.session_id;
     const editing = editingId === s.session_id;
@@ -467,7 +542,12 @@ export function Sidebar(props: Props) {
               {s.pinned && <Icon name="pin" size={11} className="text-faint shrink-0" />}
               <span className="truncate">{title}</span>
             </span>
-            <span className="flex items-center gap-1.5 shrink-0 group-hover:hidden">
+            <span
+              className={
+                "flex items-center gap-1.5 shrink-0 group-hover:hidden" +
+                (rowMenu?.id === s.session_id ? " hidden" : "")
+              }
+            >
               {opts.showTime && compactAge(s.updated_at) && (
                 <span className="text-[11px] text-faint tabular-nums">{compactAge(s.updated_at)}</span>
               )}
@@ -483,7 +563,7 @@ export function Sidebar(props: Props) {
   };
 
   // A 2-line card row (mock §141 list-flat): an optional persona icon tile + title + a
-  // persona/channel subtitle + right-side indicators, with a pin/unpin button revealed on hover.
+  // persona/channel subtitle + right-side indicators, with the ⋮ actions kebab revealed on hover.
   // Shared by the flat layout's Pinned (no icon) and Recent (with icon) sections.
   const cardRow = (s: SessionInfo) => {
     const active = s.session_id === props.activeSession;
@@ -536,7 +616,12 @@ export function Sidebar(props: Props) {
               <span className="block truncate text-[13px] font-medium">{title}</span>
               <span className="block truncate text-[11px] text-faint">{subParts.join(" · ")}</span>
             </span>
-            <span className="flex items-center gap-1.5 shrink-0 group-hover:hidden">
+            <span
+              className={
+                "flex items-center gap-1.5 shrink-0 group-hover:hidden" +
+                (rowMenu?.id === s.session_id ? " hidden" : "")
+              }
+            >
               <OriginIcon s={s} />
               <ConnectorDot subs={s.subscriptions} />
               <LiveDot state={s.liveness} />

--- a/platform/surfaces/gui/src/components/Transcript.test.tsx
+++ b/platform/surfaces/gui/src/components/Transcript.test.tsx
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { Transcript } from "./Transcript";
 import { humanizeTool } from "../humanize";
 import type { Item } from "../types";
@@ -143,6 +143,40 @@ describe("live turns (§33 flicker fix)", () => {
     const { container } = render(<Transcript items={items} onApprove={vi.fn()} running />);
     expect(container.querySelector("details.stepgroup")).toBeNull();
     expect(container.querySelector(".bubble-assistant")?.textContent).toContain("Hello!");
+  });
+});
+
+describe("bubble hover affordances (FB-005)", () => {
+  const TS = 1752969720; // unix seconds, as the server stamps them
+  const ITEMS: Item[] = [
+    { kind: "user", text: "post the digest", ts: TS },
+    { kind: "assistant", text: "Done — posted to #all-openworker." }, // pre-stamp history: no ts
+  ];
+
+  it("copy button copies the bubble's raw text and flashes Copied", async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, "clipboard", { value: { writeText }, configurable: true });
+    render(<Transcript items={ITEMS} onApprove={vi.fn()} />);
+
+    const copies = screen.getAllByTestId("bubble-copy");
+    expect(copies).toHaveLength(2); // user + assistant bubbles both get one
+    fireEvent.click(copies[0]);
+    expect(writeText).toHaveBeenCalledWith("post the digest");
+    // "Copied" lands only after the clipboard write RESOLVES (a rejected write must
+    // not claim success), hence the await.
+    await waitFor(() => expect(copies[0].textContent).toBe("Copied"));
+    fireEvent.click(copies[1]);
+    expect(writeText).toHaveBeenCalledWith("Done — posted to #all-openworker.");
+  });
+
+  it("timestamp renders only when the item carries ts; full date rides the title", () => {
+    render(<Transcript items={ITEMS} onApprove={vi.fn()} />);
+
+    const stamps = screen.getAllByTestId("bubble-ts");
+    expect(stamps).toHaveLength(1); // the ts-less assistant bubble shows none
+    const when = new Date(TS * 1000);
+    expect(stamps[0].textContent).toBe(when.toLocaleTimeString([], { hour: "numeric", minute: "2-digit" }));
+    expect(stamps[0].getAttribute("title")).toBe(when.toLocaleString());
   });
 });
 

--- a/platform/surfaces/gui/src/components/Transcript.tsx
+++ b/platform/surfaces/gui/src/components/Transcript.tsx
@@ -4,6 +4,51 @@ import { shortArgs } from "./ApprovalCard";
 import { humanizeAsk, humanizeTool, type HumanLine } from "../humanize";
 import { Markdown } from "./Markdown";
 import { ConnectorMessageCard } from "./ConnectorMessageCard";
+import { Icon } from "./Icon";
+
+// Hover affordances for a message bubble (FB-005): copy the raw text + the message's time.
+// Lives in a ZERO-HEIGHT strip under the bubble (absolute, inside the transcript's 20px gap)
+// so revealing it on group-hover never shifts the layout. `ts` is unix seconds — canonical
+// messages carry it, pre-stamp history doesn't, so the time simply omits itself when absent.
+function BubbleMeta({ text, ts, align }: { text: string; ts?: number; align: "left" | "right" }) {
+  const [copied, setCopied] = useState(false);
+  const when = typeof ts === "number" ? new Date(ts * 1000) : null;
+  const copy = () => {
+    // "Copied" only after the write actually lands — WebKit can reject outside a
+    // trusted gesture, and claiming success on a silent no-op would gaslight the user.
+    navigator.clipboard
+      ?.writeText(text)
+      .then(() => {
+        setCopied(true);
+        window.setTimeout(() => setCopied(false), 1200);
+      })
+      .catch(() => {});
+  };
+  return (
+    <div className="relative h-0 select-none">
+      <div
+        className={
+          "absolute top-1 flex items-center gap-1.5 text-[10.5px] leading-none text-faint whitespace-nowrap opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 transition-opacity " +
+          (align === "right" ? "right-0" : "left-0")
+        }
+      >
+        <button
+          className="flex items-center cursor-pointer hover:text-muted"
+          data-testid="bubble-copy"
+          title="Copy message"
+          onClick={copy}
+        >
+          {copied ? "Copied" : <Icon name="copy" size={11} />}
+        </button>
+        {when && (
+          <span data-testid="bubble-ts" title={when.toLocaleString()}>
+            {when.toLocaleTimeString([], { hour: "numeric", minute: "2-digit" })}
+          </span>
+        )}
+      </div>
+    </div>
+  );
+}
 
 type ToolItem = Extract<Item, { kind: "tool" }>;
 type ApprovalItem = Extract<Item, { kind: "approval" }>;
@@ -296,29 +341,30 @@ export function Transcript({ items, running, streamingText }: Props) {
             return <ConnectorMessageCard source={item.source} key={bi} />;
           case "user":
             return (
-              <div
-                className="bubble-user self-end max-w-[78%] px-3.5 py-2.5 rounded-[14px_14px_4px_14px] bg-solid text-onSolid text-[14.5px] leading-relaxed whitespace-pre-wrap"
-                key={bi}
-              >
-                {item.attachments && item.attachments.length > 0 && (
-                  <div className="bubble-attachments">
-                    {item.attachments.map((a, i) =>
-                      a.kind === "image" ? (
-                        <img key={i} className="msg-img" src={a.data_url} alt={a.name} />
-                      ) : (
-                        <span key={i} className="msg-file">📄 {a.name}</span>
-                      ),
-                    )}
-                  </div>
-                )}
-                {item.text}
+              <div className="group self-end max-w-[78%] flex flex-col items-end" key={bi}>
+                <div className="bubble-user px-3.5 py-2.5 rounded-[14px_14px_4px_14px] bg-solid text-onSolid text-[14.5px] leading-relaxed whitespace-pre-wrap">
+                  {item.attachments && item.attachments.length > 0 && (
+                    <div className="bubble-attachments">
+                      {item.attachments.map((a, i) =>
+                        a.kind === "image" ? (
+                          <img key={i} className="msg-img" src={a.data_url} alt={a.name} />
+                        ) : (
+                          <span key={i} className="msg-file">📄 {a.name}</span>
+                        ),
+                      )}
+                    </div>
+                  )}
+                  {item.text}
+                </div>
+                <BubbleMeta text={item.text} ts={item.ts} align="right" />
               </div>
             );
           case "assistant":
             return (
-              <div className="bubble-assistant" key={bi}>
+              <div className="group bubble-assistant" key={bi}>
                 <div className="who">assistant</div>
                 <Markdown text={item.text} />
+                <BubbleMeta text={item.text} ts={item.ts} align="left" />
               </div>
             );
           case "dirreq":

--- a/platform/surfaces/gui/src/components/UpdateBanner.test.tsx
+++ b/platform/surfaces/gui/src/components/UpdateBanner.test.tsx
@@ -1,0 +1,97 @@
+// Auto-update banner: periodic check + per-version "Later" + background pre-download,
+// driven through a mocked __TAURI__ global (the browser build renders nothing, so the
+// e2e harness never sees this — these unit tests are the coverage).
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { act, cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { UpdateBanner } from "./UpdateBanner";
+
+const FIRST_CHECK_MS = 15_000;
+const RECHECK_MS = 30 * 60_000;
+
+let invoke: ReturnType<typeof vi.fn>;
+let available: { version: string; notes: string } | null;
+let download: () => Promise<void>;
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  available = { version: "1.2.0", notes: "" };
+  download = async () => {};
+  invoke = vi.fn(async (cmd: string) => {
+    if (cmd === "check_for_update") return available;
+    if (cmd === "download_update") return download();
+    if (cmd === "install_update") return null;
+    return null;
+  });
+  (globalThis as any).__TAURI__ = { core: { invoke } };
+});
+
+afterEach(() => {
+  cleanup();
+  vi.useRealTimers();
+  delete (globalThis as any).__TAURI__;
+});
+
+const advance = (ms: number) => act(() => vi.advanceTimersByTimeAsync(ms));
+
+describe("UpdateBanner", () => {
+  it("shows after the boot-settle check finds an update", async () => {
+    render(<UpdateBanner />);
+    expect(screen.queryByTestId("update-banner")).toBeNull();
+
+    await advance(FIRST_CHECK_MS);
+    expect(screen.getByTestId("update-banner").textContent).toContain("v1.2.0");
+    // Pre-download resolved immediately → the button is ready and enabled.
+    const btn = screen.getByTestId("update-install") as HTMLButtonElement;
+    expect(btn.textContent).toBe("Restart to update");
+    expect(btn.disabled).toBe(false);
+  });
+
+  it("Later hides the banner and a same-version re-check keeps it hidden", async () => {
+    render(<UpdateBanner />);
+    await advance(FIRST_CHECK_MS);
+
+    fireEvent.click(screen.getByTestId("update-later"));
+    expect(screen.queryByTestId("update-banner")).toBeNull();
+
+    await advance(RECHECK_MS);
+    expect(screen.queryByTestId("update-banner")).toBeNull();
+  });
+
+  it("a NEWER version found by a later check overrides the dismissal", async () => {
+    render(<UpdateBanner />);
+    await advance(FIRST_CHECK_MS);
+    fireEvent.click(screen.getByTestId("update-later"));
+
+    available = { version: "1.3.0", notes: "" };
+    await advance(RECHECK_MS);
+    expect(screen.getByTestId("update-banner").textContent).toContain("v1.3.0");
+  });
+
+  it("button reads Downloading… (disabled) until the pre-download resolves", async () => {
+    let finish!: () => void;
+    download = () => new Promise((resolve) => (finish = resolve));
+    render(<UpdateBanner />);
+    await advance(FIRST_CHECK_MS);
+
+    const btn = screen.getByTestId("update-install") as HTMLButtonElement;
+    expect(btn.textContent).toBe("Downloading…");
+    expect(btn.disabled).toBe(true);
+
+    await act(async () => finish());
+    expect(btn.textContent).toBe("Restart to update");
+    expect(btn.disabled).toBe(false);
+  });
+
+  it("a failed pre-download falls back to the enabled download-on-click path", async () => {
+    download = () => Promise.reject(new Error("offline"));
+    render(<UpdateBanner />);
+    await advance(FIRST_CHECK_MS);
+
+    const btn = screen.getByTestId("update-install") as HTMLButtonElement;
+    expect(btn.textContent).toBe("Restart to update");
+    expect(btn.disabled).toBe(false);
+
+    fireEvent.click(btn);
+    expect(invoke).toHaveBeenCalledWith("install_update", undefined);
+  });
+});

--- a/platform/surfaces/gui/src/components/UpdateBanner.tsx
+++ b/platform/surfaces/gui/src/components/UpdateBanner.tsx
@@ -1,27 +1,67 @@
 import { useEffect, useRef, useState } from "react";
-import { checkForUpdate, installUpdate, isTauri, type UpdateInfo } from "../tauri";
+import {
+  checkForUpdate,
+  clearPendingUpdate,
+  downloadUpdate,
+  installUpdate,
+  isTauri,
+  type UpdateInfo,
+} from "../tauri";
 
 // Auto-update prompt (desktop shell only — the browser build never renders this).
 // Deliberately a PROMPT, not a silent background install: swapping the app under a
 // user mid-session would kill their running coworker turn, and quiet self-mutation
-// sits badly with the local-first trust posture. "Later" dismisses until next launch.
+// sits badly with the local-first trust posture. "Later" dismisses that VERSION for
+// this app run; long-lived instances still hear about the next release because the
+// check repeats every 30 minutes (FB-001 — the app can sit open for weeks).
 //
-// The check runs once, shortly after boot settles (the splash and session restore own
-// the first seconds). Update integrity is enforced below this layer: the shell verifies
-// the manifest's minisign signature against the pubkey compiled into tauri.conf.json.
+// The first check runs shortly after boot settles (the splash and session restore own
+// the first seconds). Once a release is offered, the bytes are pre-fetched in the
+// background (FB-003) so "Restart to update" is instant instead of a multi-minute
+// download; if the pre-fetch fails the button falls back to download-on-click.
+// Update integrity is enforced below this layer: the shell verifies the manifest's
+// minisign signature against the pubkey compiled into tauri.conf.json.
+
+const FIRST_CHECK_MS = 15_000;
+const RECHECK_MS = 30 * 60_000;
+
+// downloading: background pre-fetch in flight (button locked).
+// ready: bytes cached in the shell — install is instant.
+// fallback: pre-fetch failed — the button does the full download-on-click as before.
+type Phase = "downloading" | "ready" | "fallback" | "installing" | "error";
 
 export function UpdateBanner() {
   const [update, setUpdate] = useState<UpdateInfo | null>(null);
-  const [phase, setPhase] = useState<"idle" | "installing" | "error">("idle");
-  const checked = useRef(false);
+  const [phase, setPhase] = useState<Phase>("downloading");
+  // Per-run, per-version dismissal — no localStorage, so a restart re-offers, and a
+  // NEWER release found by a later check overrides an earlier "Later".
+  const dismissed = useRef<string | null>(null);
+  // Version the background pre-fetch was kicked off for: keeps periodic re-checks of
+  // the same release from re-firing the download or resetting the button state.
+  const fetched = useRef<string | null>(null);
+
+  const offer = (u: UpdateInfo) => {
+    if (u.version === dismissed.current) return;
+    setUpdate((prev) => (prev?.version === u.version ? prev : u));
+    if (fetched.current === u.version) return;
+    fetched.current = u.version;
+    setPhase("downloading");
+    const v = u.version; // guard: a newer release may supersede this fetch mid-flight
+    downloadUpdate()
+      .then(() => fetched.current === v && setPhase("ready"))
+      .catch(() => fetched.current === v && setPhase("fallback"));
+  };
 
   useEffect(() => {
-    if (!isTauri() || checked.current) return;
-    checked.current = true;
-    const t = setTimeout(() => {
-      checkForUpdate().then((u) => u && setUpdate(u)).catch(() => {});
-    }, 15_000);
-    return () => clearTimeout(t);
+    if (!isTauri()) return;
+    const check = () => checkForUpdate().then((u) => u && offer(u)).catch(() => {});
+    const t = setTimeout(check, FIRST_CHECK_MS);
+    const i = setInterval(check, RECHECK_MS);
+    return () => {
+      clearTimeout(t);
+      clearInterval(i);
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   if (!update) return null;
@@ -35,9 +75,16 @@ export function UpdateBanner() {
     }
   };
 
+  const busy = phase === "downloading" || phase === "installing";
+
   return (
+    // Docked over the sidebar column (FB-002, owner call): 264px grid column minus the
+    // 12px side margins, bottom offset clearing the ~57px account row so the card sits
+    // just above it. z-[35]: above the account menu's click-away backdrop (z-30) so the
+    // card stays clickable, but BELOW the menu itself (z-40) — an open menu must never
+    // be occluded by a passive status card.
     <div
-      className="fixed bottom-4 right-4 z-50 w-[300px] rounded-xl border border-line bg-panel shadow-2xl px-4 py-3.5"
+      className="fixed bottom-[64px] left-3 z-[35] w-[240px] rounded-xl border border-line bg-panel shadow-2xl px-4 py-3.5"
       role="status"
       data-testid="update-banner"
     >
@@ -54,14 +101,21 @@ export function UpdateBanner() {
         <button
           className="px-3 py-1.5 rounded-full bg-accent text-white text-[12.5px] disabled:opacity-50"
           onClick={install}
-          disabled={phase === "installing"}
+          disabled={busy}
           data-testid="update-install"
         >
-          {phase === "installing" ? "Downloading…" : "Restart to update"}
+          {busy ? "Downloading…" : "Restart to update"}
         </button>
         <button
           className="px-2 py-1.5 text-[12.5px] text-faint hover:text-muted"
-          onClick={() => setUpdate(null)}
+          onClick={() => {
+            dismissed.current = update.version;
+            setUpdate(null);
+            // Free the pre-fetched bundle (tens of MB) — a dismissed release may sit
+            // unused for weeks; it re-downloads if the user changes their mind.
+            fetched.current = null;
+            clearPendingUpdate().catch(() => {});
+          }}
           disabled={phase === "installing"}
           data-testid="update-later"
         >

--- a/platform/surfaces/gui/src/components/connectors/AddConnectionModal.tsx
+++ b/platform/surfaces/gui/src/components/connectors/AddConnectionModal.tsx
@@ -9,7 +9,7 @@ import {
 } from "../../api";
 import { ConnectorBadge } from "../../connectors/ConnectorIcon";
 import { ConnectSetup } from "../ManageTabs";
-import { CloudSignInInline } from "./CloudSignIn";
+import { CloudSignInInline, CloudStatusPending } from "./CloudSignIn";
 import { PILL_ACCENT, PILL_LINE, TAG_ACCENT } from "./ui";
 
 // The ONE place a connection gets added (UX-DECISIONS §21): the detail page's header
@@ -198,8 +198,10 @@ function GenericOneClick({ c, cloud }: { c: Connector; cloud: CloudStatus | null
         >
           {waiting ? "Check your browser…" : `Connect ${c.title}`}
         </button>
-      ) : (
+      ) : cloud ? (
         <CloudSignInInline />
+      ) : (
+        <CloudStatusPending />
       )}
       {error && <div className="text-[12.5px] text-danger">{error}</div>}
       <p className="text-[12px] text-faint text-center flex items-center justify-center gap-1.5">
@@ -228,8 +230,10 @@ function SlackOneClick({ c, cloud }: { c: Connector; cloud: CloudStatus | null }
         <button className={PILL_ACCENT + " w-full !py-2"} data-testid="modal-add-to-slack" onClick={go} disabled={waiting}>
           {waiting ? "Check your browser…" : "Add to Slack"}
         </button>
-      ) : (
+      ) : cloud ? (
         <CloudSignInInline />
+      ) : (
+        <CloudStatusPending />
       )}
       {error && <div className="text-[12.5px] text-danger">{error}</div>}
       <p className="text-[12px] text-faint text-center flex items-center justify-center gap-1.5">
@@ -262,8 +266,10 @@ function GithubOneClick({ c, cloud }: { c: Connector; cloud: CloudStatus | null 
         <button className={PILL_ACCENT + " w-full !py-2"} data-testid="modal-install-github-app" onClick={() => go()} disabled={waiting}>
           {waiting ? "Check your browser…" : "Connect GitHub"}
         </button>
-      ) : (
+      ) : cloud ? (
         <CloudSignInInline />
+      ) : (
+        <CloudStatusPending />
       )}
       {error && <div className="text-[12.5px] text-danger">{error}</div>}
       <p className="text-[12px] text-faint text-center flex items-center justify-center gap-1.5">
@@ -316,8 +322,10 @@ function HubSpotOneClick({ c, cloud }: { c: Connector; cloud: CloudStatus | null
         <button className={PILL_ACCENT + " w-full !py-2"} data-testid="modal-connect-hubspot" onClick={go} disabled={waiting}>
           {waiting ? "Check your browser…" : "Connect HubSpot"}
         </button>
-      ) : (
+      ) : cloud ? (
         <CloudSignInInline />
+      ) : (
+        <CloudStatusPending />
       )}
       {error && <div className="text-[12.5px] text-danger">{error}</div>}
       <p className="text-[12px] text-faint text-center">

--- a/platform/surfaces/gui/src/components/connectors/CloudSignIn.tsx
+++ b/platform/surfaces/gui/src/components/connectors/CloudSignIn.tsx
@@ -1,11 +1,16 @@
-import { useState } from "react";
-import { cloudLogin } from "../../api";
+import { useEffect, useRef, useState } from "react";
+import { announceCloudChanged, cloudLogin, waitForCloudSignIn } from "../../api";
 
 // The signed-out state of every one-click pane: a REAL sign-in button, not a
-// hint pointing at another page. Sign-in completes in the system browser; the
-// Connectors section's 5s poll picks it up and the pane re-renders signed in.
+// hint pointing at another page. Sign-in completes in the system browser; this
+// component then polls until the status flips and broadcasts CLOUD_CHANGED, so
+// even poll-less hosts (the Sources rail's inline pane) re-render signed in —
+// relying on "some other section's 5s poll" left the rail stuck on the prompt
+// (FB-013).
 export function CloudSignInInline({ blurb }: { blurb?: string }) {
   const [waiting, setWaiting] = useState(false);
+  const cancelRef = useRef<(() => void) | null>(null);
+  useEffect(() => () => cancelRef.current?.(), []);
   return (
     <div className="space-y-1.5">
       <button
@@ -14,7 +19,11 @@ export function CloudSignInInline({ blurb }: { blurb?: string }) {
         onClick={async () => {
           setWaiting(true);
           await cloudLogin();
-          setTimeout(() => setWaiting(false), 4000);
+          cancelRef.current?.();
+          cancelRef.current = waitForCloudSignIn((s) => {
+            setWaiting(false);
+            if (s?.signed_in) announceCloudChanged();
+          });
         }}
       >
         {waiting ? "Check your browser…" : "Sign in to OpenWorker Cloud"}
@@ -22,6 +31,20 @@ export function CloudSignInInline({ blurb }: { blurb?: string }) {
       <div className="text-[11.5px] text-faint">
         {blurb || "Sign-in unlocks one-click connects — or switch to Manual, which works without it."}
       </div>
+    </div>
+  );
+}
+
+// The UNKNOWN state: the status fetch hasn't resolved (or is being retried).
+// Rendering the sign-in prompt here told signed-in users they weren't (FB-013) —
+// pending must look like pending.
+export function CloudStatusPending() {
+  return (
+    <div
+      className="text-[12px] text-faint py-2 text-center"
+      data-testid="cloud-status-pending"
+    >
+      Checking OpenWorker Cloud sign-in…
     </div>
   );
 }

--- a/platform/surfaces/gui/src/itemsFromMessages.test.ts
+++ b/platform/surfaces/gui/src/itemsFromMessages.test.ts
@@ -32,3 +32,19 @@ describe("itemsFromMessages _display sidecar", () => {
     expect(tools[0].preview).not.toContain("hidden"); // content stays clean
   });
 });
+
+describe("itemsFromMessages timestamps", () => {
+  it("carries the server ts through to user/assistant items; pre-stamp history gets none", () => {
+    const items = itemsFromMessages([
+      { role: "user", content: "hi", ts: 1752969720 },
+      { role: "assistant", content: "hello", ts: 1752969724 },
+      { role: "user", content: "old message" }, // saved before the server stamped ts
+    ] as any);
+
+    expect(items).toEqual([
+      { kind: "user", text: "hi", ts: 1752969720 },
+      { kind: "assistant", text: "hello", ts: 1752969724 },
+      { kind: "user", text: "old message" },
+    ]);
+  });
+});

--- a/platform/surfaces/gui/src/itemsFromMessages.ts
+++ b/platform/surfaces/gui/src/itemsFromMessages.ts
@@ -33,9 +33,12 @@ export function itemsFromMessages(messages: ConversationMessage[]): Item[] {
         continue;
       }
       const user = userItemFromContent(m.content);
+      // `ts` (unix seconds) is the server's canonical-message stamp; older sessions have none.
+      if (typeof m.ts === "number") user.ts = m.ts;
       if (user.text || user.attachments?.length) items.push(user);
     } else if (m.role === "assistant") {
-      if (m.content) items.push({ kind: "assistant", text: m.content });
+      if (m.content)
+        items.push({ kind: "assistant", text: m.content, ...(typeof m.ts === "number" ? { ts: m.ts } : {}) });
       for (const tc of m.tool_calls || []) {
         let args: any = {};
         try {

--- a/platform/surfaces/gui/src/tauri.ts
+++ b/platform/surfaces/gui/src/tauri.ts
@@ -100,8 +100,19 @@ export type UpdateInfo = { version: string; notes: string };
  * null = up to date, unreachable endpoint, or not the desktop app. */
 export const checkForUpdate = () => invoke<UpdateInfo | null>("check_for_update");
 
-/** Download + verify + install the update, then relaunch. Resolves only on failure paths
- * (success restarts the process on macOS; Windows hands off to the installer). */
+/** Pre-fetch + verify the update bytes in the background so the install is instant.
+ * The shell caches them keyed by version; calling again for the same version is a no-op.
+ * Rejects when there is no update or the download fails — callers fall back to the
+ * download-on-install path. */
+export const downloadUpdate = () => invokeStrict<void>("download_update");
+
+/** Drop the pre-fetched update bundle (freed on "Later" so a dismissed release
+ * doesn't pin tens of MB for a weeks-long app run). */
+export const clearPendingUpdate = () => invokeStrict<void>("clear_pending_update");
+
+/** Install the update (pre-fetched bytes when available, else download + verify now),
+ * then relaunch. Resolves only on failure paths (success restarts the process on macOS;
+ * Windows hands off to the installer). */
 export const installUpdate = () => invokeStrict<void>("install_update");
 
 /** Best-effort open a URL in the user's browser. Uses the Tauri opener plugin if present, else

--- a/platform/surfaces/gui/src/types.ts
+++ b/platform/surfaces/gui/src/types.ts
@@ -69,13 +69,15 @@ export interface Attachment {
 }
 
 // Transcript items
+// `ts` = unix seconds (the server's canonical-message stamp; live items stamp locally).
+// Optional: sessions saved before the server stamped timestamps have none.
 export type Item =
-  | { kind: "user"; text: string; attachments?: Attachment[] }
+  | { kind: "user"; text: string; attachments?: Attachment[]; ts?: number }
   // A connector-delivered inbound message (Slack/Salesforce/…), rendered as a structured card
   // (ConnectorMessageCard) instead of a plain user bubble. Generalizes to any connector via the
   // registry — no per-connector special-casing.
   | { kind: "connector"; source: MessageSource }
-  | { kind: "assistant"; text: string }
+  | { kind: "assistant"; text: string; ts?: number }
   // `hidden` = results the user's privacy filters removed before the agent saw them
   // (from the tool message's `_display` sidecar; the agent-visible content has no trace).
   // `standingRule` = the task-scoped rule that auto-allowed this call ("tool → target").

--- a/platform/tests/test_autotitle.py
+++ b/platform/tests/test_autotitle.py
@@ -1,0 +1,148 @@
+"""FB-010 — LLM auto-titles.
+
+After a user turn completes, the manager fires ONE fire-and-forget completion on the
+session's own provider/model to generate a 4-5 word title, stored in `auto_title` —
+never in `title`, so a manual rename always wins. The small-talk sentinel earns exactly
+one retry (with both openers) after the next user turn; every failure is swallowed."""
+
+from __future__ import annotations
+
+import asyncio
+import time
+
+from coworker.providers import AssistantTurn, ModelCapabilities, ProviderClient
+from coworker.server.manager import SessionManager
+
+
+class TitleAwareProvider(ProviderClient):
+    """Chat turns come from one queue; title calls (recognized by the titling system
+    prompt) are answered from another — so the fire-and-forget title call can never
+    steal a scripted chat turn."""
+
+    def __init__(self, chat_turns, titles):
+        self._chat = list(chat_turns)
+        self._titles = list(titles)
+        self.title_calls: list[list[dict]] = []
+
+    def complete(self, *, model, messages, tools=None, **settings):
+        if messages and "title chat sessions" in str(messages[0].get("content", "")):
+            self.title_calls.append([dict(m) for m in messages])
+            item = self._titles.pop(0)
+            if isinstance(item, Exception):
+                raise item
+            return AssistantTurn(text=item, finish_reason="stop")
+        return self._chat.pop(0)
+
+    def capabilities(self, model):
+        return ModelCapabilities()
+
+
+def _text(text):
+    return AssistantTurn(text=text, finish_reason="stop")
+
+
+async def _turn(mgr: SessionManager, sid: str, text: str) -> None:
+    """Drive one user turn the way the server does: run, save, mark idle (the
+    auto-title hook), then wait for the fire-and-forget call to settle."""
+    engine = mgr.get_engine(sid, agent="chat")
+    mgr.mark_running(sid)
+    async for _ in engine.run(text):
+        pass
+    mgr.save(sid, engine)
+    mgr.mark_idle(sid)
+    deadline = time.time() + 5.0
+    while sid in mgr._autotitle_inflight and time.time() < deadline:
+        await asyncio.sleep(0.005)
+
+
+def _mgr(tmp_path, chat_turns, titles):
+    provider = TitleAwareProvider(chat_turns, titles)
+    return SessionManager(workspace=tmp_path, provider=provider), provider
+
+
+async def test_title_set_after_first_turn(tmp_path):
+    mgr, provider = _mgr(tmp_path, [_text("sure")], ["Japan Trip Planning Help"])
+    await _turn(mgr, "s1", "help me plan a trip to japan")
+
+    assert len(provider.title_calls) == 1
+    assert provider.title_calls[0][-1]["content"] == "help me plan a trip to japan"
+    assert mgr.session_store.title_state("s1")["auto_title"] == (
+        "Japan Trip Planning Help"
+    )
+    # display precedence: the auto title wins over the title_from snapshot everywhere
+    assert mgr.session_store.load("s1").title == "Japan Trip Planning Help"
+    row = next(s for s in mgr.list_sessions() if s["session_id"] == "s1")
+    assert row["title"] == "Japan Trip Planning Help"
+
+
+async def test_small_talk_sentinel_then_retry_with_both_openers(tmp_path):
+    mgr, provider = _mgr(
+        tmp_path,
+        [_text("hey!"), _text("on it")],
+        ["small-talk", "Quarterly Report Draft"],
+    )
+    await _turn(mgr, "s2", "hey")
+    assert mgr.session_store.title_state("s2")["auto_title"] is None
+    assert mgr.session_store.load("s2").title == "hey"  # title_from fallback stands
+
+    await _turn(mgr, "s2", "help me draft the quarterly report")
+    assert len(provider.title_calls) == 2
+    retry_opener = provider.title_calls[1][-1]["content"]
+    assert "hey" in retry_opener and "quarterly report" in retry_opener
+    assert mgr.session_store.load("s2").title == "Quarterly Report Draft"
+
+
+async def test_gives_up_after_second_sentinel(tmp_path):
+    mgr, provider = _mgr(
+        tmp_path,
+        [_text("hi"), _text("hello"), _text("yo")],
+        ["small-talk", "small-talk", "Should Never Be Asked"],
+    )
+    await _turn(mgr, "s3", "hey")
+    await _turn(mgr, "s3", "how are you")
+    await _turn(mgr, "s3", "good morning")
+    assert len(provider.title_calls) == 2  # attempt 1 + the single retry, then give up
+    assert mgr.session_store.title_state("s3")["auto_title"] is None
+    assert mgr.session_store.load("s3").title == "hey"
+
+
+async def test_manual_rename_always_wins(tmp_path):
+    # rename AFTER the auto title landed
+    mgr, _ = _mgr(tmp_path, [_text("ok")], ["Login Bug Investigation"])
+    await _turn(mgr, "s4", "the login page 500s")
+    assert mgr.session_store.load("s4").title == "Login Bug Investigation"
+    mgr.rename_session("s4", "Prod incident 42")
+    assert mgr.session_store.load("s4").title == "Prod incident 42"
+    # ...and a late-landing generated title can't displace it
+    assert mgr.session_store.set_auto_title("s4", "sneaky") is False
+    assert mgr.session_store.load("s4").title == "Prod incident 42"
+
+
+async def test_rename_before_generation_blocks_it(tmp_path):
+    mgr, provider = _mgr(
+        tmp_path, [_text("hi"), _text("ok")], ["small-talk", "Should Never Be Asked"]
+    )
+    await _turn(mgr, "s5", "hey")  # sentinel — no title yet
+    mgr.rename_session("s5", "My Thread")
+    await _turn(mgr, "s5", "help me plan the offsite")
+    assert len(provider.title_calls) == 1  # the retry never fired
+    assert mgr.session_store.load("s5").title == "My Thread"
+
+
+async def test_provider_failure_is_swallowed(tmp_path):
+    mgr, provider = _mgr(tmp_path, [_text("ok")], [RuntimeError("model down")])
+    await _turn(mgr, "s6", "summarize this doc")  # must not raise
+    assert mgr.session_store.title_state("s6")["auto_title"] is None
+    assert mgr.session_store.load("s6").title == "summarize this doc"
+
+
+async def test_sanitizes_and_rejects_absurd_output(tmp_path):
+    # surrounding quotes stripped + whitespace collapsed
+    mgr, _ = _mgr(tmp_path, [_text("ok")], ['"Fix   Login Bug"'])
+    await _turn(mgr, "s7", "the login page 500s")
+    assert mgr.session_store.load("s7").title == "Fix Login Bug"
+
+    # absurdly long output (>80 chars) is a failure, not a title
+    mgr2, _ = _mgr(tmp_path / "b", [_text("ok")], ["x" * 90])
+    await _turn(mgr2, "s8", "the login page 500s")
+    assert mgr2.session_store.title_state("s8")["auto_title"] is None

--- a/platform/tests/test_message_timestamps.py
+++ b/platform/tests/test_message_timestamps.py
@@ -1,0 +1,152 @@
+"""FB-005 (server half) — canonical messages carry a `ts` sidecar.
+
+`ts` (unix seconds) is stamped when a message is appended to the canonical history,
+persisted, and served raw by `GET /v1/sessions/{id}/messages` — but, like `source` and
+`_display`, it must NEVER reach a provider payload."""
+
+from __future__ import annotations
+
+import asyncio
+import time
+
+import aisuite as ai
+from fastapi.testclient import TestClient
+
+from coworker.engine import TurnEngine
+from coworker.permissions import PermissionEngine
+from coworker.providers import (
+    AssistantTurn,
+    ModelCapabilities,
+    ProviderClient,
+    ToolCall,
+)
+from coworker.server import SessionManager, create_app
+from coworker.tools import ToolRegistry
+
+
+class CapturingProvider(ProviderClient):
+    """Queued turns + a record of every message list the provider was handed."""
+
+    def __init__(self, turns):
+        self._turns = list(turns)
+        self.calls: list[list[dict]] = []
+
+    def complete(self, *, model, messages, tools=None, **settings):
+        self.calls.append([dict(m) for m in messages])
+        return self._turns.pop(0)
+
+    def capabilities(self, model):
+        return ModelCapabilities()
+
+
+def _text(text):
+    return AssistantTurn(text=text, finish_reason="stop")
+
+
+def _tool(name, args, call_id="call_1"):
+    return AssistantTurn(
+        tool_calls=[ToolCall(id=call_id, name=name, arguments=args)],
+        finish_reason="tool_calls",
+    )
+
+
+def _engine(tmp_path, turns):
+    provider = CapturingProvider(turns)
+    registry = ToolRegistry()
+    registry.register_all(ai.toolkits.files(root=str(tmp_path), allow_write=True))
+    engine = TurnEngine(
+        provider=provider,
+        registry=registry,
+        permissions=PermissionEngine(workspace_root=tmp_path),
+        model="gpt-5.5",
+    )
+    return engine, provider
+
+
+def _run(engine, text):
+    async def _go():
+        return [ev async for ev in engine.run(text)]
+
+    return asyncio.run(_go())
+
+
+def test_appended_messages_carry_ts(tmp_path):
+    (tmp_path / "a.txt").write_text("hello", encoding="utf-8")
+    engine, _ = _engine(
+        tmp_path,
+        [_tool("read_file", {"path": "a.txt"}), _text("it says hello")],
+    )
+    before = time.time()
+    _run(engine, "read a.txt")
+    after = time.time()
+    assert [m["role"] for m in engine.messages] == [
+        "user",
+        "assistant",
+        "tool",
+        "assistant",
+    ]
+    for m in engine.messages:  # user, assistant, AND tool messages are stamped
+        assert isinstance(m["ts"], float)
+        assert before <= m["ts"] <= after
+
+
+def test_provider_payload_never_carries_ts(tmp_path):
+    (tmp_path / "a.txt").write_text("hello", encoding="utf-8")
+    engine, provider = _engine(
+        tmp_path,
+        [_tool("read_file", {"path": "a.txt"}), _text("done")],
+    )
+    _run(engine, "read a.txt")
+    assert provider.calls, "provider should have been invoked"
+    assert all("ts" not in m for call in provider.calls for m in call)
+    # the strip is a copy — the canonical history keeps its timestamps
+    assert all("ts" in m for m in engine.messages)
+
+
+def test_outbound_strip_is_unconditional(tmp_path):
+    # Direct check on the single provider feed, no-context early-return path included.
+    engine, _ = _engine(tmp_path, [])
+    engine.messages.append({"role": "user", "content": "hi", "ts": 1700000000.0})
+    out = engine._outbound_messages()
+    assert all("ts" not in m for m in out)
+    assert engine.messages[-1]["ts"] == 1700000000.0  # original untouched
+
+
+def _no_ts_keys(value) -> bool:
+    if isinstance(value, dict):
+        return all(k != "ts" and _no_ts_keys(v) for k, v in value.items())
+    if isinstance(value, list):
+        return all(_no_ts_keys(v) for v in value)
+    return True
+
+
+def test_provider_adapters_drop_ts():
+    """Defense in depth: the native Anthropic/Gemini payload builders rebuild messages
+    from role/content, so a `ts` that somehow slipped past the engine strip still never
+    reaches the wire."""
+    from coworker.providers.anthropic_provider import convert_messages as to_anthropic
+    from coworker.providers.gemini_provider import convert_messages as to_gemini
+
+    history = [
+        {"role": "system", "content": "be brief"},
+        {"role": "user", "content": "hi", "ts": 1700000000.0},
+        {"role": "assistant", "content": "hello", "ts": 1700000001.0},
+    ]
+    for convert in (to_anthropic, to_gemini):
+        _system, payload = convert(history)
+        assert _no_ts_keys(payload)
+
+
+def test_messages_endpoint_returns_ts(tmp_path):
+    manager = SessionManager(
+        workspace=tmp_path, provider=CapturingProvider([_text("hi there")])
+    )
+    client = TestClient(create_app(manager))
+    with client.websocket_connect("/ws/session/ts1") as ws:
+        assert ws.receive_json()["type"] == "ready"
+        ws.send_json({"type": "user_message", "text": "hello world"})
+        while ws.receive_json()["type"] != "turn_done":
+            pass
+    msgs = client.get("/v1/sessions/ts1/messages").json()["messages"]
+    stamped = [m for m in msgs if m.get("role") in ("user", "assistant")]
+    assert stamped and all(isinstance(m.get("ts"), float) for m in stamped)


### PR DESCRIPTION
Fixing multiple user-reported bugs
- The update card moves bottom-left above the account row, re-checks every 30 minutes, and pre-downloads in the background so "Restart to update" is instant
- the transcript stops yanking the viewport during streaming (scroll up pins, a jump-to-latest pill re-engages)
- chat bubbles gain hover copy + timestamps
- sessions get LLM-generated 4-5 word titles with a small-talk retry sentinel
- sidebar row actions collapse into one kebab menu
- the Sources-rail connector picker shows the full catalog on focus; and a rail bug that demanded cloud sign-in from signed-in users (single unretried status fetch rendering pending as signed-out) is fixed 

TSC 63 unit + 801 pytest + 131 Playwright pass (new regression specs for scroll pinning, cloud-status states, and pin-via-kebab).