### PR TITLE
OpenWorker: Automations in the sidebar (UX-023) + turn-freeze and auto-title fixes

### DIFF
--- a/platform/coworker/automation/models.py
+++ b/platform/coworker/automation/models.py
@@ -135,6 +135,9 @@ class ScheduledTask:
     last_status: Optional[str] = None
     run_count: int = 0
     max_runs: Optional[int] = None
+    # Sidebar unread tracking (UX-023): runs started after this mark count as
+    # "unseen"; opening the automation's detail advances it. 0.0 = never opened.
+    seen_runs_at: float = 0.0
 
     def __post_init__(self) -> None:
         if not self.task_session_id:
@@ -199,6 +202,8 @@ class ScheduledTask:
             "last_status": self.last_status,
             "run_count": self.run_count,
             "notify_on_completion": self.notify_on_completion,
+            # UX-023: lets the detail freeze the pre-open mark for its "new" pills.
+            "seen_runs_at": self.seen_runs_at,
             # Structured for the task page's revoke list; `entry` is the revoke handle.
             "always_allowed": [
                 {"entry": e, "tool": t, "target": tg}

--- a/platform/coworker/providers/openai_provider.py
+++ b/platform/coworker/providers/openai_provider.py
@@ -51,14 +51,25 @@ def _pin_reasoning_effort(kwargs: dict[str, Any]) -> None:
         kwargs.setdefault("reasoning_effort", "none")
 
 
-def _effort_none_retry(kwargs: dict[str, Any], exc: Exception) -> dict[str, Any]:
-    """Kwargs for the one retry this error earns, or re-raise anything else."""
-    if (
-        kwargs.get("reasoning_effort") == "none"
-        or _EFFORT_ERROR not in str(exc).lower()
-    ):
-        raise exc
-    return {**kwargs, "reasoning_effort": "none"}
+_MAX_TOKENS_ERROR = "'max_tokens' is not supported"
+
+
+def _param_fix_retry(kwargs: dict[str, Any], exc: Exception) -> dict[str, Any]:
+    """Kwargs for the one retry an unsupported-parameter error earns, or re-raise.
+
+    Reasoning-routed OpenAI models reject `max_tokens` outright (they want
+    `max_completion_tokens`) — but compat servers (Ollama's /v1) know ONLY
+    `max_tokens`, so the swap must happen on rejection, never up front. Same
+    contract as the reasoning_effort retry: fix exactly what the server named.
+    """
+    msg = str(exc).lower()
+    if _EFFORT_ERROR in msg and kwargs.get("reasoning_effort") != "none":
+        return {**kwargs, "reasoning_effort": "none"}
+    if _MAX_TOKENS_ERROR in msg and "max_tokens" in kwargs:
+        fixed = dict(kwargs)
+        fixed["max_completion_tokens"] = fixed.pop("max_tokens")
+        return fixed
+    raise exc
 
 
 class OpenAIProvider(ProviderClient):
@@ -117,10 +128,15 @@ class OpenAIProvider(ProviderClient):
         _pin_reasoning_effort(kwargs)
 
         client = self._ensure_client()
-        try:
+        # Up to two param-fix retries: effort and max_tokens can BOTH need fixing.
+        for _ in range(2):
+            try:
+                response = client.chat.completions.create(**kwargs)
+                break
+            except Exception as exc:
+                kwargs = _param_fix_retry(kwargs, exc)
+        else:
             response = client.chat.completions.create(**kwargs)
-        except Exception as exc:
-            response = client.chat.completions.create(**_effort_none_retry(kwargs, exc))
         choice = response.choices[0]
         message = choice.message
         text = getattr(message, "content", None)
@@ -159,10 +175,15 @@ class OpenAIProvider(ProviderClient):
         tool_accum: dict[int, dict[str, str]] = {}
         finish_reason = None
 
-        try:
+        # Up to two param-fix retries: effort and max_tokens can BOTH need fixing.
+        for _ in range(2):
+            try:
+                chunks = client.chat.completions.create(**kwargs)
+                break
+            except Exception as exc:
+                kwargs = _param_fix_retry(kwargs, exc)
+        else:
             chunks = client.chat.completions.create(**kwargs)
-        except Exception as exc:
-            chunks = client.chat.completions.create(**_effort_none_retry(kwargs, exc))
         for chunk in chunks:
             choices = getattr(chunk, "choices", None)
             if not choices:

--- a/platform/coworker/server/app.py
+++ b/platform/coworker/server/app.py
@@ -1327,6 +1327,10 @@ def create_app(manager: SessionManager) -> FastAPI:
     def automation_delete(task_id: str) -> dict[str, Any]:
         return manager.delete_automation(task_id)
 
+    @app.post("/v1/automations/{task_id}/seen")
+    def automations_seen(task_id: str) -> dict[str, Any]:
+        return manager.mark_automation_seen(task_id)
+
     @app.post("/v1/automations/{task_id}/run")
     def automation_run(task_id: str) -> dict[str, Any]:
         # Prepare a live manual run; the GUI opens the returned session and drives it.

--- a/platform/coworker/server/manager.py
+++ b/platform/coworker/server/manager.py
@@ -2991,7 +2991,10 @@ class SessionManager:
                     },
                 )
         except Exception:
-            pass  # a failed title must never surface as a session error
+            # A failed title must never surface as a session error — but it must
+            # not be invisible either (a silent provider 400 hid the max_tokens
+            # rejection for a whole owner test pass, 2026-07-20).
+            logger.debug("autotitle failed for %s", session_id, exc_info=True)
         finally:
             self._autotitle_inflight.discard(session_id)
 

--- a/platform/coworker/server/manager.py
+++ b/platform/coworker/server/manager.py
@@ -2724,7 +2724,29 @@ class SessionManager:
 
     # -- automation REST --------------------------------------------------------
     def list_automations(self) -> dict[str, Any]:
-        return {"tasks": [t.public() for t in self.task_store.list()]}
+        # Unseen = runs started after the task's seen mark (UX-023 sidebar badges).
+        # `unseen_failed` tints the badge when the NEWEST unseen run errored.
+        tasks = []
+        for t in self.task_store.list():
+            unseen = [
+                r for r in self.task_store.runs(t.id) if r.started_at > t.seen_runs_at
+            ]
+            tasks.append(
+                {
+                    **t.public(),
+                    "unseen_runs": len(unseen),
+                    "unseen_failed": bool(unseen) and unseen[0].status == "error",
+                }
+            )
+        return {"tasks": tasks}
+
+    def mark_automation_seen(self, task_id: str) -> dict[str, Any]:
+        task = self.task_store.get(task_id)
+        if task is None:
+            return {"ok": False, "error": "not found"}
+        task.seen_runs_at = time.time()
+        self.task_store.save(task)
+        return {"ok": True}
 
     def get_automation(self, task_id: str) -> dict[str, Any]:
         task = self.task_store.get(task_id)

--- a/platform/coworker/server/manager.py
+++ b/platform/coworker/server/manager.py
@@ -796,12 +796,23 @@ class SessionManager:
             tool_enabled,
         )
 
+        from ..mcp import oauth as mcp_oauth
+
         ws = self.engine_workspace(session_id, workspace=workspace, agent=agent)
         loop = asyncio.get_running_loop()
         effective: Optional[set[str]] = None  # computed lazily, once
         out: list[Any] = []
         for server in load_mcp_servers(ws, secrets=self.secrets):
             if not server.enabled:
+                continue
+            if server.auth == "oauth" and not mcp_oauth.has_tokens(
+                server.name, self.secrets
+            ):
+                # NEVER start an interactive OAuth flow from a turn: a token-less
+                # server here would open a browser and block every session for the
+                # full flow timeout (owner-hit 2026-07-20 — a failed one-click's
+                # leftover config froze all new sessions). Flows start only from an
+                # explicit connect in Settings/Connectors.
                 continue
             descriptor = get_descriptor(server.name)
             backed = descriptor is not None and bool(descriptor.mcp_url)
@@ -941,6 +952,12 @@ class SessionManager:
             self.secrets.put(
                 f"{name}:default", {**profile, "mode": "mcp", "enabled": True}
             )
+        else:
+            # A failed connect must take its seeded config with it: an enabled
+            # oauth entry with no tokens lingers forever (nothing owns it once
+            # the descriptor's mcp_url is gone) and re-arms at every session
+            # start — the owner-hit asana leftover, 2026-07-20.
+            delete_global_server(name)
         return result
 
     async def signout_mcp(self, name: str) -> dict[str, Any]:

--- a/platform/surfaces/gui/e2e/automations-manage.spec.ts
+++ b/platform/surfaces/gui/e2e/automations-manage.spec.ts
@@ -38,11 +38,15 @@ test("enable toggle pauses the task", async ({ page }) => {
   await expect(page.getByText("Paused", { exact: false })).toBeVisible();
 });
 
-test("delete removes the task and returns to an empty list", async ({ page }) => {
+test("delete removes the task; deleting the last one shows the empty state", async ({ page }) => {
   await openAutomations(page);
   await page.locator(".sched-card", { hasText: "Daily AI News" }).click();
   await page.getByRole("button", { name: /Delete/ }).click();
-  // Back on the list, the task is gone (the seeded set had exactly one).
+  // Back on the list, the deleted task is gone; the other seeded task remains.
   await expect(page.locator(".sched-card", { hasText: "Daily AI News" })).toHaveCount(0);
+  await expect(page.locator(".sched-card", { hasText: "Weekly CRM digest" })).toHaveCount(1);
+
+  await page.locator(".sched-card", { hasText: "Weekly CRM digest" }).click();
+  await page.getByRole("button", { name: /Delete/ }).click();
   await expect(page.getByText(/No scheduled tasks yet/)).toBeVisible();
 });

--- a/platform/surfaces/gui/e2e/fixtures.ts
+++ b/platform/surfaces/gui/e2e/fixtures.ts
@@ -277,6 +277,21 @@ const AUTOMATION = {
   always_allowed: [
     { entry: "send_message slack:T1/C1", tool: "send_message", target: "slack:T1/C1" },
   ],
+  // UX-023 sidebar badges: two unopened runs, the newest of them failed.
+  unseen_runs: 2,
+  unseen_failed: true,
+  seen_runs_at: 0,
+};
+// A second, quiet automation so the Scheduled band shows badge-less rows too.
+const AUTOMATION_CLEAN = {
+  ...AUTOMATION,
+  id: "task-2",
+  title: "Weekly CRM digest",
+  schedule: "Every Monday at ~9:00 AM",
+  last_status: "ok",
+  unseen_runs: 0,
+  unseen_failed: false,
+  always_allowed: [],
 };
 const AUTOMATION_RUNS = [
   {
@@ -503,7 +518,7 @@ export async function mockApi(page: import("@playwright/test").Page) {
   // backend's set_provider. verify (POST) never mutates: it's a live read-only credential check.
   const providers: any[] = PROVIDERS.map((p) => ({ ...p }));
   // Automations — mutable so Run now appends a run, enable/disable toggles, and delete removes.
-  const automations: any[] = [{ ...AUTOMATION }];
+  const automations: any[] = [{ ...AUTOMATION }, { ...AUTOMATION_CLEAN }];
   // MCP servers (empty by default; the granola OAuth quick-add test populates it).
   const mcpServers: any[] = [];
   const automationRuns: any[] = AUTOMATION_RUNS.map((r) => ({ ...r }));
@@ -1200,6 +1215,16 @@ export async function mockApi(page: import("@playwright/test").Page) {
     // automations: one scheduled task with a running run (drives the Automations detail page
     // and the run-session banner + Back-to-runs flow). Mutable: Run now appends a run and opens
     // its live session; the enable toggle (PATCH) and delete (DELETE) round-trip through the UI.
+    if (/\/v1\/automations\/[^/]+\/seen$/.test(p) && m === "POST") {
+      const id = p.split("/").slice(-2)[0];
+      const task = automations.find((t) => t.id === id);
+      if (task) {
+        task.unseen_runs = 0;
+        task.unseen_failed = false;
+        task.seen_runs_at = Math.floor(Date.now() / 1000);
+      }
+      return json({ ok: !!task });
+    }
     if (/\/v1\/automations\/[^/]+\/run$/.test(p) && m === "POST") {
       const id = p.split("/").slice(-2)[0];
       const task = automations.find((t) => t.id === id);

--- a/platform/surfaces/gui/e2e/sidebar-automations.spec.ts
+++ b/platform/surfaces/gui/e2e/sidebar-automations.spec.ts
@@ -1,0 +1,72 @@
+// UX-023: automations get sidebar presence — an "Automations" nav row under Search
+// (aggregate unseen badge) and a "Scheduled" band with ONE entry per automation
+// (name + cadence + unseen-runs badge). Opening an automation's detail marks it
+// seen: the badge clears immediately via the AUTOMATIONS_CHANGED broadcast, and
+// runs newer than the pre-open mark wear a "new" pill inside the detail.
+import { expect } from "@playwright/test";
+import { test } from "./fixtures";
+
+test("nav row + Scheduled band render with unseen badges; runs stay out of Recent", async ({
+  page,
+}) => {
+  await page.goto("/");
+
+  // Nav row sits right under Search — no badge of its own (owner call: the
+  // Scheduled entry alone carries the count).
+  const nav = page.getByTestId("nav-automations");
+  await expect(nav).toBeVisible();
+  await expect(nav).toContainText("Automations");
+  await expect(nav).not.toContainText("2");
+
+  // Scheduled band: one entry PER AUTOMATION — never per run. The noisy task wears
+  // its badge; the quiet one shows none.
+  const band = page.getByTestId("scheduled-band");
+  await expect(band.getByTestId("scheduled-task-1")).toContainText("Daily AI News");
+  await expect(band.getByTestId("scheduled-task-1")).toContainText("2");
+  await expect(band.getByTestId("scheduled-task-2")).toContainText("Weekly CRM digest");
+  await expect(band.getByTestId("scheduled-task-2")).not.toContainText("2");
+
+  // Runs never appear as session rows (their sessions are __run__-prefixed and the
+  // server hides them) — the band's entries are the only automation presence.
+  await expect(page.getByTitle("__run__r1")).toHaveCount(0);
+});
+
+test("opening a Scheduled entry lands on the detail, marks seen, clears the badge", async ({
+  page,
+}) => {
+  await page.goto("/");
+  await page.getByTestId("scheduled-task-1").click();
+
+  // The Automations surface opens ON that automation's detail…
+  await expect(page.getByRole("heading", { name: "Daily AI News" })).toBeVisible();
+  // …runs newer than the pre-open seen mark wear the "new" pill…
+  await expect(page.getByTestId("run-new").first()).toBeVisible();
+  // …and the entry's badge clears without waiting for any poll (mark-seen broadcast).
+  await expect(page.getByTestId("scheduled-task-1")).not.toContainText("2");
+});
+
+test("the nav row opens the Automations overview", async ({ page }) => {
+  await page.goto("/");
+  await page.getByTestId("nav-automations").click();
+  await expect(page.getByRole("heading", { name: "Automations" })).toBeVisible();
+});
+
+test("deleting an automation clears the band at once; nav re-entry lands on the list", async ({
+  page,
+}) => {
+  await page.goto("/");
+  // Open the automation from the band, delete it from the detail.
+  await page.getByTestId("scheduled-task-2").click();
+  await expect(page.getByRole("heading", { name: "Weekly CRM digest" })).toBeVisible();
+  await page.getByRole("button", { name: /Delete/ }).click();
+
+  // The Scheduled band drops the entry immediately (broadcast, not the 15s poll)…
+  await expect(page.getByTestId("scheduled-task-2")).toHaveCount(0);
+
+  // …and after visiting a session, the nav row must land on the OVERVIEW — the
+  // remembered detail target for a deleted automation once left "Loading…" forever.
+  await page.getByTitle("Weekly plan 1").click();
+  await page.getByTestId("nav-automations").click();
+  await expect(page.getByRole("heading", { name: "Automations" })).toBeVisible();
+  await expect(page.getByText("Loading…")).toHaveCount(0);
+});

--- a/platform/surfaces/gui/src/App.tsx
+++ b/platform/surfaces/gui/src/App.tsx
@@ -161,7 +161,10 @@ export function App() {
   // to, driving the banner + "Back to runs". Best-effort — a run session without context still
   // shows a generic banner (detected by its __run__ id).
   const [runContext, setRunContext] = useState<{ id: string; title: string } | null>(null);
-  // Which automation the Automations surface opens on (set by the banner's Back link).
+  // Which automation the Automations surface opens on (set by the banner's Back link
+  // or a sidebar Scheduled-band click). Cleared on leaving the surface: a remembered
+  // id going stale (e.g. the automation was deleted) reopened a dead detail —
+  // "Loading…" forever (owner-hit 2026-07-20). Nav re-entry should land on the list.
   const [scheduledOpenId, setScheduledOpenId] = useState<string | null>(null);
   const [gateCreate, setGateCreate] = useState(false);
   // Which Settings section the full-page Settings surface opens on (§ Settings-as-page).
@@ -179,6 +182,12 @@ export function App() {
   const [surface, setSurface] = useState<
     "session" | "scheduled" | "integrations" | "audit" | "inbox" | "persona" | "settings"
   >("session");
+  // A remembered Scheduled-detail target must not outlive the surface (see the
+  // scheduledOpenId comment above): nav re-entry lands on the list, never a
+  // possibly-deleted automation's dead detail.
+  useEffect(() => {
+    if (surface !== "scheduled") setScheduledOpenId(null);
+  }, [surface]);
   // The persona whose detail page is showing (surface === "persona"); empty falls back to the
   // active session's persona. Phase 5 wires the grouped-nav gear + "Manage personas…" entry points.
   const [personaViewId, setPersonaViewId] = useState<string>("");
@@ -1098,6 +1107,10 @@ export function App() {
         }}
         onManagePersonas={() => openSettings("personas")}
         onOpenScheduled={() => setSurface("scheduled")}
+        onOpenAutomation={(id) => {
+          setScheduledOpenId(id);
+          setSurface("scheduled");
+        }}
         onOpenIntegrations={() => setSurface("integrations")}
         onOpenAudit={() => setSurface("audit")}
         onOpenInbox={() => setSurface("inbox")}

--- a/platform/surfaces/gui/src/api.ts
+++ b/platform/surfaces/gui/src/api.ts
@@ -1305,6 +1305,11 @@ export interface Automation {
   last_status: string | null;
   run_count: number;
   notify_on_completion: boolean;
+  // UX-023 sidebar badges: runs started since the user last opened this automation's
+  // detail; `unseen_failed` = the newest unseen run errored (danger tint).
+  unseen_runs?: number;
+  unseen_failed?: boolean;
+  seen_runs_at?: number;
   // Standing scoped approvals (§25): target-bound rules this automation may exercise
   // without asking. `entry` is the raw record entry — the revoke handle; `target` is
   // null for legacy name-only entries.
@@ -1327,6 +1332,19 @@ export interface AutomationRun {
 export async function getAutomations(): Promise<Automation[]> {
   const res = await fetch(`${httpBase()}/v1/automations`);
   return (await res.json()).tasks ?? [];
+}
+
+// Fired after any automation mutation the sidebar should reflect immediately
+// (mark-seen, create, delete) — its poll covers the rest.
+export const AUTOMATIONS_CHANGED = "coworker:automations-changed";
+export function announceAutomationsChanged() {
+  window.dispatchEvent(new CustomEvent(AUTOMATIONS_CHANGED));
+}
+
+/** Advance the automation's seen mark — clears its unseen-runs badge (UX-023). */
+export async function markAutomationSeen(id: string): Promise<{ ok: boolean }> {
+  const res = await fetch(`${httpBase()}/v1/automations/${id}/seen`, { method: "POST" });
+  return res.json();
 }
 
 export async function createAutomation(payload: {

--- a/platform/surfaces/gui/src/components/ScheduledView.tsx
+++ b/platform/surfaces/gui/src/components/ScheduledView.tsx
@@ -4,6 +4,8 @@ import {
   deleteAutomation,
   getAutomation,
   getAutomations,
+  markAutomationSeen,
+  announceAutomationsChanged,
   updateAutomation,
   type Automation,
   type AutomationRun,
@@ -67,6 +69,12 @@ export function ScheduledView({ onOpenRun, onRunNow, initialOpenId }: Props) {
   const [showForm, setShowForm] = useState(false);
   const [busy, setBusy] = useState<string | null>(null);
 
+  // The sidebar's Scheduled band can retarget an ALREADY-open Automations surface —
+  // initial state alone would ignore the change (UX-023).
+  useEffect(() => {
+    if (initialOpenId) setOpenId(initialOpenId);
+  }, [initialOpenId]);
+
   const refresh = () => getAutomations().then(setTasks).catch(() => setTasks([]));
   useEffect(() => {
     refresh();
@@ -85,6 +93,7 @@ export function ScheduledView({ onOpenRun, onRunNow, initialOpenId }: Props) {
     setBusy(payload.title);
     try {
       const res = await createAutomation(payload);
+      announceAutomationsChanged(); // new entry shows in the sidebar band right away
       await refresh();
       if (res.ok && res.task) {
         setShowForm(false);
@@ -288,15 +297,32 @@ function TaskDetail({
   const [freq, setFreq] = useState("daily");
   const [saving, setSaving] = useState(false);
 
+  // The seen mark AS OF opening — the "new" pills compare against this frozen value
+  // while mark-seen advances the stored one (badge clears; highlights survive).
+  const [seenMark, setSeenMark] = useState<number | null>(null);
+
   const refresh = () =>
     getAutomation(id)
       .then((d) => {
+        if (!d.task) {
+          // Deleted (or a stale reopen target): "Loading…" forever is a trap —
+          // fall back to the overview (owner-hit 2026-07-20).
+          onBack();
+          return;
+        }
         setTask(d.task);
         setRuns(d.runs || []);
+        setSeenMark((cur) => (cur === null ? d.task?.seen_runs_at ?? 0 : cur));
       })
       .catch(() => {});
   useEffect(() => {
+    setSeenMark(null);
     refresh();
+    // Opening the detail IS reading it: advance the seen mark and nudge the
+    // sidebar so the badge clears immediately (UX-023).
+    markAutomationSeen(id)
+      .then(() => announceAutomationsChanged())
+      .catch(() => {});
   }, [id]);
 
   if (!task)
@@ -334,6 +360,7 @@ function TaskDetail({
   };
   const remove = async () => {
     await deleteAutomation(id);
+    announceAutomationsChanged(); // the sidebar band must not wait out its poll
     onBack();
   };
 
@@ -461,6 +488,9 @@ function TaskDetail({
           >
             <div className="sched-run-row">
               <span>
+                {seenMark !== null && r.started_at > seenMark && (
+                  <span className="run-new-pill" data-testid="run-new">new</span>
+                )}
                 {fmt(r.started_at)} · <span className={"run-" + r.status}>{r.status}</span> · {r.trigger}
                 {r.artifacts.length > 0 && <span className="dim"> · {r.artifacts.length} file(s)</span>}
               </span>

--- a/platform/surfaces/gui/src/components/Sidebar.test.tsx
+++ b/platform/surfaces/gui/src/components/Sidebar.test.tsx
@@ -55,6 +55,7 @@ const baseProps = {
   onOpenPersona: vi.fn(),
   onManagePersonas: vi.fn(),
   onOpenScheduled: vi.fn(),
+  onOpenAutomation: vi.fn(),
   onOpenIntegrations: vi.fn(),
   onOpenAudit: vi.fn(),
   onOpenInbox: vi.fn(),

--- a/platform/surfaces/gui/src/components/Sidebar.tsx
+++ b/platform/surfaces/gui/src/components/Sidebar.tsx
@@ -1,9 +1,11 @@
 import { useEffect, useMemo, useState, type ReactNode } from "react";
 import {
   announceCloudChanged,
+  AUTOMATIONS_CHANGED,
   CLOUD_CHANGED,
   cloudLogin,
   cloudLogout,
+  getAutomations,
   getCloudStatus,
   getPersonas,
   getSettings,
@@ -11,6 +13,7 @@ import {
   PERSONAS_CHANGED,
   setNavLayout,
   waitForCloudSignIn,
+  type Automation,
   type CloudStatus,
   type Persona,
   type RecentWorkspace,
@@ -48,6 +51,21 @@ function AttnBadge({ n }: { n: number }) {
     <span
       className="text-[10px] font-semibold text-ink bg-faint/30 rounded-full px-1.5 leading-[15px] shrink-0"
       title={`${n} awaiting your attention`}
+    >
+      {n > 99 ? "99+" : n}
+    </span>
+  );
+}
+
+// UX-023: unseen-run count on a Scheduled entry. Deliberately QUIET — same neutral
+// treatment as the attention badge; failure only colors the tooltip's words, not the
+// sidebar (owner call 2026-07-20: no color, and the entry alone carries the count).
+function UnseenBadge({ n, failed }: { n: number; failed?: boolean }) {
+  if (!n) return null;
+  return (
+    <span
+      className="text-[10px] font-semibold text-ink bg-faint/30 rounded-full px-1.5 leading-[15px] shrink-0"
+      title={failed ? `${n} new run${n > 1 ? "s" : ""} — the latest failed` : `${n} new run${n > 1 ? "s" : ""}`}
     >
       {n > 99 ? "99+" : n}
     </span>
@@ -114,6 +132,8 @@ interface Props {
   onOpenPersona: (id: string) => void;
   onManagePersonas: () => void;
   onOpenScheduled: () => void;
+  // Scheduled-band row click: open the Automations surface ON that automation (UX-023).
+  onOpenAutomation: (id: string) => void;
   onOpenIntegrations: () => void;
   onOpenAudit: () => void;
   onOpenInbox: () => void;
@@ -128,7 +148,7 @@ interface Props {
   onPeekLeave?: () => void;
 }
 
-// Codex-style compact age for project session rows: "now" / "5m" / "6h" / "3d" / "2w" / "4mo" / "2y".
+// Compact age for project session rows: "now" / "5m" / "6h" / "3d" / "2w" / "4mo" / "2y".
 const compactAge = (iso?: string | null): string => {
   if (!iso) return "";
   const then = Date.parse(iso);
@@ -176,6 +196,20 @@ export function Sidebar(props: Props) {
       window.removeEventListener("focus", onFocus);
       window.removeEventListener(CLOUD_CHANGED, onFocus);
       window.removeEventListener(INBOX_UNLOCK, unlock);
+    };
+  }, []);
+  // UX-023: automations feed the nav row's badge + the Scheduled band. The 15s poll
+  // is the baseline; mutations announce AUTOMATIONS_CHANGED for an instant refresh
+  // (mark-seen must clear the badge the moment the detail opens).
+  const [automations, setAutomations] = useState<Automation[]>([]);
+  useEffect(() => {
+    const load = () => getAutomations().then(setAutomations).catch(() => {});
+    load();
+    const t = setInterval(load, 15_000);
+    window.addEventListener(AUTOMATIONS_CHANGED, load);
+    return () => {
+      clearInterval(t);
+      window.removeEventListener(AUTOMATIONS_CHANGED, load);
     };
   }, []);
   const [editingId, setEditingId] = useState<string | null>(null);
@@ -243,18 +277,24 @@ export function Sidebar(props: Props) {
   const personaOf = (id: string) => personas?.find((p) => p.id === id);
 
   // Sidebar layout (§7): "grouped" = the per-persona accordion; "flat" = a single ungrouped list
-  // (Pinned + Recent). Read the persisted preference on load (absent → grouped, the accordion),
-  // write via setNavLayout when toggled (now flips flat-list ↔ accordion).
-  const [layout, setLayout] = useState<"flat" | "grouped">("grouped");
+  // (Pinned + Recent). Read the persisted preference on load; ABSENT falls back by the
+  // Personas flag — with personas hidden for launch, a per-persona accordion groups by
+  // a concept the user can't see, so the default is the flat chronological list
+  // (owner call 2026-07-20). An explicit stored choice always wins.
+  const defaultLayout: "flat" | "grouped" = showPersonas() ? "grouped" : "flat";
+  const [layout, setLayout] = useState<"flat" | "grouped">(defaultLayout);
   // Sessions shown per group before "Show more" — Settings ▸ Appearance ▸ Sidebar.
   const [peek, setPeek] = useState(5);
   useEffect(() => {
     getSettings()
       .then((s) => {
-        setLayout(s.nav_layout === "flat" ? "flat" : "grouped");
+        setLayout(
+          s.nav_layout === "flat" ? "flat" : s.nav_layout === "grouped" ? "grouped" : defaultLayout,
+        );
         if (s.sessions_peek) setPeek(s.sessions_peek);
       })
       .catch(() => {});
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
   const setGroupBy = (next: "flat" | "grouped") => {
     setLayout(next);
@@ -386,7 +426,7 @@ export function Sidebar(props: Props) {
   // so they list flat. Workspace-aware (not id-aware) — any git/project persona gets Projects.
   const workspaceSurface = isProjectScoped(personaOf(browseKey));
 
-  // Search now lives in the SearchModal (Codex-style overlay), so the sidebar lists never filter
+  // Search now lives in the SearchModal (command-palette overlay), so the sidebar lists never filter
   // in place — these stay constant and the `.filter(matches)` / `normalizedQuery ? …` call sites
   // below are intentional no-ops kept to avoid churn.
   const normalizedQuery = "";
@@ -644,6 +684,35 @@ export function Sidebar(props: Props) {
         </div>
         <div className="space-y-0.5">
           {pinnedSessions.map((s) => cardRow(s))}
+        </div>
+      </div>
+    ) : null;
+
+  // UX-023: the Scheduled band — ONE entry per automation (never per run): name +
+  // cadence, with the unseen-runs badge. Runs themselves never enter Recent (run
+  // sessions are __run__-prefixed and hidden from the sessions list).
+  const scheduledBand = () =>
+    automations.length > 0 ? (
+      <div data-testid="scheduled-band">
+        <div className="px-1.5 text-[10.5px] uppercase tracking-[0.07em] text-faint font-semibold mb-1">
+          Scheduled
+        </div>
+        <div className="space-y-0.5">
+          {automations.map((a) => (
+            <button
+              key={a.id}
+              className="w-full flex items-center gap-2 px-1.5 py-1 rounded-lg text-left hover:bg-paper"
+              data-testid={`scheduled-${a.id}`}
+              title={a.title}
+              onClick={() => props.onOpenAutomation(a.id)}
+            >
+              <div className="flex-1 min-w-0">
+                <div className="text-[13px] text-ink truncate">{a.title}</div>
+                <div className="text-[11px] text-faint truncate">{a.schedule}</div>
+              </div>
+              <UnseenBadge n={a.unseen_runs || 0} failed={a.unseen_failed} />
+            </button>
+          ))}
         </div>
       </div>
     ) : null;
@@ -996,11 +1065,28 @@ export function Sidebar(props: Props) {
         </button>
       </div>
 
+      {/* Automations: a first-class nav row (UX-023) — the account menu keeps its entry.
+          The badge is the cross-automation unseen-run total. */}
+      <div className="px-2.5 mt-1">
+        <button
+          className={
+            "w-full flex items-center gap-2.5 px-2.5 py-2 rounded-lg text-[13px] text-left hover:bg-paper hover:text-ink " +
+            (props.scheduledActive ? "text-ink bg-paper" : "text-muted")
+          }
+          data-testid="nav-automations"
+          onClick={props.onOpenScheduled}
+        >
+          <Icon name="clock" size={15} className="shrink-0" />
+          <span className="flex-1">Automations</span>
+        </button>
+      </div>
+
       {/* Scroll area: Pinned band + the RECENT header (with group/filter control), then the body —
           grouped (per-persona accordion) or flat (chronological list). */}
       <div className="flex-1 overflow-y-auto px-2.5 mt-3 pb-2">
         <div className="space-y-4">
           {pinnedBand()}
+          {scheduledBand()}
           {fromSlackBand()}
           <div>
             {recentHeader()}

--- a/platform/surfaces/gui/src/styles.css
+++ b/platform/surfaces/gui/src/styles.css
@@ -21,7 +21,7 @@
   --faint: #9aa1aa;
   --line: #e8eaed;
   --line-strong: #d8dce1;
-  --accent: #2563eb; /* cobalt — our signature, distinct from Claude's coral */
+  --accent: #2563eb; /* cobalt — our signature, distinct from the coral-leaning tools */
   --accent-soft: #e9f0fd;
   --ok: #2f7d57;
   --ok-soft: #eef6f0;
@@ -938,6 +938,11 @@ button.btn.sm.danger-btn:hover { border-color: var(--danger); }
 .sched-run { border-bottom: 1px solid var(--line); }
 .sched-run-row { display: flex; align-items: center; justify-content: space-between; font-size: 13px; padding: 8px 2px; cursor: pointer; color: var(--muted); }
 .run-ok { color: var(--ok); } .run-error { color: var(--accent); } .run-running { color: var(--muted); }
+/* UX-023: marks runs newer than the seen mark captured when the detail opened. */
+.run-new-pill {
+  display: inline-block; margin-right: 8px; padding: 0 6px; border-radius: 999px;
+  background: var(--accent); color: #fff; font-size: 10px; font-weight: 600; line-height: 16px;
+}
 /* Run row = a launcher into the run's conversation. */
 .sched-run.open { border: 1px solid var(--line); border-radius: 10px; margin-bottom: 8px; padding: 4px 12px 10px; cursor: pointer; background: var(--panel); }
 .sched-run.open:hover { border-color: var(--line-strong); background: var(--paper); }

--- a/platform/tests/test_automation.py
+++ b/platform/tests/test_automation.py
@@ -7,6 +7,7 @@ operate on a real SQLite store; execution policy (catch-up, overlap) is exercise
 from __future__ import annotations
 
 import asyncio
+import time
 from datetime import datetime, timezone
 
 import pytest
@@ -361,3 +362,32 @@ def test_automations_rest(tmp_path, monkeypatch):
     )
     assert client.get(f"/v1/automations/{t.id}").json()["task"]["id"] == t.id
     assert client.delete(f"/v1/automations/{t.id}").json()["ok"] is True
+
+
+# -- unseen-run tracking (UX-023 sidebar badges) --------------------------------
+def test_unseen_runs_counted_and_cleared_by_mark_seen(tmp_path, monkeypatch):
+    """list_automations surfaces unseen counts (runs after the seen mark), with
+    unseen_failed keyed to the NEWEST unseen run; mark_automation_seen clears them
+    and later runs count fresh."""
+    monkeypatch.setenv("COWORKER_STATE_DIR", str(tmp_path / "state"))
+    from coworker.server.manager import SessionManager
+
+    manager = SessionManager(data_dir=tmp_path / "data")
+    t = manager.task_store.save(_task())
+    manager.task_store.add_run(TaskRun(task_id=t.id, status="ok"))
+    manager.task_store.add_run(TaskRun(task_id=t.id, status="error"))
+
+    row = manager.list_automations()["tasks"][0]
+    assert row["unseen_runs"] == 2
+    assert row["unseen_failed"] is True  # newest unseen run errored
+
+    assert manager.mark_automation_seen(t.id)["ok"]
+    row = manager.list_automations()["tasks"][0]
+    assert row["unseen_runs"] == 0 and row["unseen_failed"] is False
+
+    time.sleep(0.01)  # a run strictly after the seen mark
+    manager.task_store.add_run(TaskRun(task_id=t.id, status="ok"))
+    row = manager.list_automations()["tasks"][0]
+    assert row["unseen_runs"] == 1 and row["unseen_failed"] is False
+
+    assert not manager.mark_automation_seen("task-nope")["ok"]

--- a/platform/tests/test_mcp_connectors.py
+++ b/platform/tests/test_mcp_connectors.py
@@ -93,6 +93,52 @@ def test_mcp_connect_seeds_pinned_config_and_profile(tmp_path, monkeypatch):
     assert not out["ok"]
 
 
+def test_failed_mcp_connect_removes_the_seeded_config(tmp_path, monkeypatch):
+    """A one-click that fails (DCR rejected, user closed the browser) must not leave
+    an enabled oauth server behind — the leftover re-arms at every session start
+    (owner-hit: the pulled asana attempt froze all new sessions, 2026-07-20)."""
+    _state(tmp_path, monkeypatch)
+    manager = SessionManager(data_dir=tmp_path / "data")
+
+    async def fail_connect(name):
+        return {"ok": False, "error": "no DCR"}
+
+    monkeypatch.setattr(manager, "connect_mcp", fail_connect)
+    out = asyncio.run(manager.mcp_connect_connector("monday"))
+    assert not out["ok"]
+    assert "monday" not in read_global()
+    assert manager.secrets.get("monday:default") is None
+
+
+def test_prepare_mcp_tools_never_starts_an_oauth_flow(tmp_path, monkeypatch):
+    """Token-less oauth servers are SKIPPED at turn start — connecting one would
+    open a browser and block the session for the whole flow timeout. Tokens
+    present → the server connects as usual."""
+    _state(tmp_path, monkeypatch)
+    manager = SessionManager(data_dir=tmp_path / "data")
+    put_global_server(
+        "granola",
+        {"url": "https://mcp.granola.ai/mcp", "auth": "oauth", "enabled": True},
+    )
+
+    async def must_not_connect(server):
+        raise AssertionError(f"ensure() reached for token-less {server.name}")
+
+    monkeypatch.setattr(manager.mcp, "ensure", must_not_connect)
+    assert asyncio.run(manager.prepare_mcp_tools("s1")) == []
+
+    manager.secrets.put("mcp-oauth:granola", {"tokens": {"access_token": "at"}})
+    seen = {}
+
+    async def fake_ensure(server):
+        seen["name"] = server.name
+        return SimpleNamespace(tools=[])
+
+    monkeypatch.setattr(manager.mcp, "ensure", fake_ensure)
+    asyncio.run(manager.prepare_mcp_tools("s2"))
+    assert seen["name"] == "granola"
+
+
 def test_connected_follows_tokens_and_disconnect_forgets_everything(
     tmp_path, monkeypatch
 ):
@@ -140,6 +186,9 @@ def test_prepare_mcp_tools_gates_by_session_pin_and_toggles(tmp_path, monkeypatc
     _state(tmp_path, monkeypatch)
     manager = SessionManager(data_dir=tmp_path / "data")
     manager.secrets.put("monday:default", {"mode": "mcp", "enabled": True})
+    # Tokens present — a token-less oauth server is skipped outright (see
+    # test_prepare_mcp_tools_never_starts_an_oauth_flow).
+    manager.secrets.put("mcp-oauth:monday", {"tokens": {"access_token": "at"}})
     # Stale config: include_tools claims a tool we never pinned.
     put_global_server(
         "monday",

--- a/platform/tests/test_providers.py
+++ b/platform/tests/test_providers.py
@@ -186,6 +186,36 @@ def test_effort_400_from_an_unpinned_model_retries_once_at_none():
     assert out[-1].turn.text == "ok" and len(client.chat.completions.calls) == 4
 
 
+def test_max_tokens_rejection_retries_as_max_completion_tokens():
+    """Reasoning-routed models 400 on max_tokens (want max_completion_tokens); compat
+    servers know only max_tokens — so the swap happens on rejection, never up front.
+    (Owner-hit 2026-07-20: the auto-title call silently no-oped on gpt-5.6-sol.)"""
+
+    class _MaxTokensRejecting:
+        def __init__(self, response):
+            self._response = response
+            self.calls: list[dict] = []
+
+        def create(self, **kwargs):
+            self.calls.append(kwargs)
+            if "max_tokens" in kwargs:
+                raise RuntimeError(
+                    "Error code: 400 - Unsupported parameter: 'max_tokens' is not "
+                    "supported with this model. Use 'max_completion_tokens' instead."
+                )
+            return self._response
+
+    client = _FakeClient(_response(content="Jira vs Linear"))
+    client.chat.completions = _MaxTokensRejecting(_response(content="Jira vs Linear"))
+    provider = OpenAIProvider(client=client)
+
+    turn = provider.complete(model="gpt-5.6-sol", messages=[], max_tokens=64)
+    calls = client.chat.completions.calls
+    assert turn.text == "Jira vs Linear" and len(calls) == 2
+    assert calls[0]["max_tokens"] == 64
+    assert "max_tokens" not in calls[1] and calls[1]["max_completion_tokens"] == 64
+
+
 def test_unrelated_400s_are_not_retried():
     class _AlwaysRejects:
         calls: list = []


### PR DESCRIPTION
Automations become first-class in the sidebar
Recent list defaults to the flat chronological layout while personas are hidden.
Other fixes.
Full suites green: 805 pytest, 63 unit, 135 Playwright (new specs for the band, badges, and the delete flow).