### PR TITLE
Add Volcano Engine provider support

### DIFF
--- a/aisuite/providers/volcano_provider.py
+++ b/aisuite/providers/volcano_provider.py
@@ -1,0 +1,38 @@
+import os
+import openai
+
+from aisuite.provider import Provider, LLMError
+
+
+class VolcanoProvider(Provider):
+    """Provider for Volcano Engine's OpenAI-compatible API."""
+
+    def __init__(self, **config):
+        """
+        Initialize the Volcano Engine provider with the given configuration.
+        Pass the entire configuration dictionary to the OpenAI client constructor.
+        """
+        config.setdefault(
+            "api_key",
+            os.getenv("VOLCANO_API_KEY") or os.getenv("VOLCENGINE_API_KEY"),
+        )
+        config.setdefault("base_url", "https://ark.cn-beijing.volces.com/api/v3")
+
+        if not config["api_key"]:
+            raise ValueError(
+                "Volcano API key is missing. Please provide it in the config or set "
+                "the VOLCANO_API_KEY or VOLCENGINE_API_KEY environment variable."
+            )
+
+        self.client = openai.OpenAI(**config)
+
+    def chat_completions_create(self, model, messages, **kwargs):
+        try:
+            response = self.client.chat.completions.create(
+                model=model,
+                messages=messages,
+                **kwargs,
+            )
+            return response
+        except Exception as e:
+            raise LLMError(f"An error occurred: {e}") from e

--- a/tests/providers/test_volcano_provider.py
+++ b/tests/providers/test_volcano_provider.py
@@ -1,0 +1,31 @@
+from unittest.mock import MagicMock, patch
+
+from aisuite.providers.volcano_provider import VolcanoProvider
+
+
+def test_volcano_provider_initializes_and_sends_chat_request(monkeypatch):
+    monkeypatch.setenv("VOLCANO_API_KEY", "test-api-key")
+
+    provider = VolcanoProvider()
+    mock_response = MagicMock()
+    mock_response.choices = [MagicMock()]
+    mock_response.choices[0].message = MagicMock()
+    mock_response.choices[0].message.content = "mocked-text-response-from-volcano"
+
+    with patch.object(
+        provider.client.chat.completions,
+        "create",
+        return_value=mock_response,
+    ) as mock_create:
+        response = provider.chat_completions_create(
+            model="deepseek-r1-250120",
+            messages=[{"role": "user", "content": "Hello!"}],
+            temperature=0.7,
+        )
+
+        mock_create.assert_called_with(
+            model="deepseek-r1-250120",
+            messages=[{"role": "user", "content": "Hello!"}],
+            temperature=0.7,
+        )
+        assert response.choices[0].message.content == "mocked-text-response-from-volcano"


### PR DESCRIPTION
## Summary
- add a new OpenAI-compatible `VolcanoProvider`
- use `https://ark.cn-beijing.volces.com/api/v3` as the default base URL
- support `VOLCANO_API_KEY` / `VOLCENGINE_API_KEY`
- add a regression test covering provider initialization and chat call forwarding

## Verification
Ran locally:

```bash
pytest -q tests/providers/test_tongyi_provider.py tests/providers/test_volcano_provider.py
```

Result: `2 passed in 3.77s`