### PR TITLE
Fix MCPToolWrapper._create_signature for schemas with optional-before-required properties

### DIFF
--- a/aisuite/mcp/tool_wrapper.py
+++ b/aisuite/mcp/tool_wrapper.py
@@ -80,12 +80,25 @@ class MCPToolWrapper:
 
         This allows inspect.signature() to see the proper parameters with
         type annotations, rather than just **kwargs.
+
+        inspect.Signature (like Python's own `def` syntax) requires every
+        non-default parameter to precede any default parameter, but JSON
+        Schema's `required` list is independent of `properties` order, so
+        a schema listing an optional property before a required one would
+        otherwise raise "non-default argument follows default argument"
+        here. Required parameters are sorted first (stable otherwise) to
+        satisfy that constraint without changing which parameters are
+        required -- callers always pass keyword arguments, so parameter
+        position carries no other meaning.
         """
         properties = input_schema.get("properties", {})
         required = input_schema.get("required", [])
 
         parameters = []
-        for param_name, annotation in self.__annotations__.items():
+        sorted_annotations = sorted(
+            self.__annotations__.items(), key=lambda item: item[0] not in required
+        )
+        for param_name, annotation in sorted_annotations:
             # Create parameter with annotation and default
             if param_name in required:
                 # Required parameter (no default)

--- a/tests/mcp/tests/mcp/test_tool_wrapper.py
+++ b/tests/mcp/tests/mcp/test_tool_wrapper.py
@@ -1,0 +1,116 @@
+"""Unit tests for MCPToolWrapper's signature construction."""
+
+import inspect
+import unittest
+
+from aisuite.mcp.tool_wrapper import MCPToolWrapper
+
+
+class TestCreateSignatureParameterOrdering(unittest.TestCase):
+    """Regression tests for a schema-order bug in _create_signature.
+
+    inspect.Signature (like Python's own `def` syntax) requires every
+    non-default parameter to precede any default parameter. JSON Schema's
+    `required` list is independent of `properties` order, so a tool schema
+    listing an optional property before a required one used to raise
+    "ValueError: non-default argument follows default argument" while
+    constructing the wrapper. This is not a rare shape: most interaction
+    tools in the official @playwright/mcp server list an optional
+    human-readable `element` description before the required `target`
+    element reference (browser_click, browser_type, browser_hover,
+    browser_drag, browser_take_screenshot, browser_evaluate,
+    browser_select_option all use this pattern).
+    """
+
+    def test_optional_before_required_does_not_raise(self):
+        schema = {
+            "name": "browser_click",
+            "description": "Click an element",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "element": {
+                        "type": "string",
+                        "description": "Human-readable element description",
+                    },
+                    "target": {"type": "string", "description": "Element target ref"},
+                },
+                "required": ["target"],
+            },
+        }
+
+        # Should not raise ValueError: non-default argument follows default argument
+        wrapper = MCPToolWrapper(
+            mcp_client=None, tool_name="browser_click", tool_schema=schema
+        )
+
+        parameters = list(wrapper.__signature__.parameters.values())
+        self.assertEqual([p.name for p in parameters], ["target", "element"])
+        self.assertEqual(parameters[0].default, inspect.Parameter.empty)
+        self.assertIsNone(parameters[1].default)
+
+    def test_multiple_required_and_optional_are_each_grouped_and_stable(self):
+        schema = {
+            "name": "browser_drag",
+            "description": "Drag from one element to another",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "startElement": {"type": "string"},
+                    "startTarget": {"type": "string"},
+                    "endElement": {"type": "string"},
+                    "endTarget": {"type": "string"},
+                },
+                "required": ["startTarget", "endTarget"],
+            },
+        }
+
+        wrapper = MCPToolWrapper(
+            mcp_client=None, tool_name="browser_drag", tool_schema=schema
+        )
+
+        parameters = list(wrapper.__signature__.parameters.values())
+        # Required params keep their relative order, then optional params
+        # keep theirs -- this is a stable sort, not a semantic reordering.
+        self.assertEqual(
+            [p.name for p in parameters],
+            ["startTarget", "endTarget", "startElement", "endElement"],
+        )
+
+    def test_all_required_or_all_optional_schemas_still_work(self):
+        all_required_schema = {
+            "name": "tool_a",
+            "description": "",
+            "inputSchema": {
+                "type": "object",
+                "properties": {"a": {"type": "string"}, "b": {"type": "string"}},
+                "required": ["a", "b"],
+            },
+        }
+        all_optional_schema = {
+            "name": "tool_b",
+            "description": "",
+            "inputSchema": {
+                "type": "object",
+                "properties": {"a": {"type": "string"}, "b": {"type": "string"}},
+                "required": [],
+            },
+        }
+
+        wrapper_a = MCPToolWrapper(
+            mcp_client=None, tool_name="tool_a", tool_schema=all_required_schema
+        )
+        wrapper_b = MCPToolWrapper(
+            mcp_client=None, tool_name="tool_b", tool_schema=all_optional_schema
+        )
+
+        self.assertEqual(
+            [p.name for p in wrapper_a.__signature__.parameters.values()], ["a", "b"]
+        )
+        self.assertEqual(
+            [p.name for p in wrapper_b.__signature__.parameters.values()], ["a", "b"]
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
# MCPToolWrapper._create_signature raises ValueError for tool schemas with an optional property listed before a required one

## Summary

`MCPToolWrapper._create_signature` (in `aisuite/mcp/tool_wrapper.py`) builds
the wrapper's `inspect.Signature` by iterating the tool's JSON Schema
properties in their original declaration order, placing each as a
required (no-default) or optional (`default=None`) `inspect.Parameter`
depending on whether it's in the schema's `required` list — but without
first sorting required parameters ahead of optional ones.

Python's `inspect.Signature`/`def` syntax requires every non-default
parameter to precede any default parameter. JSON Schema has no such
ordering constraint — `required` is just a list, independent of
`properties` order — so any tool whose schema lists an optional property
before a required one causes construction to fail:

```
ValueError: non-default argument follows default argument
```

This is not a rare edge case. It's the pattern used by most interaction
tools in the official `@playwright/mcp` server (an optional
human-readable `element` description listed before the required `target`
element reference), including `browser_click`, `browser_type`,
`browser_hover`, `browser_drag`, `browser_take_screenshot`,
`browser_evaluate`, and `browser_select_option`.

## Impact

`MCPClient.get_callable_tools()` calls `create_mcp_tool_wrapper` for every
tool the server reports; when this raises, the calling code (e.g. a
try/except around tool discovery) can end up silently skipping the tool
or the whole server, with no indication to the end user that the failure
is a library bug rather than a misconfigured server. In our case (a
downstream project extending aisuite), connecting to a real
`@playwright/mcp` server via `MCPClient.get_callable_tools()` returned
**zero tools** — every one of the schema-order-affected tools failed to
construct.

## Minimal repro

```python
from aisuite.mcp.tool_wrapper import MCPToolWrapper

schema = {
    "name": "browser_click",
    "description": "Click an element",
    "inputSchema": {
        "type": "object",
        "properties": {
            "element": {"type": "string", "description": "Human-readable element"},
            "target": {"type": "string", "description": "Element target ref"},
        },
        "required": ["target"],
    },
}

MCPToolWrapper(mcp_client=None, tool_name="browser_click", tool_schema=schema)
# ValueError: non-default argument follows default argument
```

## Suggested fix

Sort parameters so required ones come first (stable otherwise) before
constructing the `inspect.Signature`, e.g. in `_create_signature`:

```python
def _create_signature(self, input_schema: Dict[str, Any]) -> inspect.Signature:
    properties = input_schema.get("properties", {})
    required = input_schema.get("required", [])

    parameters = []
    for param_name, annotation in sorted(
        self.__annotations__.items(), key=lambda item: item[0] not in required
    ):
        if param_name in required:
            param = inspect.Parameter(
                param_name,
                inspect.Parameter.POSITIONAL_OR_KEYWORD,
                annotation=annotation,
            )
        else:
            param = inspect.Parameter(
                param_name,
                inspect.Parameter.POSITIONAL_OR_KEYWORD,
                default=None,
                annotation=annotation,
            )
        parameters.append(param)

    return inspect.Signature(parameters, return_annotation=Any)
```

This only changes construction order, not semantics -- MCP tool calls are
always made with keyword arguments, so parameter position doesn't affect
callers.

## Environment

- aisuite version: 0.1.14 (latest published release as of this report)
- Reproduced against the official `@playwright/mcp@latest` server (npm),
  version 0.0.78 at time of testing