### PR TITLE
README: point OpenWorker to its own repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,23 +1,15 @@
-> ![NEW](https://img.shields.io/badge/%E2%9C%A8_NEW-8250df?style=for-the-badge)
+> ![OpenWorker](https://img.shields.io/badge/%E2%9C%A8-OpenWorker-8250df?style=for-the-badge)
 > ## OpenWorker
-> **An AI agent that lives on your desktop, built on aisuite.**
+> **A desktop AI coworker, built on aisuite — now in its own repository: [andrewyng/openworker](https://github.com/andrewyng/openworker).**
 >
-> OpenWorker is a desktop AI agent that can not only chat, but also do deep research and carry out tasks for
-> you on your computer. It can read files (with permission) to gain context, read/send messages (slack, email, etc.),
-> and create real deliverables like PDF reports, documents, spreadsheets. It also supports scheduled automations,
-> such as providing you a daily news summary. 
+> OpenWorker chats, does deep research, and carries out real tasks on your computer — reading files with
+> permission, connecting to Slack/email, producing PDFs, documents, and spreadsheets, and running scheduled
+> automations. Bring your own API key (OpenAI, Anthropic, Google) or run fully local with Ollama; your data
+> stays on your machine.
 >
-> Requires bringing your own API key (OpenAI, Anthropic, Google) or run fully local with Ollama. Your data stays on your machine.
+> [**⬇ Download for macOS**](https://github.com/andrewyng/openworker/releases/latest/download/OpenWorker-macos-arm64.dmg) <sub>macOS 13+ (Apple Silicon)</sub> &nbsp;·&nbsp; [**⬇ Download for Windows**](https://github.com/andrewyng/openworker/releases/latest/download/OpenWorker-windows-setup.exe) <sub>Windows 10/11 (x64)</sub> &nbsp;·&nbsp; [**Quickstart**](https://github.com/andrewyng/openworker#readme)
 >
-> [**⬇ Download for macOS**](https://github.com/andrewyng/aisuite/releases/latest/download/OpenWorker-macos-arm64.dmg)
-> <sub>&nbsp;&nbsp;macOS 13+ (Apple Silicon)</sub> &nbsp;&nbsp;
-> 
-> [**⬇ Download for Windows**](https://github.com/andrewyng/aisuite/releases/latest/download/OpenWorker-windows-setup.exe)
-> <sub>&nbsp;&nbsp;Windows 10/11 (x64) &nbsp;·&nbsp; </sub>
->
-> [**Quickstart:**](docs/openworker-quickstart.md) — install, connect a model, first tasks, automations.
-> 
-> Its source lives in this repository under `platform/` — a working reference for building your own agent harness on aisuite.
+> *OpenWorker development has moved to the new repo. A snapshot of its source remains here under `platform/` for now and will be removed in a future release.*
 
 <br>
 
@@ -26,11 +18,11 @@
 [![PyPI](https://img.shields.io/pypi/v/aisuite)](https://pypi.org/project/aisuite/)
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
 
-`aisuite` is a lightweight Python library for building with LLMs, in two layers: a unified **Chat Completions API** across providers, and an **Agents API** with tools and toolkits on top. This repo is also home to **OpenWorker**, a desktop AI coworker built using aisuite:
+`aisuite` is a lightweight Python library for building with LLMs, in two layers: a unified **Chat Completions API** across providers, and an **Agents API** with tools and toolkits on top. aisuite also powers **OpenWorker**, a desktop AI coworker developed in [its own repository](https://github.com/andrewyng/openworker):
 
 ```text
 ┌───────────────────────────────────────────────┐
-│                 OpenWorker                  │   agent harness for doing everyday tasks
+│          OpenWorker  (separate repo)          │   agent harness for doing everyday tasks
 ├───────────────────────────────────────────────┤
 │        Agents API  ·  Toolkits  ·  MCP        │   build agents across multiple LLMs
 ├───────────────────────────────────────────────┤
@@ -42,13 +34,11 @@
 
 * **[Chat Completions API](#chat-completions)** — a unified, OpenAI-style interface for *OpenAI, Anthropic, Google, Mistral, Hugging Face, AWS, Cohere, Ollama, OpenRouter, Requesty*, and more. Swap providers by changing one string.
 * **[Agents API · Toolkits · MCP](#agents)** — give models real Python functions as tools, run multi-turn loops, attach ready-made toolkits (files, git, shell) or any MCP server, and govern it all with tool policies.
-* **[OpenWorker](docs/openworker-quickstart.md)** — a desktop AI coworker built using aisuite, shipped as an app for everyday tasks.
+* **[OpenWorker](https://github.com/andrewyng/openworker)** — a desktop AI coworker built using aisuite, shipped as an app for everyday tasks. Developed in its own repository.
 
 ---
 
 ## Installation
-
-### The aisuite library (Python)
 
 Install the base package, or include the SDKs of the providers you plan to use:
 
@@ -60,11 +50,7 @@ pip install 'aisuite[all]'        # with all provider SDKs
 
 You'll also need API keys for the providers you call — the [Chat Completions quickstart](docs/chat-completions-quickstart.md) covers key setup and your first calls.
 
-### The OpenWorker app (desktop)
-
-Download the installer and bring your own API key (or run local models with Ollama):
-
-[**⬇ macOS (Apple Silicon)**](https://github.com/andrewyng/aisuite/releases/latest/download/OpenWorker-macos-arm64.dmg) &nbsp;·&nbsp; [**⬇ Windows 10/11 (x64)**](https://github.com/andrewyng/aisuite/releases/latest/download/OpenWorker-windows-setup.exe) &nbsp;·&nbsp; [OpenWorker quickstart](docs/openworker-quickstart.md)
+Looking for the OpenWorker desktop app? Downloads are on [its releases page](https://github.com/andrewyng/openworker/releases/latest).
 
 ---
 


### PR DESCRIPTION
OpenWorker now lives in andrewyng/openworker, so the README's download links, quickstart link, and framing now point there; the intro and install section re-center on the aisuite library, with a note that the platform/ source snapshot remains here temporarily and will be removed later.
